### PR TITLE
fix: pin gqlgen and isolate OKX integration tests

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,11 +1,15 @@
-.PHONY: build run test clean docker-up docker-down generate help
+.PHONY: build run test test-okx clean docker-up docker-down generate help
+
+TEST_PACKAGES = $(shell go list ./... | grep -v '/tests$$')
+GQLGEN_VERSION = $(shell go list -m -f '{{.Version}}' github.com/99designs/gqlgen)
 
 help:
 	@echo "Available commands:"
 	@echo "  build       - Build the application"
 	@echo "  serve       - Build and serve the application"
 	@echo "  run         - Run the application"
-	@echo "  test        - Run tests"
+	@echo "  test        - Run default regression tests"
+	@echo "  test-okx    - Run OKX integration tests"
 	@echo "  clean       - Clean build artifacts"
 	@echo "  docker-up   - Start Docker services"
 	@echo "  docker-down - Stop Docker services"
@@ -25,8 +29,11 @@ serve-with-log: build
 	@mkdir -p _tmp/logs
 	./bin/degov-server 2>&1 | tee _tmp/logs/serve-$$(date +%Y%m%d-%H%M%S).log.txt
 
-test:
-	go test ./...
+test: generate
+	go test $(TEST_PACKAGES)
+
+test-okx: generate
+	go test ./tests/...
 
 clean:
 	rm -rf bin/
@@ -39,7 +46,7 @@ docker-down:
 	docker-compose down
 
 generate:
-	go get github.com/99designs/gqlgen
+	go get github.com/99designs/gqlgen@$(GQLGEN_VERSION)
 	go generate ./...
 	go mod tidy
 

--- a/backend/graph/resolver.go
+++ b/backend/graph/resolver.go
@@ -1,4 +1,4 @@
-//go:generate go run github.com/99designs/gqlgen generate
+//go:generate go run -mod=readonly github.com/99designs/gqlgen generate
 
 package graph
 

--- a/backend/tests/okx_test.go
+++ b/backend/tests/okx_test.go
@@ -1,8 +1,11 @@
 package tests
 
 import (
+	"errors"
 	"log/slog"
+	"os"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -15,8 +18,11 @@ import (
 func init() {
 	err := godotenv.Load("../.env")
 	if err != nil {
-		slog.Warn("No .env file found, using default environment variables")
-		panic(err)
+		if errors.Is(err, os.ErrNotExist) {
+			slog.Warn("No .env file found, using environment variables only")
+		} else {
+			slog.Warn("Failed to load .env file, using environment variables only", "error", err)
+		}
 	}
 
 	err = config.InitConfig()
@@ -26,20 +32,38 @@ func init() {
 	}
 }
 
-func okx() *internal.OkxAPI {
+func okx(t *testing.T) *internal.OkxAPI {
+	t.Helper()
+
 	cfg := config.GetConfig()
+	requiredKeys := []string{
+		"OKX_PROJECT",
+		"OKX_ACCESS_KEY",
+		"OKX_SECRET_KEY",
+		"OKX_PASSPHRASE",
+	}
+	missingKeys := make([]string, 0, len(requiredKeys))
+	for _, key := range requiredKeys {
+		if cfg.GetString(key) == "" {
+			missingKeys = append(missingKeys, key)
+		}
+	}
+	if len(missingKeys) > 0 {
+		t.Skipf("skipping OKX integration test; missing %s", strings.Join(missingKeys, ", "))
+	}
+
 	okx := internal.NewOkxAPI(internal.OkxOptions{
 		BaseURL:    config.GetStringWithDefault("OKX_API_ENDPOINT", internal.DefaultOKXAPIEndpoint),
-		Project:    cfg.GetStringRequired("OKX_PROJECT"),
-		AccessKey:  cfg.GetStringRequired("OKX_ACCESS_KEY"),
-		SecretKey:  cfg.GetStringRequired("OKX_SECRET_KEY"),
-		Passphrase: cfg.GetStringRequired("OKX_PASSPHRASE"),
+		Project:    cfg.GetString("OKX_PROJECT"),
+		AccessKey:  cfg.GetString("OKX_ACCESS_KEY"),
+		SecretKey:  cfg.GetString("OKX_SECRET_KEY"),
+		Passphrase: cfg.GetString("OKX_PASSPHRASE"),
 	})
 	return okx
 }
 
 func TestBalances(t *testing.T) {
-	okx := okx()
+	okx := okx(t)
 
 	balances, err := okx.Balances(internal.OkxBalanceOptions{
 		Chains:  []string{"1"},
@@ -77,7 +101,7 @@ func TestBalances(t *testing.T) {
 }
 
 func TestPrices(t *testing.T) {
-	okx := okx()
+	okx := okx(t)
 
 	// Test getting price for USDT on Ethereum
 	price, err := okx.Price(internal.OkxPriceOptions{
@@ -113,7 +137,7 @@ func TestPrices(t *testing.T) {
 }
 
 func TestHistory(t *testing.T) {
-	okx := okx()
+	okx := okx(t)
 
 	history, err := okx.History(internal.OkxHistoryOptions{
 		Address: "0xc18360217d8f7ab5e7c516566761ea12ce7f9d72",
@@ -143,7 +167,7 @@ func TestHistory(t *testing.T) {
 }
 
 func TestHistoricalPrice(t *testing.T) {
-	okx := okx()
+	okx := okx(t)
 
 	now := time.Now()
 	histories, err := okx.HistoricalPrice(internal.OkxHistoricalPriceOptions{


### PR DESCRIPTION
## Summary
- pin backend `make generate` to the `gqlgen` version already recorded in `go.mod`
- make default `make test` regenerate code and exclude the credentialed OKX integration package
- add explicit `make test-okx` coverage and clean skips when OKX credentials are absent

## Testing
- `go clean -modcache && make generate`
- `make test`
- `make test-okx`
- `go test -v ./tests/...`

Refs OHH-44
