### PR TITLE
feat(mcp): add proposal read tools

### DIFF
--- a/backend/internal/mcp/server.go
+++ b/backend/internal/mcp/server.go
@@ -20,6 +20,7 @@ func NewServer(cfg Config) *sdkmcp.Server {
 	}, nil)
 
 	addPingTool(server, cfg)
+	addProposalTools(server)
 
 	return server
 }

--- a/backend/internal/mcp/tools_proposal.go
+++ b/backend/internal/mcp/tools_proposal.go
@@ -1,0 +1,142 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/ringecosystem/degov-square/services"
+	"github.com/ringecosystem/degov-square/types"
+	"gorm.io/gorm"
+)
+
+func addProposalTools(server *sdkmcp.Server) {
+	sdkmcp.AddTool(server, &sdkmcp.Tool{
+		Name:        "list_proposals",
+		Title:       "List Proposals",
+		Description: "Return bounded governance proposal rows for a DAO.",
+		Annotations: &sdkmcp.ToolAnnotations{
+			ReadOnlyHint: true,
+		},
+	}, listProposalsTool)
+
+	sdkmcp.AddTool(server, &sdkmcp.Tool{
+		Name:        "get_proposal",
+		Title:       "Get Proposal",
+		Description: "Return a governance proposal detail payload for a DAO.",
+		Annotations: &sdkmcp.ToolAnnotations{
+			ReadOnlyHint: true,
+		},
+	}, getProposalTool)
+}
+
+func listProposalsTool(ctx context.Context, req *sdkmcp.CallToolRequest, input listProposalsInput) (*sdkmcp.CallToolResult, listProposalsOutput, error) {
+	daoCode, err := normalizeDaoCode(input.DaoCode)
+	if err != nil {
+		return nil, listProposalsOutput{}, err
+	}
+	if input.Offset < 0 {
+		return nil, listProposalsOutput{}, errors.New("invalid_offset: offset must be greater than or equal to 0")
+	}
+
+	limit := normalizeProposalListLimit(input.Limit)
+	var state string
+	listInput := types.ListProposalsInput{
+		DaoCode: daoCode,
+		Limit:   limit,
+		Offset:  input.Offset,
+	}
+	if strings.TrimSpace(input.State) != "" {
+		normalizedState, err := normalizeProposalState(input.State)
+		if err != nil {
+			return nil, listProposalsOutput{}, err
+		}
+		listInput.State = normalizedState
+		state = string(normalizedState)
+	}
+
+	if err := requireDAO(daoCode); err != nil {
+		return nil, listProposalsOutput{}, err
+	}
+
+	proposalService := services.NewProposalService()
+	proposals, err := proposalService.ListProposals(listInput)
+	if err != nil {
+		return nil, listProposalsOutput{}, fmt.Errorf("proposal_list_failed: %w", err)
+	}
+
+	output := listProposalsOutput{
+		DaoCode:   daoCode,
+		State:     state,
+		Limit:     limit,
+		Offset:    input.Offset,
+		Proposals: make([]proposalToolOutput, 0, len(proposals)),
+	}
+	for _, proposal := range proposals {
+		output.Proposals = append(output.Proposals, proposalToolDTO(proposal))
+	}
+
+	return nil, output, nil
+}
+
+func getProposalTool(ctx context.Context, req *sdkmcp.CallToolRequest, input getProposalInput) (*sdkmcp.CallToolResult, getProposalOutput, error) {
+	daoCode, err := normalizeDaoCode(input.DaoCode)
+	if err != nil {
+		return nil, getProposalOutput{}, err
+	}
+	proposalID := strings.TrimSpace(input.ProposalID)
+	if proposalID == "" {
+		return nil, getProposalOutput{}, errors.New("invalid_proposal_id: proposalId is required")
+	}
+	if err := requireDAO(daoCode); err != nil {
+		return nil, getProposalOutput{}, err
+	}
+
+	proposalService := services.NewProposalService()
+	proposal, err := proposalService.InspectProposal(types.InspectProposalInput{
+		DaoCode:    daoCode,
+		ProposalID: proposalID,
+	})
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, getProposalOutput{}, fmt.Errorf("proposal_not_found: proposal %q was not found for DAO %q", proposalID, daoCode)
+		}
+		return nil, getProposalOutput{}, fmt.Errorf("proposal_lookup_failed: %w", err)
+	}
+
+	return nil, getProposalOutput{
+		Proposal: proposalToolDTO(proposal),
+	}, nil
+}
+
+func normalizeProposalListLimit(limit int) int {
+	if limit <= 0 {
+		return defaultProposalListLimit
+	}
+	if limit > maxProposalListLimit {
+		return maxProposalListLimit
+	}
+	return limit
+}
+
+func normalizeDaoCode(raw string) (string, error) {
+	daoCode := strings.TrimSpace(raw)
+	if daoCode == "" {
+		return "", errors.New("invalid_dao_code: daoCode is required")
+	}
+	return daoCode, nil
+}
+
+func requireDAO(daoCode string) error {
+	daoService := services.NewDaoService()
+	dao, err := daoService.GetByCode(daoCode)
+	if err != nil {
+		return fmt.Errorf("dao_lookup_failed: %w", err)
+	}
+	if dao == nil {
+		return fmt.Errorf("dao_not_found: DAO %q was not found", daoCode)
+	}
+	return nil
+}

