### PR TITLE
Bump web version to 0.7.8

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.7.2",
+  "version": "0.7.8",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bump web package version from `0.7.2` to `0.7.8`.

## Verification

- Not run; package metadata only.