### PR TITLE
fix: repair degov-square DAO metrics fallback

### DIFF
--- a/backend/internal/indexer.go
+++ b/backend/internal/indexer.go
@@ -11,7 +11,7 @@ import (
 
 // DataMetrics represents the data metrics structure from GraphQL response
 type DataMetrics struct {
-	ProposalsCount          int    `json:"proposalsCount"`
+	ProposalsCount          *int   `json:"proposalsCount"`
 	MemberCount             int    `json:"memberCount"`
 	PowerSum                string `json:"powerSum"`
 	VotesCount              int    `json:"votesCount"`
@@ -26,6 +26,14 @@ type DataMetrics struct {
 // DataMetricsResponse represents the GraphQL response structure
 type DataMetricsResponse struct {
 	DataMetrics []DataMetrics `json:"dataMetrics"`
+}
+
+type ProposalConnection struct {
+	TotalCount int `json:"totalCount"`
+}
+
+type ProposalConnectionResponse struct {
+	ProposalsConnection ProposalConnection `json:"proposalsConnection"`
 }
 
 // Proposal represents the structure of a governance proposal.
@@ -158,12 +166,48 @@ func (d *DegovIndexer) QueryGlobalDataMetrics(scope ProposalScope) (*DataMetrics
 		return nil, fmt.Errorf("failed to execute QueryDataMetrics: %w", err)
 	}
 
-	// Return the first item if available, otherwise return nil
-	if len(response.DataMetrics) > 0 {
-		return &response.DataMetrics[0], nil
+	metrics := DataMetrics{}
+	hasGlobalMetrics := len(response.DataMetrics) > 0
+	if hasGlobalMetrics {
+		metrics = response.DataMetrics[0]
 	}
 
-	return nil, fmt.Errorf("no data metrics found for global id")
+	if !hasGlobalMetrics || metrics.ProposalsCount == nil {
+		proposalsCount, err := d.QueryProposalsCount(scope)
+		if err != nil {
+			if hasGlobalMetrics {
+				return &metrics, nil
+			}
+			return nil, err
+		}
+
+		metrics.ProposalsCount = &proposalsCount
+	}
+
+	return &metrics, nil
+}
+
+func (d *DegovIndexer) QueryProposalsCount(scope ProposalScope) (int, error) {
+	query := `
+		query QueryProposalsCount($where: ProposalWhereInput) {
+			proposalsConnection(orderBy: [id_ASC], where: $where) {
+				totalCount
+			}
+		}
+	`
+
+	req := graphql.NewRequest(query)
+	req.Var("where", scope.withScope(nil))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var response ProposalConnectionResponse
+	if err := d.client.Run(ctx, req, &response); err != nil {
+		return 0, fmt.Errorf("failed to execute QueryProposalsCount: %w", err)
+	}
+
+	return response.ProposalsConnection.TotalCount, nil
 }
 
 func (d *DegovIndexer) InspectProposal(scope ProposalScope, proposalId string) (*Proposal, error) {

--- a/backend/internal/indexer_test.go
+++ b/backend/internal/indexer_test.go
@@ -1,0 +1,99 @@
+package internal
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestQueryGlobalDataMetricsFallsBackToProposalsConnectionWhenGlobalProposalCountUnavailable(t *testing.T) {
+	t.Parallel()
+
+	type graphqlRequest struct {
+		Query     string         `json:"query"`
+		Variables map[string]any `json:"variables"`
+	}
+
+	tests := []struct {
+		name                string
+		dataMetricsResponse string
+	}{
+		{
+			name:                "null proposals count",
+			dataMetricsResponse: `{"data":{"dataMetrics":[{"proposalsCount":null,"memberCount":5,"powerSum":"8","votesCount":3,"votesWeightAbstainSum":"0","votesWeightAgainstSum":"0","votesWeightForSum":"8","votesWithParamsCount":0,"votesWithoutParamsCount":3,"id":"global"}]}}`,
+		},
+		{
+			name:                "missing global row",
+			dataMetricsResponse: `{"data":{"dataMetrics":[]}}`,
+		},
+	}
+
+	scope := ProposalScope{
+		ChainID:         46,
+		DaoCode:         "ring-dao",
+		GovernorAddress: "0xAbC123",
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			requestCount := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var req graphqlRequest
+				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+					t.Fatalf("decode request: %v", err)
+				}
+
+				where, ok := req.Variables["where"].(map[string]any)
+				if !ok {
+					t.Fatalf("expected where variables, got %#v", req.Variables)
+				}
+				if got, want := where["chainId_eq"], float64(scope.ChainID); got != want {
+					t.Fatalf("chainId_eq = %#v, want %#v", got, want)
+				}
+				if got, want := where["daoCode_eq"], scope.DaoCode; got != want {
+					t.Fatalf("daoCode_eq = %#v, want %#v", got, want)
+				}
+				if got, want := where["governorAddress_eq"], "0xabc123"; got != want {
+					t.Fatalf("governorAddress_eq = %#v, want %#v", got, want)
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				switch requestCount {
+				case 0:
+					if got, want := where["id_eq"], "global"; got != want {
+						t.Fatalf("id_eq = %#v, want %#v", got, want)
+					}
+					_, _ = w.Write([]byte(tt.dataMetricsResponse))
+				case 1:
+					if _, exists := where["id_eq"]; exists {
+						t.Fatalf("unexpected id_eq in proposal count fallback where: %#v", where)
+					}
+					_, _ = w.Write([]byte(`{"data":{"proposalsConnection":{"totalCount":10}}}`))
+				default:
+					t.Fatalf("unexpected request count %d", requestCount)
+				}
+				requestCount++
+			}))
+			defer server.Close()
+
+			indexer := NewDegovIndexer(server.URL)
+			metrics, err := indexer.QueryGlobalDataMetrics(scope)
+			if err != nil {
+				t.Fatalf("QueryGlobalDataMetrics() error = %v", err)
+			}
+			if metrics == nil || metrics.ProposalsCount == nil {
+				t.Fatalf("expected proposal count fallback, got %#v", metrics)
+			}
+			if got, want := *metrics.ProposalsCount, 10; got != want {
+				t.Fatalf("proposal count = %d, want %d", got, want)
+			}
+			if got, want := requestCount, 2; got != want {
+				t.Fatalf("request count = %d, want %d", got, want)
+			}
+		})
+	}
+}