--- a/backend/internal/mcp/tools_proposal_test.go
+++ b/backend/internal/mcp/tools_proposal_test.go
@@ -1,0 +1,334 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/ringecosystem/degov-square/database"
+	dbmodels "github.com/ringecosystem/degov-square/database/models"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newTestProposalServer(t *testing.T) *sdkmcp.Server {
+	t.Helper()
+
+	previousDB := database.DB
+	t.Cleanup(func() {
+		database.DB = previousDB
+	})
+
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite db: %v", err)
+	}
+	if err := db.Exec(`
+		CREATE TABLE dgv_dao (
+			id TEXT PRIMARY KEY,
+			chain_id INTEGER NOT NULL,
+			chain_name TEXT NOT NULL,
+			chain_logo TEXT,
+			name TEXT NOT NULL,
+			code TEXT NOT NULL,
+			logo TEXT,
+			seq INTEGER NOT NULL DEFAULT 0,
+			endpoint TEXT NOT NULL,
+			state TEXT NOT NULL,
+			tags TEXT,
+			domains TEXT,
+			features TEXT,
+			config_link TEXT NOT NULL,
+			time_syncd DATETIME,
+			metrics_count_proposals INTEGER NOT NULL DEFAULT 0,
+			metrics_count_members INTEGER NOT NULL DEFAULT 0,
+			metrics_sum_power TEXT NOT NULL DEFAULT '0',
+			metrics_count_vote INTEGER NOT NULL DEFAULT 0,
+			last_tracked_block_number INTEGER NOT NULL DEFAULT 0,
+			last_tracked_proposal_id TEXT NOT NULL DEFAULT '',
+			ctime DATETIME NOT NULL,
+			utime DATETIME
+		)
+	`).Error; err != nil {
+		t.Fatalf("create dao table: %v", err)
+	}
+	if err := db.Exec(`
+		CREATE TABLE dgv_proposal_tracking (
+			id TEXT PRIMARY KEY,
+			dao_code TEXT NOT NULL,
+			chain_id INTEGER NOT NULL,
+			title TEXT NOT NULL,
+			proposal_link TEXT NOT NULL,
+			proposal_id TEXT NOT NULL,
+			state TEXT NOT NULL,
+			proposal_created_at DATETIME,
+			proposal_at_block INTEGER NOT NULL,
+			times_track INTEGER NOT NULL DEFAULT 0,
+			time_next_track DATETIME,
+			message TEXT,
+			offset_tracking_vote INTEGER DEFAULT 0,
+			fulfilled INTEGER DEFAULT 0,
+			fulfilled_explain TEXT,
+			fulfilled_at DATETIME,
+			times_fulfill INTEGER DEFAULT 0,
+			fulfill_errored INTEGER DEFAULT 0,
+			ctime DATETIME NOT NULL,
+			utime DATETIME
+		)
+	`).Error; err != nil {
+		t.Fatalf("create proposal tracking table: %v", err)
+	}
+	database.DB = db
+
+	seedMCPDao(t, db, "ring-dao")
+	return NewServer(Config{Name: "degov-square", Version: "test-version"})
+}
+
+func seedMCPDao(t *testing.T, db *gorm.DB, code string) {
+	t.Helper()
+
+	if err := db.Create(&dbmodels.Dao{
+		ID:         "dao-" + code,
+		ChainID:    46,
+		ChainName:  "Darwinia",
+		Name:       "Ring DAO",
+		Code:       code,
+		Endpoint:   "https://gov.ringdao.com",
+		State:      dbmodels.DaoStateActive,
+		ConfigLink: "https://example.com/config.yml",
+		CTime:      time.Now(),
+	}).Error; err != nil {
+		t.Fatalf("seed dao: %v", err)
+	}
+}
+
+func seedMCPProposal(t *testing.T, proposal dbmodels.ProposalTracking) {
+	t.Helper()
+
+	if err := database.DB.Create(&proposal).Error; err != nil {
+		t.Fatalf("seed proposal: %v", err)
+	}
+}
+
+func callProposalTool(t *testing.T, server *sdkmcp.Server, name string, arguments map[string]any) *sdkmcp.CallToolResult {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clientTransport, serverTransport := sdkmcp.NewInMemoryTransports()
+	go func() {
+		_ = server.Run(ctx, serverTransport)
+	}()
+
+	client := sdkmcp.NewClient(&sdkmcp.Implementation{Name: "test-client"}, nil)
+	session, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("Connect() error = %v", err)
+	}
+	defer session.Close()
+
+	result, err := session.CallTool(ctx, &sdkmcp.CallToolParams{
+		Name:      name,
+		Arguments: arguments,
+	})
+	if err != nil {
+		t.Fatalf("CallTool() protocol error = %v", err)
+	}
+	return result
+}
+
+func requireStructuredContent(t *testing.T, result *sdkmcp.CallToolResult) map[string]any {
+	t.Helper()
+
+	if result.IsError {
+		t.Fatalf("CallTool() returned error result: %v", result.Content)
+	}
+	content, ok := result.StructuredContent.(map[string]any)
+	if !ok {
+		t.Fatalf("StructuredContent type = %T, want map[string]any", result.StructuredContent)
+	}
+	return content
+}
+
+func requireToolErrorContains(t *testing.T, result *sdkmcp.CallToolResult, want string) {
+	t.Helper()
+
+	if !result.IsError {
+		t.Fatalf("IsError = false, want true")
+	}
+	if len(result.Content) == 0 {
+		t.Fatalf("error content is empty")
+	}
+	text, ok := result.Content[0].(*sdkmcp.TextContent)
+	if !ok {
+		t.Fatalf("error content type = %T, want *TextContent", result.Content[0])
+	}
+	if !strings.Contains(text.Text, want) {
+		t.Fatalf("error text = %q, want substring %q", text.Text, want)
+	}
+}
+
+func TestListProposalsToolReturnsBoundedRows(t *testing.T) {
+	server := newTestProposalServer(t)
+	createdAt := time.Now().Add(-time.Hour)
+	for i := 0; i < 60; i++ {
+		seedMCPProposal(t, dbmodels.ProposalTracking{
+			ID:                fmt.Sprintf("proposal-%d", i),
+			DaoCode:           "ring-dao",
+			ChainId:           46,
+			Title:             fmt.Sprintf("Proposal %d", i),
+			ProposalLink:      fmt.Sprintf("https://gov.ringdao.com/proposal/%d", i),
+			ProposalID:        fmt.Sprintf("0x%x", i),
+			State:             dbmodels.ProposalStateActive,
+			ProposalCreatedAt: &createdAt,
+			CTime:             time.Now(),
+		})
+	}
+
+	result := callProposalTool(t, server, "list_proposals", map[string]any{
+		"daoCode": "ring-dao",
+		"limit":   99,
+	})
+	content := requireStructuredContent(t, result)
+
+	if got, want := content["limit"], float64(50); got != want {
+		t.Fatalf("limit = %v, want %v", got, want)
+	}
+	proposals, ok := content["proposals"].([]any)
+	if !ok {
+		t.Fatalf("proposals type = %T, want []any", content["proposals"])
+	}
+	if len(proposals) != 50 {
+		t.Fatalf("len(proposals) = %d, want 50", len(proposals))
+	}
+}
+
+func TestListProposalsToolFiltersByState(t *testing.T) {
+	server := newTestProposalServer(t)
+
+	seedMCPProposal(t, dbmodels.ProposalTracking{
+		ID:           "proposal-active",
+		DaoCode:      "ring-dao",
+		ChainId:      46,
+		Title:        "Active proposal",
+		ProposalLink: "https://gov.ringdao.com/proposal/active",
+		ProposalID:   "0xactive",
+		State:        dbmodels.ProposalStateActive,
+		CTime:        time.Now(),
+	})
+	seedMCPProposal(t, dbmodels.ProposalTracking{
+		ID:           "proposal-executed",
+		DaoCode:      "ring-dao",
+		ChainId:      46,
+		Title:        "Executed proposal",
+		ProposalLink: "https://gov.ringdao.com/proposal/executed",
+		ProposalID:   "0xexecuted",
+		State:        dbmodels.ProposalStateExecuted,
+		CTime:        time.Now(),
+	})
+
+	result := callProposalTool(t, server, "list_proposals", map[string]any{
+		"daoCode": "ring-dao",
+		"state":   "executed",
+	})
+	content := requireStructuredContent(t, result)
+	proposals := content["proposals"].([]any)
+
+	if len(proposals) != 1 {
+		t.Fatalf("len(proposals) = %d, want 1", len(proposals))
+	}
+	proposal := proposals[0].(map[string]any)
+	if got, want := proposal["proposalId"], "0xexecuted"; got != want {
+		t.Fatalf("proposalId = %v, want %v", got, want)
+	}
+}
+
+func TestGetProposalToolReturnsDetail(t *testing.T) {
+	server := newTestProposalServer(t)
+	createdAt := time.Now().Add(-time.Hour)
+
+	seedMCPProposal(t, dbmodels.ProposalTracking{
+		ID:                 "proposal-detail",
+		DaoCode:            "ring-dao",
+		ChainId:            46,
+		Title:              "Detailed proposal",
+		ProposalLink:       "https://gov.ringdao.com/proposal/detail",
+		ProposalID:         "0xdetail",
+		State:              dbmodels.ProposalStateSucceeded,
+		ProposalCreatedAt:  &createdAt,
+		ProposalAtBlock:    12345,
+		OffsetTrackingVote: 12,
+		CTime:              time.Now(),
+	})
+
+	result := callProposalTool(t, server, "get_proposal", map[string]any{
+		"daoCode":    "ring-dao",
+		"proposalId": "0xdetail",
+	})
+	content := requireStructuredContent(t, result)
+
+	proposal := content["proposal"].(map[string]any)
+	if got, want := proposal["proposalId"], "0xdetail"; got != want {
+		t.Fatalf("proposalId = %v, want %v", got, want)
+	}
+	if got, want := proposal["state"], "SUCCEEDED"; got != want {
+		t.Fatalf("state = %v, want %v", got, want)
+	}
+	if got, want := proposal["offsetTrackingVote"], float64(12); got != want {
+		t.Fatalf("offsetTrackingVote = %v, want %v", got, want)
+	}
+}
+
+func TestProposalToolsReturnClearErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		tool      string
+		arguments map[string]any
+		wantError string
+	}{
+		{
+			name:      "invalid state",
+			tool:      "list_proposals",
+			arguments: map[string]any{"daoCode": "ring-dao", "state": "bad"},
+			wantError: "invalid_state",
+		},
+		{
+			name:      "invalid dao code",
+			tool:      "list_proposals",
+			arguments: map[string]any{"daoCode": ""},
+			wantError: "invalid_dao_code",
+		},
+		{
+			name:      "unknown dao",
+			tool:      "list_proposals",
+			arguments: map[string]any{"daoCode": "missing-dao"},
+			wantError: "dao_not_found",
+		},
+		{
+			name:      "invalid proposal id",
+			tool:      "get_proposal",
+			arguments: map[string]any{"daoCode": "ring-dao", "proposalId": ""},
+			wantError: "invalid_proposal_id",
+		},
+		{
+			name:      "unknown proposal",
+			tool:      "get_proposal",
+			arguments: map[string]any{"daoCode": "ring-dao", "proposalId": "0xmissing"},
+			wantError: "proposal_not_found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := newTestProposalServer(t)
+
+			result := callProposalTool(t, server, tt.tool, tt.arguments)
+
+			requireToolErrorContains(t, result, tt.wantError)
+		})
+	}
+}

