### PR TITLE
Add backend ENS GraphQL lookup

### DIFF
--- a/backend/graph/resolver.go
+++ b/backend/graph/resolver.go
@@ -17,6 +17,7 @@ type Resolver struct {
 	authService            *services.AuthService
 	daoService             *services.DaoService
 	daoConfigService       *services.DaoConfigService
+	userService            *services.UserService
 	userLikedService       *services.UserLikedDaoService
 	userSubscribedService  *services.UserSubscribedDaoService
 	userInteractionService *services.UserInteractionService
@@ -34,6 +35,7 @@ func NewResolver() *Resolver {
 		authService:            services.NewAuthService(),
 		daoService:             services.NewDaoService(),
 		daoConfigService:       services.NewDaoConfigService(),
+		userService:            services.NewUserService(),
 		userLikedService:       services.NewUserLikedDaoService(),
 		userSubscribedService:  services.NewUserSubscribedDaoService(),
 		userInteractionService: services.NewUserInteractionService(),

--- a/backend/graph/schema.graphqls
+++ b/backend/graph/schema.graphqls
@@ -102,6 +102,11 @@ type EvmAbiOutput {
   type: AbiType!
 }
 
+type EnsOutput {
+  address: String
+  name: String
+}
+
 type Proposal {
   id: ID!
   title: String!
@@ -259,6 +264,11 @@ input EvmAbiInput {
   contract: String!
 }
 
+input EnsInput {
+  address: String
+  name: String
+}
+
 input BaseNotificationChannelInput {
   type: NotificationChannelType!
   value: String!
@@ -332,6 +342,7 @@ type Query {
 
   # Tool queries
   evmAbi(input: EvmAbiInput!): [EvmAbiOutput!] @auth(required: false)
+  ens(input: EnsInput!): EnsOutput @auth(required: false)
 
   # notifications
   listNotificationChannels: [NotificationChannel!] @auth

--- a/backend/graph/schema.resolvers.go
+++ b/backend/graph/schema.resolvers.go
@@ -8,6 +8,7 @@ package graph
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/jinzhu/copier"
@@ -140,6 +141,46 @@ func (r *queryResolver) DaoConfig(ctx context.Context, input *gqlmodels.GetDaoCo
 func (r *queryResolver) EvmAbi(ctx context.Context, input gqlmodels.EvmAbiInput) ([]*gqlmodels.EvmAbiOutput, error) {
 	// panic(fmt.Errorf("not implemented: EvmAbi - evmAbi"))
 	return r.evmChainService.GetAbi(input)
+}
+
+// Ens is the resolver for the ens field.
+func (r *queryResolver) Ens(ctx context.Context, input gqlmodels.EnsInput) (*gqlmodels.EnsOutput, error) {
+	address := ""
+	if input.Address != nil {
+		address = strings.TrimSpace(*input.Address)
+	}
+
+	name := ""
+	if input.Name != nil {
+		name = strings.TrimSpace(*input.Name)
+	}
+
+	if (address == "" && name == "") || (address != "" && name != "") {
+		return nil, fmt.Errorf("ens query requires exactly one of address or name")
+	}
+
+	if address != "" {
+		resolvedName, err := r.userService.GetENSName(address)
+		if err != nil {
+			return nil, err
+		}
+
+		normalizedAddress := strings.ToLower(address)
+		return &gqlmodels.EnsOutput{
+			Address: &normalizedAddress,
+			Name:    resolvedName,
+		}, nil
+	}
+
+	resolvedAddress, err := r.userService.GetENSAddress(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return &gqlmodels.EnsOutput{
+		Address: resolvedAddress,
+		Name:    &name,
+	}, nil
 }
 
 // ListNotificationChannels is the resolver for the listNotificationChannels field.

--- a/backend/services/user.go
+++ b/backend/services/user.go
@@ -19,6 +19,40 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 )
 
+var resolveENSNameViaRPC = func(ctx context.Context, rpcURL string, address string) (*string, error) {
+	client, err := ethclient.DialContext(ctx, rpcURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to %s: %w", rpcURL, err)
+	}
+	defer client.Close()
+
+	ensName, err := ens.ReverseResolve(client, common.HexToAddress(address))
+	if err != nil {
+		return nil, err
+	}
+
+	return &ensName, nil
+}
+
+var resolveENSAddressViaRPC = func(ctx context.Context, rpcURL string, name string) (*string, error) {
+	client, err := ethclient.DialContext(ctx, rpcURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to %s: %w", rpcURL, err)
+	}
+	defer client.Close()
+
+	address, err := ens.Resolve(client, name)
+	if err != nil {
+		return nil, err
+	}
+	if address == (common.Address{}) {
+		return nil, errors.New("no resolution")
+	}
+
+	resolvedAddress := strings.ToLower(address.Hex())
+	return &resolvedAddress, nil
+}
+
 type UserService struct {
 	db *gorm.DB
 }
@@ -73,46 +107,26 @@ func (s *UserService) Inspect(seed string) (*dbmodels.User, error) {
 }
 
 func (s *UserService) GetENSName(address string) (*string, error) {
+	address = strings.ToLower(strings.TrimSpace(address))
+	if address == "" {
+		return nil, nil
+	}
+
 	user, err := s.Inspect(address)
 	if err == nil && user != nil && user.EnsName != nil && *user.EnsName != "" {
 		slog.Info("ENS name found in cache", "address", address, "ensName", *user.EnsName)
 		return user.EnsName, nil
 	}
 
-	rpcURLs := []string{
-		"https://ethereum-rpc.publicnode.com",
-		// "https://eth-mainnet.public.blastapi.io",
-		// "https://ethereum.therpc.io",
-		// "https://eth.api.onfinality.io/public",
-		// "https://eth.nodeconnect.org",
-	}
-
-	envRPCs := os.Getenv("RPC_URL_1")
-	if envRPCs != "" {
-		userRPCs := strings.Split(envRPCs, ",")
-		rpcURLs = append(userRPCs, rpcURLs...)
-	}
-
-	ethAddr := common.HexToAddress(address)
+	rpcURLs := getENSRPCURLs()
 	var lastErr error
 
 	for _, rpcURL := range rpcURLs {
-		if rpcURL == "" {
-			continue
-		}
 		slog.Debug("Trying to resolve ENS name via RPC", "rpcURL", rpcURL)
 
-		client, err := ethclient.DialContext(context.Background(), rpcURL)
+		ensName, err := resolveENSNameViaRPC(context.Background(), rpcURL, address)
 		if err != nil {
-			lastErr = fmt.Errorf("failed to connect to %s: %w", rpcURL, err)
-			slog.Warn("Failed to connect to Ethereum endpoint", "rpcURL", rpcURL, "err", err)
-			continue
-		}
-		defer client.Close()
-
-		ensName, err := ens.ReverseResolve(client, ethAddr)
-		if err != nil {
-			if err.Error() == "no resolution" {
+			if isNoENSResolutionError(err) {
 				slog.Info("Address has no reverse resolution", "address", address, "rpcURL", rpcURL)
 				return nil, nil
 			}
@@ -121,22 +135,85 @@ func (s *UserService) GetENSName(address string) (*string, error) {
 			continue
 		}
 
-		slog.Info("Successfully resolved ENS name", "address", address, "ensName", ensName, "rpcURL", rpcURL)
+		slog.Info("Successfully resolved ENS name", "address", address, "ensName", *ensName, "rpcURL", rpcURL)
 
 		if user == nil {
 			user = &dbmodels.User{
 				Address: address,
 			}
 		}
-		user.EnsName = &ensName
+		user.EnsName = ensName
 
 		if _, err := s.Modify(*user); err != nil {
 			slog.Error("Failed to save resolved ENS name to database", "address", address, "err", err)
 		}
 
-		return &ensName, nil
+		return ensName, nil
 	}
 
 	slog.Error("Failed to resolve ENS name after trying all available RPCs", "address", address, "lastError", lastErr)
 	return nil, fmt.Errorf("all RPCs failed: %w", lastErr)
+}
+
+func (s *UserService) GetENSAddress(name string) (*string, error) {
+	trimmedName := strings.TrimSpace(name)
+	if trimmedName == "" {
+		return nil, nil
+	}
+
+	rpcURLs := getENSRPCURLs()
+	var lastErr error
+
+	for _, rpcURL := range rpcURLs {
+		slog.Debug("Trying to resolve ENS address via RPC", "rpcURL", rpcURL, "name", trimmedName)
+
+		address, err := resolveENSAddressViaRPC(context.Background(), rpcURL, trimmedName)
+		if err != nil {
+			if isNoENSResolutionError(err) {
+				slog.Info("ENS name has no address resolution", "name", trimmedName, "rpcURL", rpcURL)
+				return nil, nil
+			}
+			lastErr = fmt.Errorf("failed to resolve via %s: %w", rpcURL, err)
+			slog.Warn("Failed to resolve ENS address", "rpcURL", rpcURL, "name", trimmedName, "err", err)
+			continue
+		}
+
+		slog.Info("Successfully resolved ENS address", "name", trimmedName, "address", *address, "rpcURL", rpcURL)
+		return address, nil
+	}
+
+	slog.Error("Failed to resolve ENS address after trying all available RPCs", "name", trimmedName, "lastError", lastErr)
+	return nil, fmt.Errorf("all RPCs failed: %w", lastErr)
+}
+
+func getENSRPCURLs() []string {
+	rpcURLs := []string{
+		"https://ethereum-rpc.publicnode.com",
+	}
+
+	envRPCs := os.Getenv("RPC_URL_1")
+	if envRPCs == "" {
+		return rpcURLs
+	}
+
+	userRPCs := make([]string, 0)
+	for _, rpcURL := range strings.Split(envRPCs, ",") {
+		trimmed := strings.TrimSpace(rpcURL)
+		if trimmed != "" {
+			userRPCs = append(userRPCs, trimmed)
+		}
+	}
+
+	return append(userRPCs, rpcURLs...)
+}
+
+func isNoENSResolutionError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "no resolution") ||
+		strings.Contains(message, "unregistered name") ||
+		strings.Contains(message, "no address")
 }

--- a/backend/services/user_test.go
+++ b/backend/services/user_test.go
@@ -1,0 +1,122 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newTestUserService(t *testing.T) *UserService {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite db: %v", err)
+	}
+
+	if err := db.Exec(`
+		CREATE TABLE dgv_user (
+			id TEXT PRIMARY KEY,
+			address TEXT NOT NULL UNIQUE,
+			email TEXT,
+			ens_name TEXT,
+			ctime DATETIME NOT NULL,
+			utime DATETIME
+		)
+	`).Error; err != nil {
+		t.Fatalf("create user table: %v", err)
+	}
+
+	return &UserService{db: db}
+}
+
+func TestGetENSNameUsesCachedUserValue(t *testing.T) {
+	service := newTestUserService(t)
+	cachedName := "cached.eth"
+	now := time.Now()
+
+	if err := service.db.Exec(`
+		INSERT INTO dgv_user (id, address, ens_name, ctime)
+		VALUES (?, ?, ?, ?)
+	`, "user-1", "0x1234", cachedName, now).Error; err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	originalLookup := resolveENSNameViaRPC
+	defer func() {
+		resolveENSNameViaRPC = originalLookup
+	}()
+
+	resolveENSNameViaRPC = func(ctx context.Context, rpcURL string, address string) (*string, error) {
+		t.Fatalf("resolveENSNameViaRPC should not be called when cache is populated")
+		return nil, nil
+	}
+
+	ensName, err := service.GetENSName("0x1234")
+	if err != nil {
+		t.Fatalf("GetENSName returned error: %v", err)
+	}
+	if ensName == nil || *ensName != cachedName {
+		t.Fatalf("expected cached ens name %q, got %#v", cachedName, ensName)
+	}
+}
+
+func TestGetENSAddressFallsBackToLaterRPC(t *testing.T) {
+	service := newTestUserService(t)
+	t.Setenv("RPC_URL_1", "https://rpc-a.example, https://rpc-b.example")
+
+	originalLookup := resolveENSAddressViaRPC
+	defer func() {
+		resolveENSAddressViaRPC = originalLookup
+	}()
+
+	calls := make([]string, 0, 2)
+	resolveENSAddressViaRPC = func(ctx context.Context, rpcURL string, name string) (*string, error) {
+		calls = append(calls, rpcURL)
+		if rpcURL == "https://rpc-a.example" {
+			return nil, errors.New("temporary dial failure")
+		}
+		address := "0xabc0000000000000000000000000000000000001"
+		return &address, nil
+	}
+
+	address, err := service.GetENSAddress("alice.eth")
+	if err != nil {
+		t.Fatalf("GetENSAddress returned error: %v", err)
+	}
+	if address == nil || *address != "0xabc0000000000000000000000000000000000001" {
+		t.Fatalf("expected resolved address, got %#v", address)
+	}
+
+	expectedCalls := []string{"https://rpc-a.example", "https://rpc-b.example"}
+	if !reflect.DeepEqual(calls, expectedCalls) {
+		t.Fatalf("expected lookup calls %v, got %v", expectedCalls, calls)
+	}
+}
+
+func TestGetENSAddressReturnsNilForUnregisteredName(t *testing.T) {
+	service := newTestUserService(t)
+	t.Setenv("RPC_URL_1", "https://rpc-a.example")
+
+	originalLookup := resolveENSAddressViaRPC
+	defer func() {
+		resolveENSAddressViaRPC = originalLookup
+	}()
+
+	resolveENSAddressViaRPC = func(ctx context.Context, rpcURL string, name string) (*string, error) {
+		return nil, errors.New("unregistered name")
+	}
+
+	address, err := service.GetENSAddress("missing.eth")
+	if err != nil {
+		t.Fatalf("GetENSAddress returned error: %v", err)
+	}
+	if address != nil {
+		t.Fatalf("expected nil address for unregistered name, got %#v", address)
+	}
+}


### PR DESCRIPTION
## Summary
- add a public `ens` GraphQL query that supports ENS name-to-address and address-to-name lookups
- reuse backend RPC resolution logic and keep existing ENS-name caching in `UserService`
- add unit coverage for cached ENS reads and RPC fallback behavior

## Testing
- just test

## Issue
- OHH-110
