### PR TITLE
fix: self-heal stale proposal status counts

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -28,6 +28,7 @@ require (
 	go.uber.org/zap/exp v0.3.0
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/driver/postgres v1.6.0
+	gorm.io/driver/sqlite v1.6.0
 	gorm.io/gorm v1.31.1
 )
 
@@ -75,6 +76,7 @@ require (
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.19 // indirect
+	github.com/mattn/go-sqlite3 v1.14.22 // indirect
 	github.com/minio/sha256-simd v1.0.0 // indirect
 	github.com/mr-tron/base58 v1.2.0 // indirect
 	github.com/multiformats/go-base32 v0.0.3 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -223,6 +223,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.19 h1:v++JhqYnZuu5jSKrk9RbgF5v4CGUjqRfBm05byFGLdw=
 github.com/mattn/go-runewidth v0.0.19/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
+github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
+github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwXFM08ygZfk=
@@ -487,6 +489,8 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gorm.io/driver/postgres v1.6.0 h1:2dxzU8xJ+ivvqTRph34QX+WrRaJlmfyPqXmoGVjMBa4=
 gorm.io/driver/postgres v1.6.0/go.mod h1:vUw0mrGgrTK+uPHEhAdV4sfFELrByKVGnaVRkXDhtWo=
+gorm.io/driver/sqlite v1.6.0 h1:WHRRrIiulaPiPFmDcod6prc4l2VGVWHz80KspNsxSfQ=
+gorm.io/driver/sqlite v1.6.0/go.mod h1:AO9V1qIQddBESngQUKWL9yoH93HIeA1X6V633rBwyT8=
 gorm.io/gorm v1.31.1 h1:7CA8FTFz/gRfgqgpeKIBcervUn3xSyPUmr6B2WXJ7kg=
 gorm.io/gorm v1.31.1/go.mod h1:XyQVbO2k6YkOis7C2437jSit3SsDK72s7n7rsSHd+Gs=
 lukechampine.com/blake3 v1.1.6 h1:H3cROdztr7RCfoaTpGZFQsrqvweFLrqS73j7L7cmR5c=

--- a/backend/services/proposal.go
+++ b/backend/services/proposal.go
@@ -81,21 +81,19 @@ func (s *ProposalService) StoreProposalTracking(input types.ProposalTrackingInpu
 func (s *ProposalService) TrackingStateProposals(input types.TrackingStateProposalsInput) ([]*dbmodels.ProposalTracking, error) {
 	var proposals []*dbmodels.ProposalTracking
 
-	timesTrack := 10
-	if input.TimesTrack != nil {
-		timesTrack = *input.TimesTrack
-	}
-
-	// Query proposals with specific states, tracking limits, and time conditions
-	err := s.db.Where(`dao_code = ?
+	query := s.db.Where(`dao_code = ?
 		AND state IN ?
-		AND times_track < ?
 		AND (time_next_track IS NULL OR time_next_track <= ?)`,
 		input.DaoCode,
 		input.States,
-		timesTrack,
 		time.Now(),
-	).
+	)
+
+	if input.TimesTrack != nil && *input.TimesTrack > 0 {
+		query = query.Where("times_track < ?", *input.TimesTrack)
+	}
+
+	err := query.
 		Order("proposal_created_at asc").
 		Find(&proposals).Error
 
@@ -110,8 +108,23 @@ func (s *ProposalService) UpdateProposalState(proposalID, daoCode string, newSta
 	return s.db.Model(&dbmodels.ProposalTracking{}).
 		Where("proposal_id = ? AND dao_code = ?", proposalID, daoCode).
 		Updates(map[string]interface{}{
-			"state": newState,
-			"utime": time.Now(),
+			"state":           newState,
+			"times_track":     0,
+			"time_next_track": nil,
+			"message":         "",
+			"utime":           time.Now(),
+		}).Error
+}
+
+// ResetProposalTrackingStatus clears transient retry metadata after a successful state read.
+func (s *ProposalService) ResetProposalTrackingStatus(proposalID, daoCode string) error {
+	return s.db.Model(&dbmodels.ProposalTracking{}).
+		Where("proposal_id = ? AND dao_code = ?", proposalID, daoCode).
+		Updates(map[string]interface{}{
+			"times_track":     0,
+			"time_next_track": nil,
+			"message":         "",
+			"utime":           time.Now(),
 		}).Error
 }
 

--- a/backend/services/proposal_test.go
+++ b/backend/services/proposal_test.go
@@ -1,0 +1,166 @@
+package services
+
+import (
+	"testing"
+	"time"
+
+	dbmodels "github.com/ringecosystem/degov-square/database/models"
+	"github.com/ringecosystem/degov-square/types"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newTestProposalService(t *testing.T) *ProposalService {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite db: %v", err)
+	}
+
+	if err := db.Exec(`
+		CREATE TABLE dgv_proposal_tracking (
+			id TEXT PRIMARY KEY,
+			dao_code TEXT NOT NULL,
+			chain_id INTEGER NOT NULL,
+			title TEXT NOT NULL,
+			proposal_link TEXT NOT NULL,
+			proposal_id TEXT NOT NULL,
+			state TEXT NOT NULL,
+			proposal_created_at DATETIME,
+			proposal_at_block INTEGER NOT NULL,
+			times_track INTEGER NOT NULL DEFAULT 0,
+			time_next_track DATETIME,
+			message TEXT,
+			offset_tracking_vote INTEGER DEFAULT 0,
+			fulfilled INTEGER DEFAULT 0,
+			fulfilled_explain TEXT,
+			fulfilled_at DATETIME,
+			times_fulfill INTEGER DEFAULT 0,
+			fulfill_errored INTEGER DEFAULT 0,
+			ctime DATETIME NOT NULL,
+			utime DATETIME
+		)
+	`).Error; err != nil {
+		t.Fatalf("create proposal tracking table: %v", err)
+	}
+
+	return &ProposalService{db: db}
+}
+
+func seedProposalTracking(t *testing.T, service *ProposalService, proposal dbmodels.ProposalTracking) {
+	t.Helper()
+
+	if err := service.db.Create(&proposal).Error; err != nil {
+		t.Fatalf("seed proposal tracking: %v", err)
+	}
+}
+
+func TestTrackingStateProposalsWithoutTimesTrackLimitReturnsStalledRows(t *testing.T) {
+	service := newTestProposalService(t)
+	readyAt := time.Now().Add(-time.Hour)
+
+	seedProposalTracking(t, service, dbmodels.ProposalTracking{
+		ID:            "proposal-1",
+		DaoCode:       "ring-dao",
+		ChainId:       46,
+		Title:         "Stalled active proposal",
+		ProposalLink:  "https://gov.ringdao.com/proposal/1",
+		ProposalID:    "0x1",
+		State:         dbmodels.ProposalStateActive,
+		TimesTrack:    10,
+		TimeNextTrack: &readyAt,
+		CTime:         time.Now(),
+	})
+
+	proposals, err := service.TrackingStateProposals(types.TrackingStateProposalsInput{
+		DaoCode: "ring-dao",
+		States:  []dbmodels.ProposalState{dbmodels.ProposalStateActive},
+	})
+	if err != nil {
+		t.Fatalf("TrackingStateProposals returned error: %v", err)
+	}
+
+	if len(proposals) != 1 {
+		t.Fatalf("expected stalled active proposal to remain trackable, got %d rows", len(proposals))
+	}
+}
+
+func TestResetProposalTrackingStatusClearsRetryMetadata(t *testing.T) {
+	service := newTestProposalService(t)
+	nextTrackAt := time.Now().Add(2 * time.Hour)
+
+	seedProposalTracking(t, service, dbmodels.ProposalTracking{
+		ID:            "proposal-2",
+		DaoCode:       "ring-dao",
+		ChainId:       46,
+		Title:         "Retry budget proposal",
+		ProposalLink:  "https://gov.ringdao.com/proposal/2",
+		ProposalID:    "0x2",
+		State:         dbmodels.ProposalStateActive,
+		TimesTrack:    7,
+		TimeNextTrack: &nextTrackAt,
+		Message:       "temporary rpc timeout",
+		CTime:         time.Now(),
+	})
+
+	if err := service.ResetProposalTrackingStatus("0x2", "ring-dao"); err != nil {
+		t.Fatalf("ResetProposalTrackingStatus returned error: %v", err)
+	}
+
+	var proposal dbmodels.ProposalTracking
+	if err := service.db.Where("proposal_id = ? AND dao_code = ?", "0x2", "ring-dao").First(&proposal).Error; err != nil {
+		t.Fatalf("reload proposal tracking: %v", err)
+	}
+
+	if proposal.TimesTrack != 0 {
+		t.Fatalf("expected times_track reset to 0, got %d", proposal.TimesTrack)
+	}
+	if proposal.TimeNextTrack != nil {
+		t.Fatalf("expected time_next_track cleared, got %v", proposal.TimeNextTrack)
+	}
+	if proposal.Message != "" {
+		t.Fatalf("expected message cleared, got %q", proposal.Message)
+	}
+}
+
+func TestUpdateProposalStateClearsRetryMetadata(t *testing.T) {
+	service := newTestProposalService(t)
+	nextTrackAt := time.Now().Add(2 * time.Hour)
+
+	seedProposalTracking(t, service, dbmodels.ProposalTracking{
+		ID:            "proposal-3",
+		DaoCode:       "ring-dao",
+		ChainId:       46,
+		Title:         "State transition proposal",
+		ProposalLink:  "https://gov.ringdao.com/proposal/3",
+		ProposalID:    "0x3",
+		State:         dbmodels.ProposalStateActive,
+		TimesTrack:    5,
+		TimeNextTrack: &nextTrackAt,
+		Message:       "temporary rpc timeout",
+		CTime:         time.Now(),
+	})
+
+	if err := service.UpdateProposalState("0x3", "ring-dao", dbmodels.ProposalStateExecuted); err != nil {
+		t.Fatalf("UpdateProposalState returned error: %v", err)
+	}
+
+	var proposal dbmodels.ProposalTracking
+	if err := service.db.Where("proposal_id = ? AND dao_code = ?", "0x3", "ring-dao").First(&proposal).Error; err != nil {
+		t.Fatalf("reload proposal tracking: %v", err)
+	}
+
+	if proposal.State != dbmodels.ProposalStateExecuted {
+		t.Fatalf("expected state EXECUTED, got %s", proposal.State)
+	}
+	if proposal.TimesTrack != 0 {
+		t.Fatalf("expected times_track reset to 0, got %d", proposal.TimesTrack)
+	}
+	if proposal.TimeNextTrack != nil {
+		t.Fatalf("expected time_next_track cleared, got %v", proposal.TimeNextTrack)
+	}
+	if proposal.Message != "" {
+		t.Fatalf("expected message cleared, got %q", proposal.Message)
+	}
+}

--- a/backend/tasks/tracking_proposal.go
+++ b/backend/tasks/tracking_proposal.go
@@ -270,6 +270,13 @@ func (t *TrackingProposalTask) updateProposalsStates(dao *gqlmodels.Dao, daoConf
 			continue
 		}
 
+		if err := t.proposalService.ResetProposalTrackingStatus(proposal.ProposalID, dao.Code); err != nil {
+			slog.Warn("Failed to reset proposal tracking retry metadata",
+				"dao_code", dao.Code,
+				"proposal_id", proposal.ProposalID,
+				"error", err)
+		}
+
 		// Check if state has changed
 		if newState != proposal.State {
 			// Update proposal state in database


### PR DESCRIPTION
## Summary
- remove the default hard retry cutoff from proposal state tracking so stalled rows can be revisited
- clear retry/backoff metadata after successful proposal state reads and state transitions
- add regression tests covering stalled tracked proposals and retry metadata resets

## Root Cause
- `summaryProposalStates` reads from `dgv_proposal_tracking`, not directly from the indexer or live governor contract
- two RingDAO proposals exhausted `times_track` after transient tracking failures while still stored as `ACTIVE`
- successful reads never reset `times_track` or `time_next_track`, so those rows stopped being revisited and the homepage summary stayed stale

## Validation
- `cd /code/symphony/fewensa/workspaces/OHH-89/degov-square/backend && just test`
- production repro: `summaryProposalStates(input:{daoCode:"ring-dao"})` returned `ACTIVE=2, DEFEATED=1, EXECUTED=7`
- source-of-truth check: RingDAO indexer + Darwinia `eth_call state(uint256)` confirmed the same 10 proposals are actually `DEFEATED=1, EXECUTED=9, ACTIVE=0`

Linear: OHH-89