--- a/backend/internal/mcp/types_proposal.go
+++ b/backend/internal/mcp/types_proposal.go
@@ -1,0 +1,94 @@
+package mcp
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	dbmodels "github.com/ringecosystem/degov-square/database/models"
+)
+
+const (
+	defaultProposalListLimit = 20
+	maxProposalListLimit     = 50
+)
+
+type listProposalsInput struct {
+	DaoCode string `json:"daoCode" jsonschema:"DAO code"`
+	State   string `json:"state,omitempty" jsonschema:"Optional proposal state filter"`
+	Limit   int    `json:"limit,omitempty" jsonschema:"Maximum rows to return"`
+	Offset  int    `json:"offset,omitempty" jsonschema:"Rows to skip"`
+}
+
+type getProposalInput struct {
+	DaoCode    string `json:"daoCode" jsonschema:"DAO code"`
+	ProposalID string `json:"proposalId" jsonschema:"Proposal id"`
+}
+
+type listProposalsOutput struct {
+	DaoCode   string               `json:"daoCode"`
+	State     string               `json:"state,omitempty"`
+	Limit     int                  `json:"limit"`
+	Offset    int                  `json:"offset"`
+	Proposals []proposalToolOutput `json:"proposals"`
+}
+
+type getProposalOutput struct {
+	Proposal proposalToolOutput `json:"proposal"`
+}
+
+type proposalToolOutput struct {
+	ID                 string     `json:"id"`
+	DaoCode            string     `json:"daoCode"`
+	ChainID            int        `json:"chainId"`
+	Title              string     `json:"title"`
+	ProposalLink       string     `json:"proposalLink"`
+	ProposalID         string     `json:"proposalId"`
+	State              string     `json:"state"`
+	ProposalCreatedAt  *time.Time `json:"proposalCreatedAt,omitempty"`
+	ProposalAtBlock    int        `json:"proposalAtBlock"`
+	OffsetTrackingVote int        `json:"offsetTrackingVote"`
+	Fulfilled          int        `json:"fulfilled"`
+	FulfilledExplain   *string    `json:"fulfilledExplain,omitempty"`
+	FulfilledAt        *time.Time `json:"fulfilledAt,omitempty"`
+	CTime              time.Time  `json:"ctime"`
+	UTime              *time.Time `json:"utime,omitempty"`
+}
+
+func normalizeProposalState(raw string) (dbmodels.ProposalState, error) {
+	state := dbmodels.ProposalState(strings.ToUpper(strings.TrimSpace(raw)))
+	switch state {
+	case dbmodels.ProposalStateUnknown,
+		dbmodels.ProposalStatePending,
+		dbmodels.ProposalStateActive,
+		dbmodels.ProposalStateCanceled,
+		dbmodels.ProposalStateDefeated,
+		dbmodels.ProposalStateSucceeded,
+		dbmodels.ProposalStateQueued,
+		dbmodels.ProposalStateExecuted,
+		dbmodels.ProposalStateExpired:
+		return state, nil
+	default:
+		return "", fmt.Errorf("invalid_state: %q is not a valid proposal state", raw)
+	}
+}
+
+func proposalToolDTO(proposal *dbmodels.ProposalTracking) proposalToolOutput {
+	return proposalToolOutput{
+		ID:                 proposal.ID,
+		DaoCode:            proposal.DaoCode,
+		ChainID:            proposal.ChainId,
+		Title:              proposal.Title,
+		ProposalLink:       proposal.ProposalLink,
+		ProposalID:         proposal.ProposalID,
+		State:              string(proposal.State),
+		ProposalCreatedAt:  proposal.ProposalCreatedAt,
+		ProposalAtBlock:    proposal.ProposalAtBlock,
+		OffsetTrackingVote: proposal.OffsetTrackingVote,
+		Fulfilled:          proposal.Fulfilled,
+		FulfilledExplain:   proposal.FulfilledExplain,
+		FulfilledAt:        proposal.FulfilledAt,
+		CTime:              proposal.CTime,
+		UTime:              proposal.UTime,
+	}
+}

