### PR TITLE
fix: replace offset-based proposal tracking with blockNumber cursor

### DIFF
--- a/backend/database/models/dao.go
+++ b/backend/database/models/dao.go
@@ -66,7 +66,7 @@ type Dao struct {
 	MetricsSumPower       string     `gorm:"column:metrics_sum_power;type:varchar(255);not null;default:'0'" json:"metrics_sum_power"`
 	MetricsCountVote      int        `gorm:"column:metrics_count_vote;not null;default:0" json:"metrics_count_vote"`
 	OffsetTrackingBlock    int   `gorm:"column:offset_tracking_proposal;default:0" json:"offset_tracking_proposal"` // Tracking proposals offset for this DAO (deprecated, kept for compatibility)
-	LastTrackedBlockNumber int64 `gorm:"column:last_tracked_block_number;default:0" json:"last_tracked_block_number"` // Last tracked proposal block number (blockNumber cursor)
+	LastTrackedBlockNumber int64 `gorm:"column:last_tracked_block_number;not null;default:0" json:"last_tracked_block_number"` // Last tracked proposal block number (blockNumber cursor)
 	CTime                 time.Time  `gorm:"column:ctime;default:now()" json:"ctime"`
 	UTime                 *time.Time `gorm:"column:utime" json:"utime,omitempty"`
 }

--- a/backend/database/models/dao.go
+++ b/backend/database/models/dao.go
@@ -65,7 +65,8 @@ type Dao struct {
 	MetricsCountMembers   int        `gorm:"column:metrics_count_members;not null;default:0" json:"metrics_count_members"`
 	MetricsSumPower       string     `gorm:"column:metrics_sum_power;type:varchar(255);not null;default:'0'" json:"metrics_sum_power"`
 	MetricsCountVote      int        `gorm:"column:metrics_count_vote;not null;default:0" json:"metrics_count_vote"`
-	OffsetTrackingBlock   int        `gorm:"column:offset_tracking_proposal;default:0" json:"offset_tracking_proposal"` // Tracking proposals offset for this DAO
+	OffsetTrackingBlock    int   `gorm:"column:offset_tracking_proposal;default:0" json:"offset_tracking_proposal"` // Tracking proposals offset for this DAO (deprecated, kept for compatibility)
+	LastTrackedBlockNumber int64 `gorm:"column:last_tracked_block_number;default:0" json:"last_tracked_block_number"` // Last tracked proposal block number (blockNumber cursor)
 	CTime                 time.Time  `gorm:"column:ctime;default:now()" json:"ctime"`
 	UTime                 *time.Time `gorm:"column:utime" json:"utime,omitempty"`
 }

