### PR TITLE
fix(ci): stop Check Backend restore-cache warning

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -38,6 +38,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: '1.25.0'
+          cache-dependency-path: backend/go.sum
 
       - uses: taiki-e/install-action@just
 


### PR DESCRIPTION
## Summary
- point `actions/setup-go@v6` cache resolution at `backend/go.sum` in the `Check Backend` job
- preserve the existing backend CI command flow while removing the repo-root restore-cache lookup

## Testing
- `rg -n "setup-go|cache-dependency-path" .github/workflows/check.yml`
- `cd backend && just generate && just deps && just build`
- `git diff --check`

## Linear
- OHH-47