--- a/backend/services/proposal.go
+++ b/backend/services/proposal.go
@@ -103,6 +103,31 @@ func (s *ProposalService) TrackingStateProposals(input types.TrackingStatePropos
 	return proposals, nil
 }
 
+func (s *ProposalService) ListProposals(input types.ListProposalsInput) ([]*dbmodels.ProposalTracking, error) {
+	var proposals []*dbmodels.ProposalTracking
+
+	query := s.db.
+		Where("dao_code = ?", input.DaoCode).
+		Order("proposal_created_at IS NULL ASC").
+		Order("proposal_created_at DESC").
+		Order("ctime DESC")
+
+	if input.State != "" {
+		query = query.Where("state = ?", input.State)
+	}
+	if input.Offset > 0 {
+		query = query.Offset(input.Offset)
+	}
+	if input.Limit > 0 {
+		query = query.Limit(input.Limit)
+	}
+
+	if err := query.Find(&proposals).Error; err != nil {
+		return nil, err
+	}
+	return proposals, nil
+}
+
 // UpdateProposalState updates the state of a proposal
 func (s *ProposalService) UpdateProposalState(proposalID, daoCode string, newState dbmodels.ProposalState) error {
 	return s.db.Model(&dbmodels.ProposalTracking{}).

--- a/backend/services/proposal_test.go
+++ b/backend/services/proposal_test.go
@@ -86,6 +86,102 @@ func TestTrackingStateProposalsWithoutTimesTrackLimitReturnsStalledRows(t *testi
 	}
 }
 