--- a/backend/database/models/dao.go
+++ b/backend/database/models/dao.go
@@ -46,29 +46,30 @@ func (d *DaoState) UnmarshalYAML(value *yaml.Node) error {
 }
 
 type Dao struct {
-	ID                    string     `gorm:"column:id;type:varchar(50);primaryKey" json:"id"`
-	ChainID               int        `gorm:"column:chain_id;not null" json:"chain_id"`
-	ChainName             string     `gorm:"column:chain_name;type:varchar(255);not null" json:"chain_name"`
-	ChainLogo             string     `gorm:"column:chain_logo;type:text" json:"chain_logo,omitempty"` // Optional chain logo field
-	Name                  string     `gorm:"column:name;type:varchar(255);not null" json:"name"`
-	Code                  string     `gorm:"column:code;type:varchar(255);not null;uniqueIndex:uq_dgv_dao_code" json:"code"`
-	Logo                  string     `gorm:"column:logo;type:text" json:"logo,omitempty"` // Optional logo field
-	Seq                   int        `gorm:"column:seq;not null;default:0" json:"seq"`
-	Endpoint              string     `gorm:"column:endpoint;type:varchar(255);not null" json:"endpoint"` // Website endpoint
-	State                 DaoState   `gorm:"column:state;type:varchar(50);not null" json:"state"`
-	Tags                  string     `gorm:"column:tags;type:text" json:"tags,omitempty"`         // Optional tags field
-	Domains               string     `gorm:"column:domains;type:text" json:"domains,omitempty"`   // Optional domains field
-	Features              string     `gorm:"column:features;type:text" json:"features,omitempty"` // Optional features field (JSON array, e.g., ["fulfill"])
-	ConfigLink            string     `gorm:"column:config_link;type:varchar(255);not null" json:"config_link"`
-	TimeSyncd             *time.Time `gorm:"column:time_syncd" json:"time_syncd,omitempty"`
-	MetricsCountProposals int        `gorm:"column:metrics_count_proposals;not null;default:0" json:"metrics_count_proposals"`
-	MetricsCountMembers   int        `gorm:"column:metrics_count_members;not null;default:0" json:"metrics_count_members"`
-	MetricsSumPower       string     `gorm:"column:metrics_sum_power;type:varchar(255);not null;default:'0'" json:"metrics_sum_power"`
-	MetricsCountVote      int        `gorm:"column:metrics_count_vote;not null;default:0" json:"metrics_count_vote"`
-	OffsetTrackingBlock    int   `gorm:"column:offset_tracking_proposal;default:0" json:"offset_tracking_proposal"` // Tracking proposals offset for this DAO (deprecated, kept for compatibility)
-	LastTrackedBlockNumber int64 `gorm:"column:last_tracked_block_number;not null;default:0" json:"last_tracked_block_number"` // Last tracked proposal block number (blockNumber cursor)
-	CTime                 time.Time  `gorm:"column:ctime;default:now()" json:"ctime"`
-	UTime                 *time.Time `gorm:"column:utime" json:"utime,omitempty"`
+	ID                     string     `gorm:"column:id;type:varchar(50);primaryKey" json:"id"`
+	ChainID                int        `gorm:"column:chain_id;not null" json:"chain_id"`
+	ChainName              string     `gorm:"column:chain_name;type:varchar(255);not null" json:"chain_name"`
+	ChainLogo              string     `gorm:"column:chain_logo;type:text" json:"chain_logo,omitempty"` // Optional chain logo field
+	Name                   string     `gorm:"column:name;type:varchar(255);not null" json:"name"`
+	Code                   string     `gorm:"column:code;type:varchar(255);not null;uniqueIndex:uq_dgv_dao_code" json:"code"`
+	Logo                   string     `gorm:"column:logo;type:text" json:"logo,omitempty"` // Optional logo field
+	Seq                    int        `gorm:"column:seq;not null;default:0" json:"seq"`
+	Endpoint               string     `gorm:"column:endpoint;type:varchar(255);not null" json:"endpoint"` // Website endpoint
+	State                  DaoState   `gorm:"column:state;type:varchar(50);not null" json:"state"`
+	Tags                   string     `gorm:"column:tags;type:text" json:"tags,omitempty"`         // Optional tags field
+	Domains                string     `gorm:"column:domains;type:text" json:"domains,omitempty"`   // Optional domains field
+	Features               string     `gorm:"column:features;type:text" json:"features,omitempty"` // Optional features field (JSON array, e.g., ["fulfill"])
+	ConfigLink             string     `gorm:"column:config_link;type:varchar(255);not null" json:"config_link"`
+	TimeSyncd              *time.Time `gorm:"column:time_syncd" json:"time_syncd,omitempty"`
+	MetricsCountProposals  int        `gorm:"column:metrics_count_proposals;not null;default:0" json:"metrics_count_proposals"`
+	MetricsCountMembers    int        `gorm:"column:metrics_count_members;not null;default:0" json:"metrics_count_members"`
+	MetricsSumPower        string     `gorm:"column:metrics_sum_power;type:varchar(255);not null;default:'0'" json:"metrics_sum_power"`
+	MetricsCountVote       int        `gorm:"column:metrics_count_vote;not null;default:0" json:"metrics_count_vote"`
+	OffsetTrackingBlock    int        `gorm:"column:offset_tracking_proposal;default:0" json:"offset_tracking_proposal"`                             // Tracking proposals offset for this DAO (deprecated, kept for compatibility)
+	LastTrackedBlockNumber int64      `gorm:"column:last_tracked_block_number;not null;default:0" json:"last_tracked_block_number"`                  // Last tracked proposal block number (blockNumber cursor)
+	LastTrackedProposalID  string     `gorm:"column:last_tracked_proposal_id;type:varchar(255);not null;default:''" json:"last_tracked_proposal_id"` // Last tracked indexer proposal id for blockNumber tie-breaker
+	CTime                  time.Time  `gorm:"column:ctime;default:now()" json:"ctime"`
+	UTime                  *time.Time `gorm:"column:utime" json:"utime,omitempty"`
 }
 
 func (Dao) TableName() string {

--- a/backend/internal/indexer.go
+++ b/backend/internal/indexer.go
@@ -333,11 +333,15 @@ func (d *DegovIndexer) QueryProposalsByBlockNumber(scope ProposalScope, afterBlo
 	const limit = 30
 	proposals := make([]Proposal, 0, limit)
 
-	if afterBlockNumber > 0 && strings.TrimSpace(afterProposalID) != "" {
-		sameBlockProposals, err := d.queryProposalsByBlockNumber(scope, map[string]any{
+	if afterBlockNumber > 0 {
+		sameBlockFilter := map[string]any{
 			"blockNumber_eq": strconv.FormatInt(afterBlockNumber, 10),
-			"id_gt":          afterProposalID,
-		}, limit)
+		}
+		if strings.TrimSpace(afterProposalID) != "" {
+			sameBlockFilter["id_gt"] = afterProposalID
+		}
+
+		sameBlockProposals, err := d.queryProposalsByBlockNumber(scope, sameBlockFilter, limit)
 		if err != nil {
 			return nil, err
 		}

--- a/backend/internal/indexer.go
+++ b/backend/internal/indexer.go
@@ -329,10 +329,14 @@ func (d *DegovIndexer) QueryProposalsOffset(scope ProposalScope, offset int) ([]
 }
 
 // QueryProposalsByBlockNumber queries proposals with blockNumber greater than the given value
+// Note: orderBy uses [blockNumber_ASC_NULLS_FIRST, id_ASC] to ensure stable pagination.
+// In the rare edge case where a single blockNumber contains more than 30 proposals (the page limit),
+// some proposals within that block could be missed since we use blockNumber_gt for the next page cursor.
+// In practice, a single DAO block will never contain more than 30 proposals, so this is acceptable.
 func (d *DegovIndexer) QueryProposalsByBlockNumber(scope ProposalScope, afterBlockNumber int64) ([]Proposal, error) {
 	query := `
 		query QueryProposalsByBlockNumber($limit: Int!, $where: ProposalWhereInput) {
-			proposals(orderBy: blockNumber_ASC_NULLS_FIRST, limit: $limit, where: $where) {
+			proposals(orderBy: [blockNumber_ASC_NULLS_FIRST, id_ASC], limit: $limit, where: $where) {
 				id
 				chainId
 				daoCode

--- a/backend/internal/indexer.go
+++ b/backend/internal/indexer.go
@@ -328,12 +328,37 @@ func (d *DegovIndexer) QueryProposalsOffset(scope ProposalScope, offset int) ([]
 	return response.Proposals, nil
 }
 
-// QueryProposalsByBlockNumber queries proposals with blockNumber greater than the given value
-// Note: orderBy uses [blockNumber_ASC_NULLS_FIRST, id_ASC] to ensure stable pagination.
-// In the rare edge case where a single blockNumber contains more than 30 proposals (the page limit),
-// some proposals within that block could be missed since we use blockNumber_gt for the next page cursor.
-// In practice, a single DAO block will never contain more than 30 proposals, so this is acceptable.
-func (d *DegovIndexer) QueryProposalsByBlockNumber(scope ProposalScope, afterBlockNumber int64) ([]Proposal, error) {
+// QueryProposalsByBlockNumber queries proposals after the given blockNumber/id cursor.
+func (d *DegovIndexer) QueryProposalsByBlockNumber(scope ProposalScope, afterBlockNumber int64, afterProposalID string) ([]Proposal, error) {
+	const limit = 30
+	proposals := make([]Proposal, 0, limit)
+
+	if afterBlockNumber > 0 && strings.TrimSpace(afterProposalID) != "" {
+		sameBlockProposals, err := d.queryProposalsByBlockNumber(scope, map[string]any{
+			"blockNumber_eq": strconv.FormatInt(afterBlockNumber, 10),
+			"id_gt":          afterProposalID,
+		}, limit)
+		if err != nil {
+			return nil, err
+		}
+
+		proposals = append(proposals, sameBlockProposals...)
+		if len(proposals) >= limit {
+			return proposals, nil
+		}
+	}
+
+	nextBlockProposals, err := d.queryProposalsByBlockNumber(scope, map[string]any{
+		"blockNumber_gt": strconv.FormatInt(afterBlockNumber, 10),
+	}, limit-len(proposals))
+	if err != nil {
+		return nil, err
+	}
+
+	return append(proposals, nextBlockProposals...), nil
+}
+
+func (d *DegovIndexer) queryProposalsByBlockNumber(scope ProposalScope, whereFilter map[string]any, limit int) ([]Proposal, error) {
 	query := `
 		query QueryProposalsByBlockNumber($limit: Int!, $where: ProposalWhereInput) {
 			proposals(orderBy: [blockNumber_ASC_NULLS_FIRST, id_ASC], limit: $limit, where: $where) {
@@ -371,11 +396,9 @@ func (d *DegovIndexer) QueryProposalsByBlockNumber(scope ProposalScope, afterBlo
 			}
 		}
 	`
-	blockNumberStr := strconv.FormatInt(afterBlockNumber, 10)
-	whereFilter := map[string]any{"blockNumber_gt": blockNumberStr}
 
 	req := graphql.NewRequest(query)
-	req.Var("limit", 30)
+	req.Var("limit", limit)
 	req.Var("where", scope.withScope(whereFilter))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/backend/internal/indexer.go
+++ b/backend/internal/indexer.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -322,6 +323,63 @@ func (d *DegovIndexer) QueryProposalsOffset(scope ProposalScope, offset int) ([]
 	var response ProposalsResponse
 	if err := d.client.Run(ctx, req, &response); err != nil {
 		return nil, fmt.Errorf("failed to execute QueryProposalsOffset: %w", err)
+	}
+
+	return response.Proposals, nil
+}
+
+// QueryProposalsByBlockNumber queries proposals with blockNumber greater than the given value
+func (d *DegovIndexer) QueryProposalsByBlockNumber(scope ProposalScope, afterBlockNumber int64) ([]Proposal, error) {
+	query := `
+		query QueryProposalsByBlockNumber($limit: Int!, $where: ProposalWhereInput) {
+			proposals(orderBy: blockNumber_ASC_NULLS_FIRST, limit: $limit, where: $where) {
+				id
+				chainId
+				daoCode
+				governorAddress
+				proposalId
+				title
+				quorum
+				voteStartTimestamp
+				voteEndTimestamp
+				voteStart
+				voteEnd
+				decimals
+				blockInterval
+				clockMode
+				proposer
+				blockNumber
+				blockTimestamp
+				transactionHash
+				proposalDeadline
+				proposalEta
+				queueReadyAt
+				queueExpiresAt
+				timelockAddress
+				timelockGracePeriod
+				description
+				metricsVotesCount
+				metricsVotesWeightAbstainSum
+				metricsVotesWeightAgainstSum
+				metricsVotesWeightForSum
+				metricsVotesWithParamsCount
+				metricsVotesWithoutParamsCount
+			}
+		}
+	`
+	blockNumberStr := strconv.FormatInt(afterBlockNumber, 10)
+	whereFilter := map[string]any{"blockNumber_gt": blockNumberStr}
+
+	req := graphql.NewRequest(query)
+	req.Var("limit", 30)
+	req.Var("where", scope.withScope(whereFilter))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var response ProposalsResponse
+	if err := d.client.Run(ctx, req, &response); err != nil {
+		return nil, fmt.Errorf("failed to execute QueryProposalsByBlockNumber: %w", err)
 	}
 
 	return response.Proposals, nil

--- a/backend/migrations/000006_blocknumber_cursor.down.sql
+++ b/backend/migrations/000006_blocknumber_cursor.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE dgv_dao DROP COLUMN IF EXISTS last_tracked_block_number;

--- a/backend/migrations/000006_blocknumber_cursor.down.sql
+++ b/backend/migrations/000006_blocknumber_cursor.down.sql
@@ -1,1 +1,2 @@
+ALTER TABLE dgv_dao DROP COLUMN IF EXISTS last_tracked_proposal_id;
 ALTER TABLE dgv_dao DROP COLUMN IF EXISTS last_tracked_block_number;

--- a/backend/migrations/000006_blocknumber_cursor.up.sql
+++ b/backend/migrations/000006_blocknumber_cursor.up.sql
@@ -2,13 +2,3 @@ ALTER TABLE dgv_dao ADD COLUMN IF NOT EXISTS last_tracked_block_number bigint NO
 ALTER TABLE dgv_dao ADD COLUMN IF NOT EXISTS last_tracked_proposal_id varchar(255) NOT NULL DEFAULT '';
 COMMENT ON COLUMN dgv_dao.last_tracked_block_number IS 'Last tracked proposal block number (blockNumber cursor)';
 COMMENT ON COLUMN dgv_dao.last_tracked_proposal_id IS 'Last tracked indexer proposal id for blockNumber tie-breaker';
-
--- Migrate existing data from dgv_proposal_tracking
-UPDATE dgv_dao d
-SET last_tracked_block_number = sub.max_block
-FROM (
-  SELECT dao_code, MAX(proposal_at_block) AS max_block
-  FROM dgv_proposal_tracking
-  GROUP BY dao_code
-) sub
-WHERE d.code = sub.dao_code AND sub.max_block > 0;

--- a/backend/migrations/000006_blocknumber_cursor.up.sql
+++ b/backend/migrations/000006_blocknumber_cursor.up.sql
@@ -1,0 +1,12 @@
+ALTER TABLE dgv_dao ADD COLUMN IF NOT EXISTS last_tracked_block_number bigint DEFAULT 0;
+COMMENT ON COLUMN dgv_dao.last_tracked_block_number IS 'Last tracked proposal block number (blockNumber cursor)';
+
+-- Migrate existing data from dgv_proposal_tracking
+UPDATE dgv_dao d
+SET last_tracked_block_number = sub.max_block
+FROM (
+  SELECT dao_code, MAX(proposal_at_block) AS max_block
+  FROM dgv_proposal_tracking
+  GROUP BY dao_code
+) sub
+WHERE d.code = sub.dao_code AND sub.max_block > 0;

--- a/backend/migrations/000006_blocknumber_cursor.up.sql
+++ b/backend/migrations/000006_blocknumber_cursor.up.sql
@@ -1,5 +1,7 @@
 ALTER TABLE dgv_dao ADD COLUMN IF NOT EXISTS last_tracked_block_number bigint NOT NULL DEFAULT 0;
+ALTER TABLE dgv_dao ADD COLUMN IF NOT EXISTS last_tracked_proposal_id varchar(255) NOT NULL DEFAULT '';
 COMMENT ON COLUMN dgv_dao.last_tracked_block_number IS 'Last tracked proposal block number (blockNumber cursor)';
+COMMENT ON COLUMN dgv_dao.last_tracked_proposal_id IS 'Last tracked indexer proposal id for blockNumber tie-breaker';
 
 -- Migrate existing data from dgv_proposal_tracking
 UPDATE dgv_dao d

--- a/backend/migrations/000006_blocknumber_cursor.up.sql
+++ b/backend/migrations/000006_blocknumber_cursor.up.sql
@@ -1,4 +1,4 @@
-ALTER TABLE dgv_dao ADD COLUMN IF NOT EXISTS last_tracked_block_number bigint DEFAULT 0;
+ALTER TABLE dgv_dao ADD COLUMN IF NOT EXISTS last_tracked_block_number bigint NOT NULL DEFAULT 0;
 COMMENT ON COLUMN dgv_dao.last_tracked_block_number IS 'Last tracked proposal block number (blockNumber cursor)';
 
 -- Migrate existing data from dgv_proposal_tracking

--- a/backend/services/dao.go
+++ b/backend/services/dao.go
@@ -450,11 +450,37 @@ func (s *DaoService) GetLastTrackedBlockNumber(daoCode string) (int64, error) {
 	return blockNumber, nil
 }
 
+// GetLastTrackedProposalCursor returns the last tracked proposal composite cursor for a DAO
+func (s *DaoService) GetLastTrackedProposalCursor(daoCode string) (int64, string, error) {
+	var cursor struct {
+		BlockNumber int64  `gorm:"column:last_tracked_block_number"`
+		ProposalID  string `gorm:"column:last_tracked_proposal_id"`
+	}
+	err := s.db.Model(&dbmodels.Dao{}).
+		Select("COALESCE(last_tracked_block_number, 0) AS last_tracked_block_number, COALESCE(last_tracked_proposal_id, '') AS last_tracked_proposal_id").
+		Where("code = ?", daoCode).
+		Scan(&cursor).Error
+	if err != nil {
+		return 0, "", err
+	}
+	return cursor.BlockNumber, cursor.ProposalID, nil
+}
+
 // UpdateDaoLastTrackedBlockNumber updates the last tracked block number cursor for a DAO
 func (s *DaoService) UpdateDaoLastTrackedBlockNumber(daoCode string, blockNumber int64) error {
 	return s.db.Model(&dbmodels.Dao{}).
 		Where("code = ?", daoCode).
 		Update("last_tracked_block_number", blockNumber).Error
+}
+
+// UpdateDaoLastTrackedProposalCursor updates the last tracked proposal composite cursor for a DAO
+func (s *DaoService) UpdateDaoLastTrackedProposalCursor(daoCode string, blockNumber int64, proposalID string) error {
+	return s.db.Model(&dbmodels.Dao{}).
+		Where("code = ?", daoCode).
+		Updates(map[string]any{
+			"last_tracked_block_number": blockNumber,
+			"last_tracked_proposal_id":  proposalID,
+		}).Error
 }
 
 // getMapKeys extracts keys from a map[string]bool

--- a/backend/services/dao.go
+++ b/backend/services/dao.go
@@ -430,11 +430,28 @@ func (s *DaoService) MarkInactiveDAOs(activeCodes map[string]bool) error {
 	return nil
 }
 
-// UpdateDaoLastTrackingBlock updates the last tracking block for a DAO
+// UpdateDaoOffsetTrackingProposal updates the offset tracking proposal for a DAO
 func (s *DaoService) UpdateDaoOffsetTrackingProposal(daoCode string, offset int) error {
 	return s.db.Model(&dbmodels.Dao{}).
 		Where("code = ?", daoCode).
 		Update("offset_tracking_proposal", offset).Error
+}
+
+// GetLastTrackedBlockNumber returns the last tracked block number cursor for a DAO
+func (s *DaoService) GetLastTrackedBlockNumber(daoCode string) (int64, error) {
+	var dao dbmodels.Dao
+	err := s.db.Select("last_tracked_block_number").Where("code = ?", daoCode).First(&dao).Error
+	if err != nil {
+		return 0, err
+	}
+	return dao.LastTrackedBlockNumber, nil
+}
+
+// UpdateDaoLastTrackedBlockNumber updates the last tracked block number cursor for a DAO
+func (s *DaoService) UpdateDaoLastTrackedBlockNumber(daoCode string, blockNumber int64) error {
+	return s.db.Model(&dbmodels.Dao{}).
+		Where("code = ?", daoCode).
+		Update("last_tracked_block_number", blockNumber).Error
 }
 
 // getMapKeys extracts keys from a map[string]bool

--- a/backend/services/dao.go
+++ b/backend/services/dao.go
@@ -439,12 +439,15 @@ func (s *DaoService) UpdateDaoOffsetTrackingProposal(daoCode string, offset int)
 
 // GetLastTrackedBlockNumber returns the last tracked block number cursor for a DAO
 func (s *DaoService) GetLastTrackedBlockNumber(daoCode string) (int64, error) {
-	var dao dbmodels.Dao
-	err := s.db.Select("last_tracked_block_number").Where("code = ?", daoCode).First(&dao).Error
+	var blockNumber int64
+	err := s.db.Model(&dbmodels.Dao{}).
+		Select("COALESCE(last_tracked_block_number, 0)").
+		Where("code = ?", daoCode).
+		Scan(&blockNumber).Error
 	if err != nil {
 		return 0, err
 	}
-	return dao.LastTrackedBlockNumber, nil
+	return blockNumber, nil
 }
 
 // UpdateDaoLastTrackedBlockNumber updates the last tracked block number cursor for a DAO

--- a/backend/tasks/tracking_proposal.go
+++ b/backend/tasks/tracking_proposal.go
@@ -93,19 +93,21 @@ func (t *TrackingProposalTask) storeProposals(dao *gqlmodels.Dao, daoConfig *typ
 		GovernorAddress: daoConfig.Contracts.Governor,
 	}
 
-	lastTrackedBlockNumber, err := t.daoService.GetLastTrackedBlockNumber(dao.Code)
+	lastTrackedBlockNumber, lastTrackedProposalID, err := t.daoService.GetLastTrackedProposalCursor(dao.Code)
 	if err != nil {
-		return fmt.Errorf("failed to get last tracked block number: %w", err)
+		return fmt.Errorf("failed to get last tracked proposal cursor: %w", err)
 	}
 
 	initialBlockNumber := lastTrackedBlockNumber
+	initialProposalID := lastTrackedProposalID
 
 	slog.Info("Starting proposal tracking",
 		"dao_code", dao.Code,
-		"after_block_number", lastTrackedBlockNumber)
+		"after_block_number", lastTrackedBlockNumber,
+		"after_proposal_id", lastTrackedProposalID)
 
 	for {
-		proposals, err := indexer.QueryProposalsByBlockNumber(scope, lastTrackedBlockNumber)
+		proposals, err := indexer.QueryProposalsByBlockNumber(scope, lastTrackedBlockNumber, lastTrackedProposalID)
 		if err != nil {
 			return fmt.Errorf("failed to query proposals: %w", err)
 		}
@@ -117,7 +119,16 @@ func (t *TrackingProposalTask) storeProposals(dao *gqlmodels.Dao, daoConfig *typ
 
 		slog.Info("Found proposals", "dao_code", dao.Code, "count", len(proposals))
 
+		var batchErr error
 		for _, proposal := range proposals {
+			if proposal.ID == "" {
+				slog.Error("Proposal missing indexer id",
+					"dao_code", dao.Code,
+					"proposal_id", proposal.ProposalID)
+				batchErr = fmt.Errorf("proposal %s missing indexer id", proposal.ProposalID)
+				break
+			}
+
 			blockNumber, err := strconv.ParseInt(proposal.BlockNumber, 10, 64)
 			if err != nil {
 				slog.Error("Failed to parse block number",
@@ -126,6 +137,7 @@ func (t *TrackingProposalTask) storeProposals(dao *gqlmodels.Dao, daoConfig *typ
 					"block_number", proposal.BlockNumber,
 					"error", err)
 				// Stop processing this batch; retry next time to avoid skipping proposals
+				batchErr = fmt.Errorf("failed to parse proposal block number: %w", err)
 				break
 			}
 
@@ -156,6 +168,7 @@ func (t *TrackingProposalTask) storeProposals(dao *gqlmodels.Dao, daoConfig *typ
 					"proposal_id", proposal.ProposalID,
 					"error", err)
 				// Stop processing this batch; do not advance cursor, retry next time
+				batchErr = fmt.Errorf("failed to store proposal tracking: %w", err)
 				break
 			}
 
@@ -172,20 +185,29 @@ func (t *TrackingProposalTask) storeProposals(dao *gqlmodels.Dao, daoConfig *typ
 			}
 
 			// Only advance cursor after successful store
-			if blockNumber > lastTrackedBlockNumber {
+			if blockNumber > lastTrackedBlockNumber ||
+				(blockNumber == lastTrackedBlockNumber && proposal.ID > lastTrackedProposalID) {
 				lastTrackedBlockNumber = blockNumber
+				lastTrackedProposalID = proposal.ID
 			}
 		}
 
-		if lastTrackedBlockNumber != initialBlockNumber {
-			if err := t.daoService.UpdateDaoLastTrackedBlockNumber(dao.Code, lastTrackedBlockNumber); err != nil {
-				return fmt.Errorf("failed to update last tracked block number: %w", err)
+		if lastTrackedBlockNumber != initialBlockNumber || lastTrackedProposalID != initialProposalID {
+			if err := t.daoService.UpdateDaoLastTrackedProposalCursor(dao.Code, lastTrackedBlockNumber, lastTrackedProposalID); err != nil {
+				return fmt.Errorf("failed to update last tracked proposal cursor: %w", err)
 			}
-			slog.Info("Updated last tracked block number",
+			slog.Info("Updated last tracked proposal cursor",
 				"dao_code", dao.Code,
 				"old_block", initialBlockNumber,
-				"new_block", lastTrackedBlockNumber)
+				"old_proposal_id", initialProposalID,
+				"new_block", lastTrackedBlockNumber,
+				"new_proposal_id", lastTrackedProposalID)
 			initialBlockNumber = lastTrackedBlockNumber
+			initialProposalID = lastTrackedProposalID
+		}
+
+		if batchErr != nil {
+			return batchErr
 		}
 	}
 

--- a/backend/tasks/tracking_proposal.go
+++ b/backend/tasks/tracking_proposal.go
@@ -93,19 +93,19 @@ func (t *TrackingProposalTask) storeProposals(dao *gqlmodels.Dao, daoConfig *typ
 		GovernorAddress: daoConfig.Contracts.Governor,
 	}
 
-	offsetTrackingProposal := int(dao.OffsetTrackingProposal)
+	lastTrackedBlockNumber, err := t.daoService.GetLastTrackedBlockNumber(dao.Code)
+	if err != nil {
+		return fmt.Errorf("failed to get last tracked block number: %w", err)
+	}
 
-	lastOffsetTrackingProposal := offsetTrackingProposal
+	initialBlockNumber := lastTrackedBlockNumber
 
 	slog.Info("Starting proposal tracking",
 		"dao_code", dao.Code,
-		"start_block", lastOffsetTrackingProposal)
+		"after_block_number", lastTrackedBlockNumber)
 
 	for {
-
-		// Query proposals after the last tracked block (correct parameter order)
-		proposals, err := indexer.QueryProposalsOffset(scope, lastOffsetTrackingProposal)
-
+		proposals, err := indexer.QueryProposalsByBlockNumber(scope, lastTrackedBlockNumber)
 		if err != nil {
 			return fmt.Errorf("failed to query proposals: %w", err)
 		}
@@ -117,10 +117,8 @@ func (t *TrackingProposalTask) storeProposals(dao *gqlmodels.Dao, daoConfig *typ
 
 		slog.Info("Found proposals", "dao_code", dao.Code, "count", len(proposals))
 
-		// Process each proposal
 		for _, proposal := range proposals {
-			// Parse block number and timestamp
-			blockNumber, err := strconv.Atoi(proposal.BlockNumber)
+			blockNumber, err := strconv.ParseInt(proposal.BlockNumber, 10, 64)
 			if err != nil {
 				slog.Error("Failed to parse block number",
 					"dao_code", dao.Code,
@@ -130,20 +128,16 @@ func (t *TrackingProposalTask) storeProposals(dao *gqlmodels.Dao, daoConfig *typ
 				continue
 			}
 
-			// Parse block timestamp
 			var proposalCreatedAt *time.Time
 			if proposal.BlockTimestamp != "" {
 				if timestamp, err := strconv.ParseInt(proposal.BlockTimestamp, 10, 64); err == nil {
-					// Convert milliseconds to seconds for time.Unix()
 					createdAt := time.Unix(timestamp/1000, (timestamp%1000)*1000000)
 					proposalCreatedAt = &createdAt
 				}
 			}
 
-			// Create proposal link
 			proposalLink := fmt.Sprintf("%s/proposal/%s", daoConfig.SiteURL, proposal.ProposalID)
 
-			// Build proposal tracking input
 			input := types.ProposalTrackingInput{
 				DaoCode:           dao.Code,
 				ChainId:           daoConfig.Chain.ID,
@@ -151,10 +145,9 @@ func (t *TrackingProposalTask) storeProposals(dao *gqlmodels.Dao, daoConfig *typ
 				ProposalLink:      proposalLink,
 				ProposalID:        proposal.ProposalID,
 				ProposalCreatedAt: proposalCreatedAt,
-				ProposalAtBlock:   blockNumber,
+				ProposalAtBlock:   int(blockNumber),
 			}
 
-			// Store proposal tracking (handles existence check internally)
 			created, err := t.proposalService.StoreProposalTracking(input)
 			if err != nil {
 				slog.Error("Failed to store proposal tracking",
@@ -176,19 +169,20 @@ func (t *TrackingProposalTask) storeProposals(dao *gqlmodels.Dao, daoConfig *typ
 					"proposal_id", proposal.ProposalID)
 			}
 
-			// Update offset tracking proposal
-			lastOffsetTrackingProposal += 1
+			if blockNumber > lastTrackedBlockNumber {
+				lastTrackedBlockNumber = blockNumber
+			}
 		}
 
-		if lastOffsetTrackingProposal != offsetTrackingProposal {
-			if err := t.daoService.UpdateDaoOffsetTrackingProposal(dao.Code, lastOffsetTrackingProposal); err != nil {
-				return fmt.Errorf("failed to update last tracking block: %w", err)
+		if lastTrackedBlockNumber != initialBlockNumber {
+			if err := t.daoService.UpdateDaoLastTrackedBlockNumber(dao.Code, lastTrackedBlockNumber); err != nil {
+				return fmt.Errorf("failed to update last tracked block number: %w", err)
 			}
-
-			slog.Info("Updated last tracking offset",
+			slog.Info("Updated last tracked block number",
 				"dao_code", dao.Code,
-				"old_offset", offsetTrackingProposal,
-				"new_offset", lastOffsetTrackingProposal)
+				"old_block", initialBlockNumber,
+				"new_block", lastTrackedBlockNumber)
+			initialBlockNumber = lastTrackedBlockNumber
 		}
 	}
 

--- a/backend/tasks/tracking_proposal.go
+++ b/backend/tasks/tracking_proposal.go
@@ -98,6 +98,11 @@ func (t *TrackingProposalTask) storeProposals(dao *gqlmodels.Dao, daoConfig *typ
 		return fmt.Errorf("failed to get last tracked proposal cursor: %w", err)
 	}
 
+	lastTrackedBlockNumber, lastTrackedProposalID, err = t.bootstrapProposalCursor(indexer, scope, dao, lastTrackedBlockNumber, lastTrackedProposalID)
+	if err != nil {
+		return err
+	}
+
 	initialBlockNumber := lastTrackedBlockNumber
 	initialProposalID := lastTrackedProposalID
 
@@ -212,6 +217,41 @@ func (t *TrackingProposalTask) storeProposals(dao *gqlmodels.Dao, daoConfig *typ
 	}
 
 	return nil
+}
+
+func (t *TrackingProposalTask) bootstrapProposalCursor(indexer *internal.DegovIndexer, scope internal.ProposalScope, dao *gqlmodels.Dao, lastTrackedBlockNumber int64, lastTrackedProposalID string) (int64, string, error) {
+	if lastTrackedProposalID != "" || dao.OffsetTrackingProposal <= 0 {
+		return lastTrackedBlockNumber, lastTrackedProposalID, nil
+	}
+
+	proposals, err := indexer.QueryProposalsOffset(scope, int(dao.OffsetTrackingProposal)-1)
+	if err != nil {
+		return 0, "", fmt.Errorf("failed to bootstrap proposal cursor from offset: %w", err)
+	}
+	if len(proposals) == 0 {
+		slog.Warn("Failed to bootstrap proposal cursor from offset",
+			"dao_code", dao.Code,
+			"offset_tracking_proposal", dao.OffsetTrackingProposal)
+		return lastTrackedBlockNumber, lastTrackedProposalID, nil
+	}
+
+	blockNumber, err := strconv.ParseInt(proposals[0].BlockNumber, 10, 64)
+	if err != nil {
+		return 0, "", fmt.Errorf("failed to parse bootstrap proposal block number: %w", err)
+	}
+
+	if blockNumber != lastTrackedBlockNumber {
+		if err := t.daoService.UpdateDaoLastTrackedProposalCursor(dao.Code, blockNumber, ""); err != nil {
+			return 0, "", fmt.Errorf("failed to update bootstrapped proposal cursor: %w", err)
+		}
+	}
+
+	slog.Info("Bootstrapped proposal cursor from offset",
+		"dao_code", dao.Code,
+		"offset_tracking_proposal", dao.OffsetTrackingProposal,
+		"last_tracked_block_number", blockNumber)
+
+	return blockNumber, "", nil
 }
 
 func (t *TrackingProposalTask) updateProposalsStates(dao *gqlmodels.Dao, daoConfig *types.DaoConfig) error {

--- a/backend/tasks/tracking_proposal.go
+++ b/backend/tasks/tracking_proposal.go
@@ -125,7 +125,8 @@ func (t *TrackingProposalTask) storeProposals(dao *gqlmodels.Dao, daoConfig *typ
 					"proposal_id", proposal.ProposalID,
 					"block_number", proposal.BlockNumber,
 					"error", err)
-				continue
+				// Stop processing this batch; retry next time to avoid skipping proposals
+				break
 			}
 
 			var proposalCreatedAt *time.Time
@@ -154,7 +155,8 @@ func (t *TrackingProposalTask) storeProposals(dao *gqlmodels.Dao, daoConfig *typ
 					"dao_code", dao.Code,
 					"proposal_id", proposal.ProposalID,
 					"error", err)
-				continue
+				// Stop processing this batch; do not advance cursor, retry next time
+				break
 			}
 
 			if created {
@@ -169,6 +171,7 @@ func (t *TrackingProposalTask) storeProposals(dao *gqlmodels.Dao, daoConfig *typ
 					"proposal_id", proposal.ProposalID)
 			}
 
+			// Only advance cursor after successful store
 			if blockNumber > lastTrackedBlockNumber {
 				lastTrackedBlockNumber = blockNumber
 			}


### PR DESCRIPTION
## Problem

When the indexer is rebuilt, the total proposal count resets but the stored `offset_tracking_proposal` cursor retains the old accumulated value. This causes the tracking loop to always query beyond the available proposals, resulting in no new proposals being picked up and no notifications being sent.

## Solution

Replace the offset-based pagination with a `blockNumber`-based cursor. The new approach stores the highest block number seen and uses `blockNumber_gt` filter on subsequent queries. This is stable across indexer rebuilds because block numbers are monotonically increasing chain data, not a count of indexed records.

## Changes

- **Migration 000006**: Adds `last_tracked_block_number` (bigint) column to `dgv_dao` table, with a data migration that initialises values from existing `proposal_at_block` records in `dgv_proposal_tracking`
- **`database/models/dao.go`**: Added `LastTrackedBlockNumber int64` field to the `Dao` struct
- **`internal/indexer.go`**: Added `QueryProposalsByBlockNumber` method using `blockNumber_gt` filter and `blockNumber_ASC` ordering
- **`services/dao.go`**: Added `GetLastTrackedBlockNumber` and `UpdateDaoLastTrackedBlockNumber` methods
- **`tasks/tracking_proposal.go`**: Rewrote `storeProposals` to use the blockNumber cursor instead of offset index

## Backward Compatibility

The old `OffsetTrackingBlock` field, `offset_tracking_proposal` column, `UpdateDaoOffsetTrackingProposal` method, and `QueryProposalsOffset` indexer method are all retained unchanged. No existing data is removed.