### PR TITLE
fix(ci): remove Node 20 action warnings

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,10 +8,10 @@ jobs:
     name: Check Web
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup NodeJS
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
 
@@ -33,9 +33,9 @@ jobs:
     name: Check Backend
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.25.0'
 

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -12,7 +12,7 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: darwinia-network/devops/actions/smart-vercel@main
         name: Deploy degov

--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -10,7 +10,7 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: darwinia-network/devops/actions/smart-vercel@main
         name: Deploy degov

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -10,7 +10,7 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: darwinia-network/devops/actions/smart-vercel@main
         name: Deploy degov
@@ -26,4 +26,3 @@ jobs:
           enable_notify_slack: false
           slack_channel: public-degov
           slack_webhook: ${{ secrets.SLACK_INCOMING_WEBHOOK_URL }}
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     name: Release backend
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Docker login
         uses: docker/login-action@v3


### PR DESCRIPTION
## Summary
- upgrade `actions/checkout` from `v4` to `v5` across repo workflows
- upgrade `actions/setup-node` to `v6` and `actions/setup-go` to `v6` in `check.yml`
- keep deploy behavior unchanged apart from the Node 24-compatible action runtimes

## Why
- `Deploy develop` on PR #218 emitted a Node 20 deprecation annotation for `actions/checkout@v4`
- the same commit also warned on `actions/setup-node@v4` and `actions/setup-go@v5` in `Check`
- a prior run on PR #216 already validated this action version set in `degov-square`

## Validation
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest`
- `git diff --check`

## Issue
- OHH-40