+func TestListProposalsReturnsBoundedRows(t *testing.T) {
+	service := newTestProposalService(t)
+	older := time.Now().Add(-2 * time.Hour)
+	newer := time.Now().Add(-time.Hour)
+
+	seedProposalTracking(t, service, dbmodels.ProposalTracking{
+		ID:                "proposal-4",
+		DaoCode:           "ring-dao",
+		ChainId:           46,
+		Title:             "Older proposal",
+		ProposalLink:      "https://gov.ringdao.com/proposal/4",
+		ProposalID:        "0x4",
+		State:             dbmodels.ProposalStateActive,
+		ProposalCreatedAt: &older,
+		CTime:             time.Now(),
+	})
+	seedProposalTracking(t, service, dbmodels.ProposalTracking{
+		ID:                "proposal-5",
+		DaoCode:           "ring-dao",
+		ChainId:           46,
+		Title:             "Newer proposal",
+		ProposalLink:      "https://gov.ringdao.com/proposal/5",
+		ProposalID:        "0x5",
+		State:             dbmodels.ProposalStateExecuted,
+		ProposalCreatedAt: &newer,
+		CTime:             time.Now(),
+	})
+	seedProposalTracking(t, service, dbmodels.ProposalTracking{
+		ID:                "proposal-6",
+		DaoCode:           "other-dao",
+		ChainId:           46,
+		Title:             "Other DAO proposal",
+		ProposalLink:      "https://gov.ringdao.com/proposal/6",
+		ProposalID:        "0x6",
+		State:             dbmodels.ProposalStateActive,
+		ProposalCreatedAt: &newer,
+		CTime:             time.Now(),
+	})
+
+	proposals, err := service.ListProposals(types.ListProposalsInput{
+		DaoCode: "ring-dao",
+		Limit:   1,
+	})
+	if err != nil {
+		t.Fatalf("ListProposals returned error: %v", err)
+	}
+
+	if len(proposals) != 1 {
+		t.Fatalf("len(proposals) = %d, want 1", len(proposals))
+	}
+	if got, want := proposals[0].ProposalID, "0x5"; got != want {
+		t.Fatalf("proposal id = %q, want %q", got, want)
+	}
+}
+
+func TestListProposalsFiltersByState(t *testing.T) {
+	service := newTestProposalService(t)
+
+	seedProposalTracking(t, service, dbmodels.ProposalTracking{
+		ID:           "proposal-7",
+		DaoCode:      "ring-dao",
+		ChainId:      46,
+		Title:        "Active proposal",
+		ProposalLink: "https://gov.ringdao.com/proposal/7",
+		ProposalID:   "0x7",
+		State:        dbmodels.ProposalStateActive,
+		CTime:        time.Now(),
+	})
+	seedProposalTracking(t, service, dbmodels.ProposalTracking{
+		ID:           "proposal-8",
+		DaoCode:      "ring-dao",
+		ChainId:      46,
+		Title:        "Executed proposal",
+		ProposalLink: "https://gov.ringdao.com/proposal/8",
+		ProposalID:   "0x8",
+		State:        dbmodels.ProposalStateExecuted,
+		CTime:        time.Now(),
+	})
+
+	proposals, err := service.ListProposals(types.ListProposalsInput{
+		DaoCode: "ring-dao",
+		State:   dbmodels.ProposalStateExecuted,
+		Limit:   10,
+	})
+	if err != nil {
+		t.Fatalf("ListProposals returned error: %v", err)
+	}
+
+	if len(proposals) != 1 {
+		t.Fatalf("len(proposals) = %d, want 1", len(proposals))
+	}
+	if got, want := proposals[0].ProposalID, "0x8"; got != want {
+		t.Fatalf("proposal id = %q, want %q", got, want)
+	}
+}
+
 func TestResetProposalTrackingStatusClearsRetryMetadata(t *testing.T) {
 	service := newTestProposalService(t)
 	nextTrackAt := time.Now().Add(2 * time.Hour)

--- a/backend/types/proposal.go
+++ b/backend/types/proposal.go
@@ -22,6 +22,13 @@ type TrackingStateProposalsInput struct {
 	States     []dbmodels.ProposalState
 }
 
+type ListProposalsInput struct {
+	DaoCode string
+	State   dbmodels.ProposalState
+	Limit   int
+	Offset  int
+}
+
 // ProposalStateCountResult represents the result of proposal state count query
 type ProposalStateCountResult struct {
 	DaoCode string                 `json:"dao_code"`


### PR DESCRIPTION
## Summary
feat(mcp): add proposal read tools

## Why
- Issue: [HBX-65](https://plane.kahub.in/endless/browse/HBX-65/)

## Changes
- Register list_proposals and get_proposal MCP tools with read-only annotations.
- Add ProposalService.ListProposals with DAO, state, limit, and offset inputs.
- Return stable JSON-friendly proposal payloads and mapped MCP tool errors.

## Impact
- backend/internal/mcp/server.go
- backend/internal/mcp/tools_proposal.go
- backend/internal/mcp/types_proposal.go
- backend/internal/mcp/tools_proposal_test.go
- backend/services/proposal.go
- backend/services/proposal_test.go
- backend/types/proposal.go

## Verification
- cd backend && go test ./services -run TestListProposals
- cd backend && go test ./internal/mcp -run TestProposalTools
- cd backend && just test
- cd backend && just build
- cd web && pnpm install --frozen-lockfile
- cd web && pnpm build

## Links
- Issue: [HBX-65](https://plane.kahub.in/endless/browse/HBX-65/)
- Related PR: https://github.com/ringecosystem/degov-square/pull/253
- metadata
  ```yaml
  schema: conductor/pr-body/1
  repository: degov-square
  issue: HBX-65
  issue_url: "https://plane.kahub.in/endless/browse/HBX-65/"
  run_id: run-hbx-65-1779934623729690251
  attempt_id: run-hbx-65-1779934623729690251-attempt-1
  head_branch: fewensa/test/hbx-65/feat-mcp-add-proposal-read
  base_branch: main
  commit_id: 3e3bac5a2c6d82d345b7da09b42893fd6a08d277
  metadata_attempt_id: run-hbx-65-1779934623729690251-attempt-1
  attempt_result_recorded: true
  related_prs:
    - "https://github.com/ringecosystem/degov-square/pull/253"
  ```