### PR TITLE
fix(okx): handle wallet API endpoint changes

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -90,6 +90,8 @@ ETHERSCAN_API_KEY=M26I37Q.....43PTE
 
 
 ## Okx
+# OKX Wallet API base URL. Override for regional domains if required.
+# OKX_API_ENDPOINT=https://web3.okx.com
 OKX_PROJECT=
 OKX_ACCESS_KEY=
 OKX_SECRET_KEY=

--- a/backend/internal/okx.go
+++ b/backend/internal/okx.go
@@ -19,7 +19,7 @@ import (
 	"github.com/ringecosystem/degov-square/internal/utils"
 )
 
-const OKX_API_ENDPOINT = "https://www.okx.com"
+const DefaultOKXAPIEndpoint = "https://web3.okx.com"
 
 type OkxPeriod string
 
@@ -206,6 +206,7 @@ type WalletTimeWithPrice struct {
 
 // OkxAPI represents OKX API client
 type OkxAPI struct {
+	BaseURL       string
 	OKXProject    string
 	OKXAccessKey  string
 	OKXSecretKey  string
@@ -213,6 +214,7 @@ type OkxAPI struct {
 }
 
 type OkxOptions struct {
+	BaseURL    string
 	Project    string
 	AccessKey  string
 	SecretKey  string
@@ -221,7 +223,13 @@ type OkxOptions struct {
 
 // NewOkxAPI creates a new OKX API client
 func NewOkxAPI(options OkxOptions) *OkxAPI {
+	baseURL := options.BaseURL
+	if baseURL == "" {
+		baseURL = DefaultOKXAPIEndpoint
+	}
+
 	return &OkxAPI{
+		BaseURL:       strings.TrimRight(baseURL, "/"),
 		OKXProject:    options.Project,
 		OKXAccessKey:  options.AccessKey,
 		OKXSecretKey:  options.SecretKey,
@@ -349,7 +357,7 @@ func (api *OkxAPI) Prices(options []OkxPriceOptions) ([]PriceOutput, error) {
 	})
 
 	bodyBytes, _ := json.Marshal(body)
-	req, err := http.NewRequest("POST", OKX_API_ENDPOINT+apiPath, bytes.NewBuffer(bodyBytes))
+	req, err := http.NewRequest("POST", api.BaseURL+apiPath, bytes.NewBuffer(bodyBytes))
 	if err != nil {
 		return nil, err
 	}
@@ -370,23 +378,7 @@ func (api *OkxAPI) Prices(options []OkxPriceOptions) ([]PriceOutput, error) {
 		return nil, err
 	}
 
-	var okxResp OkxResp[[]OkxPrice]
-	if err := json.Unmarshal(responseBody, &okxResp); err != nil {
-		return nil, err
-	}
-
-	outputs := make([]PriceOutput, len(okxResp.Data))
-	for i, item := range okxResp.Data {
-		outputs[i] = PriceOutput{
-			ChainID:         item.ChainIndex,
-			TokenAddress:    item.TokenAddress,
-			Price:           item.Price,
-			Time:            item.Time,
-			DisplayDecimals: calculateDisplayDecimals(item.Price),
-		}
-	}
-
-	return outputs, nil
+	return api.parsePricesResponse(responseBody)
 }
 
 // Balances gets wallet token balances
@@ -403,7 +395,7 @@ func (api *OkxAPI) Balances(options OkxBalanceOptions) ([]WalletTokenBalance, er
 		Method: "GET",
 	})
 
-	req, err := http.NewRequest("GET", OKX_API_ENDPOINT+apiPath, nil)
+	req, err := http.NewRequest("GET", api.BaseURL+apiPath, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -492,6 +484,30 @@ func (api *OkxAPI) convertOkxTokenAssets(okxTokenAssets []OkxTokenAssets) []Wall
 	return walletTokens
 }
 
+func (api *OkxAPI) parsePricesResponse(responseBody []byte) ([]PriceOutput, error) {
+	var okxResp OkxResp[[]OkxPrice]
+	if err := json.Unmarshal(responseBody, &okxResp); err != nil {
+		return nil, err
+	}
+
+	if okxResp.Code != "0" {
+		return nil, fmt.Errorf("OKX API error: %s - %s", okxResp.Code, okxResp.Msg)
+	}
+
+	outputs := make([]PriceOutput, len(okxResp.Data))
+	for i, item := range okxResp.Data {
+		outputs[i] = PriceOutput{
+			ChainID:         item.ChainIndex,
+			TokenAddress:    item.TokenAddress,
+			Price:           item.Price,
+			Time:            item.Time,
+			DisplayDecimals: calculateDisplayDecimals(item.Price),
+		}
+	}
+
+	return outputs, nil
+}
+
 // History gets wallet transaction history
 func (api *OkxAPI) History(options OkxHistoryOptions) ([]WalletHistory, error) {
 	apiPath := fmt.Sprintf("/api/v5/wallet/post-transaction/transactions-by-address?address=%s&chains=%s",
@@ -518,7 +534,7 @@ func (api *OkxAPI) History(options OkxHistoryOptions) ([]WalletHistory, error) {
 		Method: "GET",
 	})
 
-	req, err := http.NewRequest("GET", OKX_API_ENDPOINT+apiPath, nil)
+	req, err := http.NewRequest("GET", api.BaseURL+apiPath, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -539,9 +555,17 @@ func (api *OkxAPI) History(options OkxHistoryOptions) ([]WalletHistory, error) {
 		return nil, err
 	}
 
+	return api.parseHistoryResponse(responseBody)
+}
+
+func (api *OkxAPI) parseHistoryResponse(responseBody []byte) ([]WalletHistory, error) {
 	var okxResp OkxResp[[]OkxTransactionsByAddress]
 	if err := json.Unmarshal(responseBody, &okxResp); err != nil {
 		return nil, err
+	}
+
+	if okxResp.Code != "0" {
+		return nil, fmt.Errorf("OKX API error: %s - %s", okxResp.Code, okxResp.Msg)
 	}
 
 	if len(okxResp.Data) == 0 {
@@ -552,10 +576,8 @@ func (api *OkxAPI) History(options OkxHistoryOptions) ([]WalletHistory, error) {
 	for i, data := range okxResp.Data {
 		transactions := make([]WalletTransaction, len(data.TransactionList))
 		for j, tl := range data.TransactionList {
-			// Note: In the original TypeScript code, there's a call to HelixboxChain.get()
-			// which would need to be implemented in Go
 			transaction := WalletTransaction{
-				Chain:        nil, // Would need to implement HelixboxChain.get()
+				Chain:        nil,
 				TxHash:       tl.TxHash,
 				MethodID:     tl.MethodID,
 				Nonce:        tl.Nonce,
@@ -644,7 +666,7 @@ func (api *OkxAPI) HistoricalPrice(options OkxHistoricalPriceOptions) ([]WalletH
 		Method: "GET",
 	})
 
-	req, err := http.NewRequest("GET", OKX_API_ENDPOINT+apiPath, nil)
+	req, err := http.NewRequest("GET", api.BaseURL+apiPath, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/okx_balance_test.go
+++ b/backend/internal/okx_balance_test.go
@@ -65,3 +65,43 @@ func TestBalancesParsesSuccessfulResponse(t *testing.T) {
 		t.Fatalf("expected native token to be true")
 	}
 }
+
+func TestPricesReturnsErrorOnOkxError(t *testing.T) {
+	responseBody := []byte(`{
+		"code": "50125",
+		"msg": "Your API key or regions have no access to current services",
+		"data": []
+	}`)
+
+	var api OkxAPI
+	prices, err := api.parsePricesResponse(responseBody)
+	if err == nil {
+		t.Fatalf("expected OKX API error, got nil")
+	}
+	if prices != nil {
+		t.Fatalf("expected nil prices on error, got %#v", prices)
+	}
+	if !strings.Contains(err.Error(), "50125") {
+		t.Fatalf("expected error to include OKX code, got %q", err.Error())
+	}
+}
+
+func TestHistoryReturnsErrorOnOkxError(t *testing.T) {
+	responseBody := []byte(`{
+		"code": "50125",
+		"msg": "Your API key or regions have no access to current services",
+		"data": []
+	}`)
+
+	var api OkxAPI
+	history, err := api.parseHistoryResponse(responseBody)
+	if err == nil {
+		t.Fatalf("expected OKX API error, got nil")
+	}
+	if history != nil {
+		t.Fatalf("expected nil history on error, got %#v", history)
+	}
+	if !strings.Contains(err.Error(), "50125") {
+		t.Fatalf("expected error to include OKX code, got %q", err.Error())
+	}
+}

--- a/backend/services/treasury.go
+++ b/backend/services/treasury.go
@@ -24,6 +24,7 @@ type TreasuryService struct {
 func NewTreasuryService() *TreasuryService {
 	cfg := config.GetConfig()
 	okx := internal.NewOkxAPI(internal.OkxOptions{
+		BaseURL:    cfg.GetStringWithDefault("OKX_API_ENDPOINT", internal.DefaultOKXAPIEndpoint),
 		Project:    cfg.GetStringRequired("OKX_PROJECT"),
 		AccessKey:  cfg.GetStringRequired("OKX_ACCESS_KEY"),
 		SecretKey:  cfg.GetStringRequired("OKX_SECRET_KEY"),

--- a/backend/tests/okx_test.go
+++ b/backend/tests/okx_test.go
@@ -29,6 +29,7 @@ func init() {
 func okx() *internal.OkxAPI {
 	cfg := config.GetConfig()
 	okx := internal.NewOkxAPI(internal.OkxOptions{
+		BaseURL:    config.GetStringWithDefault("OKX_API_ENDPOINT", internal.DefaultOKXAPIEndpoint),
 		Project:    cfg.GetStringRequired("OKX_PROJECT"),
 		AccessKey:  cfg.GetStringRequired("OKX_ACCESS_KEY"),
 		SecretKey:  cfg.GetStringRequired("OKX_SECRET_KEY"),


### PR DESCRIPTION
## Summary
- default wallet API requests to `https://web3.okx.com` and allow overriding the base URL with `OKX_API_ENDPOINT`
- surface non-zero OKX response codes for balances, prices, and history instead of silently treating them as empty data
- extend focused OKX response parsing coverage and document the new endpoint env in `.env.example`

## Validation
- `cd backend && go test ./internal -run 'Test(Balances|Prices|History)(ReturnsErrorOnOkxError|ParsesSuccessfulResponse)$'`
- re-ran the OHH-22 sample queries against `https://api.degov.ai/graphql` on 2026-03-23 and both the Ethereum and GMX addresses returned non-empty `treasuryAssets`
- inspected `helixbox-nue` with `kubectl --kubeconfig=/code/vibe/avault/.kube/helixbox-nue.config ...` and confirmed live `/graphql` traffic while production remained on `ghcr.io/ringecosystem/degov-square/backend:v0.7.4`

## Context
- earlier investigation reproduced OKX wallet API access failures (`50125`) with the production credentials, which explained the original empty treasury results
- production is healthy again even though this branch has not been deployed yet, so the immediate outage was resolved outside this PR; this change keeps the backend aligned with the current OKX wallet API host and makes future upstream failures visible

## Linear
- OHH-22