--- a/backend/services/dao.go
+++ b/backend/services/dao.go
@@ -45,6 +45,7 @@ func (s *DaoService) convertToGqlDao(dbDao dbmodels.Dao) *gqlmodels.Dao {
 	copier.Copy(&gqlDao, &dbDao)
 	gqlDao.Tags = tags
 	gqlDao.Domains = domains
+	gqlDao.OffsetTrackingProposal = int32(dbDao.OffsetTrackingBlock)
 	return &gqlDao
 }
 

--- a/backend/services/dao_test.go
+++ b/backend/services/dao_test.go
@@ -1,0 +1,29 @@
+package services
+
+import (
+	"testing"
+
+	dbmodels "github.com/ringecosystem/degov-square/database/models"
+)
+
+func TestConvertToGqlDaoMapsOffsetTrackingProposal(t *testing.T) {
+	t.Parallel()
+
+	service := &DaoService{}
+	dao := service.convertToGqlDao(dbmodels.Dao{
+		Code:                "ring-dao",
+		OffsetTrackingBlock: 42,
+		Tags:                `["governance"]`,
+		Domains:             `["ringdao.com"]`,
+	})
+
+	if got, want := dao.OffsetTrackingProposal, int32(42); got != want {
+		t.Fatalf("OffsetTrackingProposal = %d, want %d", got, want)
+	}
+	if got, want := len(dao.Tags), 1; got != want {
+		t.Fatalf("len(Tags) = %d, want %d", got, want)
+	}
+	if got, want := len(dao.Domains), 1; got != want {
+		t.Fatalf("len(Domains) = %d, want %d", got, want)
+	}
+}

--- a/backend/tasks/dao_sync.go
+++ b/backend/tasks/dao_sync.go
@@ -180,7 +180,7 @@ func (t *DaoSyncTask) processSingleDao(remoteLink GithubConfigLink, daoInfo DaoR
 		// Metrics fields will be nil, indicating no update needed
 	} else if metrics != nil {
 		// Set metrics data if available
-		input.MetricsCountProposals = &metrics.ProposalsCount
+		input.MetricsCountProposals = metrics.ProposalsCount
 		input.MetricsCountMembers = &metrics.MemberCount
 		input.MetricsSumPower = &metrics.PowerSum
 		input.MetricsCountVote = &metrics.VotesCount


### PR DESCRIPTION
## Summary
- fall back to DAO-scoped `proposalsConnection.totalCount` when upstream `dataMetrics.global.proposalsCount` is null or missing
- map `OffsetTrackingBlock` onto GraphQL `offsetTrackingProposal`
- add regression tests for the fallback path and DAO conversion path

## Validation
- `cd backend && go test ./internal ./services`
- `cd backend && go test $(go list ./... | grep -v '/tests$')`

## Issue
- OHH-106
