### PR TITLE
feat(mcp): add read-only DAO tools

### DIFF
--- a/backend/internal/mcp/server.go
+++ b/backend/internal/mcp/server.go
@@ -4,13 +4,16 @@ import (
 	"net/http"
 
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/ringecosystem/degov-square/services"
 )
 
 type Config struct {
-	Name        string
-	Version     string
-	AuthMode    string
-	BearerToken string
+	Name             string
+	Version          string
+	AuthMode         string
+	BearerToken      string
+	DaoService       daoService
+	DaoConfigService daoConfigService
 }
 
 func NewServer(cfg Config) *sdkmcp.Server {
@@ -20,8 +23,19 @@ func NewServer(cfg Config) *sdkmcp.Server {
 	}, nil)
 
 	addPingTool(server, cfg)
+	addDaoTools(server, withDefaultDaoServices(cfg))
 
 	return server
+}
+
+func withDefaultDaoServices(cfg Config) Config {
+	if cfg.DaoService == nil {
+		cfg.DaoService = services.NewDaoService()
+	}
+	if cfg.DaoConfigService == nil {
+		cfg.DaoConfigService = services.NewDaoConfigService()
+	}
+	return cfg
 }
 
 func NewHTTPHandler(cfg Config) http.Handler {

--- a/backend/internal/mcp/tools_dao.go
+++ b/backend/internal/mcp/tools_dao.go
@@ -1,0 +1,256 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	dbmodels "github.com/ringecosystem/degov-square/database/models"
+	gqlmodels "github.com/ringecosystem/degov-square/graph/models"
+	"github.com/ringecosystem/degov-square/types"
+)
+
+var daoCodePattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$`)
+
+func addDaoTools(server *sdkmcp.Server, cfg Config) {
+	sdkmcp.AddTool(server, &sdkmcp.Tool{
+		Name:        "list_daos",
+		Title:       "List DAOs",
+		Description: "Return a bounded list of public DAO summaries.",
+		Annotations: &sdkmcp.ToolAnnotations{
+			ReadOnlyHint: true,
+		},
+	}, func(ctx context.Context, req *sdkmcp.CallToolRequest, input listDaosInput) (*sdkmcp.CallToolResult, listDaosOutput, error) {
+		serviceInput, err := toListDaosServiceInput(input)
+		if err != nil {
+			return nil, listDaosOutput{}, err
+		}
+		daos, err := cfg.DaoService.ListDaos(types.BasicInput[*types.ListDaosInput]{
+			Input: serviceInput,
+		})
+		if err != nil {
+			return nil, listDaosOutput{}, err
+		}
+
+		limit := normalizeListDaosLimit(input.Limit)
+		if len(daos) > limit {
+			daos = daos[:limit]
+		}
+
+		output := listDaosOutput{
+			Daos:  make([]daoSummaryOutput, 0, len(daos)),
+			Count: len(daos),
+			Limit: limit,
+		}
+		for _, dao := range daos {
+			if dao == nil {
+				continue
+			}
+			output.Daos = append(output.Daos, daoSummaryFromGQL(dao))
+		}
+		output.Count = len(output.Daos)
+
+		return nil, output, nil
+	})
+
+	sdkmcp.AddTool(server, &sdkmcp.Tool{
+		Name:        "get_dao",
+		Title:       "Get DAO",
+		Description: "Return public DAO metadata for one DAO code.",
+		Annotations: &sdkmcp.ToolAnnotations{
+			ReadOnlyHint: true,
+		},
+	}, func(ctx context.Context, req *sdkmcp.CallToolRequest, input getDaoInput) (*sdkmcp.CallToolResult, daoDetailOutput, error) {
+		daoCode, err := normalizeDaoCode(input.DaoCode)
+		if err != nil {
+			return nil, daoDetailOutput{}, err
+		}
+
+		dao, err := cfg.DaoService.Inspect(types.BasicInput[string]{Input: daoCode})
+		if err != nil {
+			return nil, daoDetailOutput{}, daoToolError("DAO", daoCode, err)
+		}
+		if dao == nil {
+			return nil, daoDetailOutput{}, notFoundError("DAO", daoCode)
+		}
+
+		return nil, daoDetailFromGQL(dao), nil
+	})
+
+	sdkmcp.AddTool(server, &sdkmcp.Tool{
+		Name:        "get_dao_config",
+		Title:       "Get DAO Config",
+		Description: "Return the public DAO registry config for one DAO code.",
+		Annotations: &sdkmcp.ToolAnnotations{
+			ReadOnlyHint: true,
+		},
+	}, func(ctx context.Context, req *sdkmcp.CallToolRequest, input getDaoConfigInput) (*sdkmcp.CallToolResult, daoConfigOutput, error) {
+		daoCode, err := normalizeDaoCode(input.DaoCode)
+		if err != nil {
+			return nil, daoConfigOutput{}, err
+		}
+
+		format, formatName, err := normalizeConfigFormat(input.Format)
+		if err != nil {
+			return nil, daoConfigOutput{}, err
+		}
+
+		content, err := cfg.DaoConfigService.RawConfig(gqlmodels.GetDaoConfigInput{
+			DaoCode: daoCode,
+			Format:  &format,
+		})
+		if err != nil {
+			return nil, daoConfigOutput{}, daoToolError("DAO config", daoCode, err)
+		}
+
+		return nil, daoConfigOutput{
+			DaoCode: daoCode,
+			Format:  formatName,
+			Content: content,
+		}, nil
+	})
+}
+
+func normalizeListDaosLimit(limit int) int {
+	if limit <= 0 {
+		return defaultListDaosLimit
+	}
+	if limit > maxListDaosLimit {
+		return maxListDaosLimit
+	}
+	return limit
+}
+
+func toListDaosServiceInput(input listDaosInput) (*types.ListDaosInput, error) {
+	serviceInput := &types.ListDaosInput{}
+	if len(input.Codes) > 0 {
+		codes := make([]string, 0, len(input.Codes))
+		for _, code := range input.Codes {
+			normalized, err := normalizeDaoCode(code)
+			if err != nil {
+				return nil, err
+			}
+			codes = append(codes, normalized)
+		}
+		serviceInput.Codes = &codes
+	}
+	if len(input.State) > 0 {
+		states := make([]dbmodels.DaoState, 0, len(input.State))
+		for _, state := range input.State {
+			normalized := dbmodels.DaoState(strings.ToUpper(strings.TrimSpace(state)))
+			switch normalized {
+			case dbmodels.DaoStateActive, dbmodels.DaoStateDraft, dbmodels.DaoStateInactive:
+				states = append(states, normalized)
+			default:
+				return nil, invalidParamsError("state must be ACTIVE, DRAFT, or INACTIVE")
+			}
+		}
+		serviceInput.State = &states
+	}
+	return serviceInput, nil
+}
+
+func normalizeDaoCode(daoCode string) (string, error) {
+	normalized := strings.TrimSpace(daoCode)
+	if normalized == "" {
+		return "", invalidParamsError("daoCode is required")
+	}
+	if !daoCodePattern.MatchString(normalized) {
+		return "", invalidParamsError("daoCode contains invalid characters")
+	}
+	return normalized, nil
+}
+
+func normalizeConfigFormat(format string) (gqlmodels.ConfigFormat, string, error) {
+	switch strings.ToLower(strings.TrimSpace(format)) {
+	case "", "json":
+		return gqlmodels.ConfigFormatJSON, "json", nil
+	case "yaml", "yml":
+		return gqlmodels.ConfigFormatYaml, "yaml", nil
+	default:
+		return "", "", invalidParamsError("format must be json or yaml")
+	}
+}
+
+func daoSummaryFromGQL(dao *gqlmodels.Dao) daoSummaryOutput {
+	return daoSummaryOutput{
+		DaoCode:               dao.Code,
+		Name:                  dao.Name,
+		Logo:                  dao.Logo,
+		Endpoint:              dao.Endpoint,
+		ChainID:               dao.ChainID,
+		ChainName:             dao.ChainName,
+		ChainLogo:             dao.ChainLogo,
+		State:                 dao.State,
+		Domains:               dao.Domains,
+		Tags:                  dao.Tags,
+		MetricsCountProposals: dao.MetricsCountProposals,
+		MetricsCountMembers:   dao.MetricsCountMembers,
+		MetricsSumPower:       dao.MetricsSumPower,
+		MetricsCountVote:      dao.MetricsCountVote,
+	}
+}
+
+func daoDetailFromGQL(dao *gqlmodels.Dao) daoDetailOutput {
+	chips := make([]daoChipOutput, 0, len(dao.Chips))
+	for _, chip := range dao.Chips {
+		if chip == nil {
+			continue
+		}
+		chips = append(chips, daoChipOutput{
+			ChipCode: chip.ChipCode,
+			Flag:     chip.Flag,
+		})
+	}
+
+	summary := daoSummaryFromGQL(dao)
+	return daoDetailOutput{
+		DaoCode:               summary.DaoCode,
+		Name:                  summary.Name,
+		Logo:                  summary.Logo,
+		Endpoint:              summary.Endpoint,
+		ChainID:               summary.ChainID,
+		ChainName:             summary.ChainName,
+		ChainLogo:             summary.ChainLogo,
+		State:                 summary.State,
+		Domains:               summary.Domains,
+		Tags:                  summary.Tags,
+		MetricsCountProposals: summary.MetricsCountProposals,
+		MetricsCountMembers:   summary.MetricsCountMembers,
+		MetricsSumPower:       summary.MetricsSumPower,
+		MetricsCountVote:      summary.MetricsCountVote,
+		Chips:                 chips,
+	}
+}
+
+func daoToolError(resource, daoCode string, err error) error {
+	if isNotFoundError(err) {
+		return notFoundError(resource, daoCode)
+	}
+	return err
+}
+
+func isNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "not found") || strings.Contains(message, "record not found")
+}
+
+func invalidParamsError(message string) error {
+	return &jsonrpc.Error{
+		Code:    jsonrpc.CodeInvalidParams,
+		Message: message,
+	}
+}
+
+func notFoundError(resource, daoCode string) error {
+	return &jsonrpc.Error{
+		Code:    jsonrpc.CodeInvalidParams,
+		Message: fmt.Sprintf("%s %q not found", resource, daoCode),
+	}
+}

--- a/backend/internal/mcp/tools_dao_test.go
+++ b/backend/internal/mcp/tools_dao_test.go
@@ -1,0 +1,281 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	dbmodels "github.com/ringecosystem/degov-square/database/models"
+	gqlmodels "github.com/ringecosystem/degov-square/graph/models"
+	"github.com/ringecosystem/degov-square/types"
+)
+
+type fakeDaoService struct {
+	listInput   types.BasicInput[*types.ListDaosInput]
+	listDaos    []*gqlmodels.Dao
+	listErr     error
+	inspectCode string
+	inspectDao  *gqlmodels.Dao
+	inspectErr  error
+}
+
+func (s *fakeDaoService) ListDaos(input types.BasicInput[*types.ListDaosInput]) ([]*gqlmodels.Dao, error) {
+	s.listInput = input
+	return s.listDaos, s.listErr
+}
+
+func (s *fakeDaoService) Inspect(input types.BasicInput[string]) (*gqlmodels.Dao, error) {
+	s.inspectCode = input.Input
+	return s.inspectDao, s.inspectErr
+}
+
+type fakeDaoConfigService struct {
+	input   gqlmodels.GetDaoConfigInput
+	content string
+	err     error
+}
+
+func (s *fakeDaoConfigService) RawConfig(input gqlmodels.GetDaoConfigInput) (string, error) {
+	s.input = input
+	return s.content, s.err
+}
+
+func TestListDaosToolReturnsBoundedSummaries(t *testing.T) {
+	t.Parallel()
+
+	daoService := &fakeDaoService{
+		listDaos: []*gqlmodels.Dao{
+			testDao("alpha-dao", "Alpha DAO"),
+			testDao("beta-dao", "Beta DAO"),
+			testDao("gamma-dao", "Gamma DAO"),
+		},
+	}
+	session, closeSession := newTestMCPSession(t, Config{
+		Name:             "degov-square",
+		Version:          "test-version",
+		DaoService:       daoService,
+		DaoConfigService: &fakeDaoConfigService{},
+	})
+	defer closeSession()
+
+	result, err := session.CallTool(context.Background(), &sdkmcp.CallToolParams{
+		Name: "list_daos",
+		Arguments: map[string]any{
+			"limit": 2,
+			"codes": []string{"alpha-dao", "beta-dao"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool(list_daos) error = %v", err)
+	}
+
+	content := structuredContent(t, result)
+	if got, want := int(content["count"].(float64)), 2; got != want {
+		t.Fatalf("count = %d, want %d", got, want)
+	}
+	if got, want := int(content["limit"].(float64)), 2; got != want {
+		t.Fatalf("limit = %d, want %d", got, want)
+	}
+	daos := content["daos"].([]any)
+	if got, want := len(daos), 2; got != want {
+		t.Fatalf("len(daos) = %d, want %d", got, want)
+	}
+	first := daos[0].(map[string]any)
+	if got, want := first["daoCode"], "alpha-dao"; got != want {
+		t.Fatalf("daoCode = %v, want %v", got, want)
+	}
+	if _, ok := first["lastProposal"]; ok {
+		t.Fatal("summary exposed lastProposal")
+	}
+	if daoService.listInput.Input == nil || daoService.listInput.Input.Codes == nil {
+		t.Fatal("ListDaos input did not include codes filter")
+	}
+}
+
+func TestGetDaoToolReturnsDetailWithoutProposalData(t *testing.T) {
+	t.Parallel()
+
+	daoService := &fakeDaoService{inspectDao: testDao("alpha-dao", "Alpha DAO")}
+	session, closeSession := newTestMCPSession(t, Config{
+		Name:             "degov-square",
+		Version:          "test-version",
+		DaoService:       daoService,
+		DaoConfigService: &fakeDaoConfigService{},
+	})
+	defer closeSession()
+
+	result, err := session.CallTool(context.Background(), &sdkmcp.CallToolParams{
+		Name:      "get_dao",
+		Arguments: map[string]any{"daoCode": "alpha-dao"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool(get_dao) error = %v", err)
+	}
+
+	content := structuredContent(t, result)
+	if got, want := content["daoCode"], "alpha-dao"; got != want {
+		t.Fatalf("daoCode = %v, want %v", got, want)
+	}
+	if got, want := content["metricsCountMembers"], float64(42); got != want {
+		t.Fatalf("metricsCountMembers = %v, want %v", got, want)
+	}
+	if _, ok := content["lastProposal"]; ok {
+		t.Fatal("detail exposed lastProposal")
+	}
+	if got, want := daoService.inspectCode, "alpha-dao"; got != want {
+		t.Fatalf("Inspect code = %q, want %q", got, want)
+	}
+}
+
+func TestGetDaoConfigToolDefaultsToJSON(t *testing.T) {
+	t.Parallel()
+
+	configService := &fakeDaoConfigService{content: `{"code":"alpha-dao"}`}
+	session, closeSession := newTestMCPSession(t, Config{
+		Name:             "degov-square",
+		Version:          "test-version",
+		DaoService:       &fakeDaoService{},
+		DaoConfigService: configService,
+	})
+	defer closeSession()
+
+	result, err := session.CallTool(context.Background(), &sdkmcp.CallToolParams{
+		Name:      "get_dao_config",
+		Arguments: map[string]any{"daoCode": "alpha-dao"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool(get_dao_config) error = %v", err)
+	}
+
+	content := structuredContent(t, result)
+	if got, want := content["daoCode"], "alpha-dao"; got != want {
+		t.Fatalf("daoCode = %v, want %v", got, want)
+	}
+	if got, want := content["format"], "json"; got != want {
+		t.Fatalf("format = %v, want %v", got, want)
+	}
+	if got, want := content["content"], `{"code":"alpha-dao"}`; got != want {
+		t.Fatalf("content = %v, want %v", got, want)
+	}
+	if configService.input.Format == nil || *configService.input.Format != gqlmodels.ConfigFormatJSON {
+		t.Fatalf("RawConfig format = %v, want JSON", configService.input.Format)
+	}
+}
+
+func TestDaoToolsRejectInvalidDaoCode(t *testing.T) {
+	t.Parallel()
+
+	session, closeSession := newTestMCPSession(t, Config{
+		Name:             "degov-square",
+		Version:          "test-version",
+		DaoService:       &fakeDaoService{},
+		DaoConfigService: &fakeDaoConfigService{},
+	})
+	defer closeSession()
+
+	_, err := session.CallTool(context.Background(), &sdkmcp.CallToolParams{
+		Name:      "get_dao",
+		Arguments: map[string]any{"daoCode": "../secret"},
+	})
+	if err == nil {
+		t.Fatal("CallTool(get_dao) error = nil, want validation error")
+	}
+	var rpcErr *jsonrpc.Error
+	if !errors.As(err, &rpcErr) {
+		t.Fatalf("error type = %T, want jsonrpc.Error", err)
+	}
+	if got, want := rpcErr.Code, int64(jsonrpc.CodeInvalidParams); got != want {
+		t.Fatalf("error code = %d, want %d", got, want)
+	}
+	if !strings.Contains(rpcErr.Message, "daoCode") {
+		t.Fatalf("error message %q does not mention daoCode", rpcErr.Message)
+	}
+}
+
+func TestDaoToolsReturnStructuredNotFoundError(t *testing.T) {
+	t.Parallel()
+
+	session, closeSession := newTestMCPSession(t, Config{
+		Name:             "degov-square",
+		Version:          "test-version",
+		DaoService:       &fakeDaoService{inspectErr: errors.New("dao not found")},
+		DaoConfigService: &fakeDaoConfigService{},
+	})
+	defer closeSession()
+
+	_, err := session.CallTool(context.Background(), &sdkmcp.CallToolParams{
+		Name:      "get_dao",
+		Arguments: map[string]any{"daoCode": "missing-dao"},
+	})
+	if err == nil {
+		t.Fatal("CallTool(get_dao) error = nil, want not-found error")
+	}
+	var rpcErr *jsonrpc.Error
+	if !errors.As(err, &rpcErr) {
+		t.Fatalf("error type = %T, want jsonrpc.Error", err)
+	}
+	if got, want := rpcErr.Code, int64(jsonrpc.CodeInvalidParams); got != want {
+		t.Fatalf("error code = %d, want %d", got, want)
+	}
+	if !strings.Contains(rpcErr.Message, "not found") {
+		t.Fatalf("error message %q does not mention not found", rpcErr.Message)
+	}
+}
+
+func newTestMCPSession(t *testing.T, cfg Config) (*sdkmcp.ClientSession, func()) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	clientTransport, serverTransport := sdkmcp.NewInMemoryTransports()
+	server := NewServer(cfg)
+	go func() {
+		_ = server.Run(ctx, serverTransport)
+	}()
+
+	client := sdkmcp.NewClient(&sdkmcp.Implementation{Name: "test-client"}, nil)
+	session, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		cancel()
+		t.Fatalf("Connect() error = %v", err)
+	}
+
+	return session, func() {
+		session.Close()
+		cancel()
+	}
+}
+
+func structuredContent(t *testing.T, result *sdkmcp.CallToolResult) map[string]any {
+	t.Helper()
+
+	content, ok := result.StructuredContent.(map[string]any)
+	if !ok {
+		t.Fatalf("StructuredContent type = %T, want map[string]any", result.StructuredContent)
+	}
+	return content
+}
+
+func testDao(code, name string) *gqlmodels.Dao {
+	now := time.Date(2026, 5, 28, 0, 0, 0, 0, time.UTC)
+	return &gqlmodels.Dao{
+		ID:                    "internal-id-" + code,
+		ChainID:               1,
+		ChainName:             "Ethereum",
+		Name:                  name,
+		Code:                  code,
+		Endpoint:              "https://" + code + ".example",
+		State:                 string(dbmodels.DaoStateActive),
+		Domains:               []string{code + ".example"},
+		Tags:                  []string{"governance"},
+		MetricsCountProposals: 7,
+		MetricsCountMembers:   42,
+		MetricsSumPower:       "1000",
+		MetricsCountVote:      21,
+		Ctime:                 now,
+		LastProposal:          &gqlmodels.Proposal{ID: "proposal-id"},
+	}
+}

--- a/backend/internal/mcp/types_dao.go
+++ b/backend/internal/mcp/types_dao.go
@@ -1,0 +1,87 @@
+package mcp
+
+import (
+	gqlmodels "github.com/ringecosystem/degov-square/graph/models"
+	"github.com/ringecosystem/degov-square/types"
+)
+
+const (
+	defaultListDaosLimit = 50
+	maxListDaosLimit     = 100
+)
+
+type daoService interface {
+	ListDaos(types.BasicInput[*types.ListDaosInput]) ([]*gqlmodels.Dao, error)
+	Inspect(types.BasicInput[string]) (*gqlmodels.Dao, error)
+}
+
+type daoConfigService interface {
+	RawConfig(gqlmodels.GetDaoConfigInput) (string, error)
+}
+
+type listDaosInput struct {
+	Codes []string `json:"codes,omitempty" jsonschema:"DAO codes to filter by."`
+	State []string `json:"state,omitempty" jsonschema:"DAO states to filter by."`
+	Limit int      `json:"limit,omitempty" jsonschema:"Maximum number of DAOs to return. Values above 100 are capped."`
+}
+
+type getDaoInput struct {
+	DaoCode string `json:"daoCode" jsonschema:"DAO code."`
+}
+
+type getDaoConfigInput struct {
+	DaoCode string `json:"daoCode" jsonschema:"DAO code."`
+	Format  string `json:"format,omitempty" jsonschema:"Config format: json or yaml. Defaults to json."`
+}
+
+type listDaosOutput struct {
+	Daos  []daoSummaryOutput `json:"daos"`
+	Count int                `json:"count"`
+	Limit int                `json:"limit"`
+}
+
+type daoSummaryOutput struct {
+	DaoCode               string   `json:"daoCode"`
+	Name                  string   `json:"name"`
+	Logo                  *string  `json:"logo,omitempty"`
+	Endpoint              string   `json:"endpoint"`
+	ChainID               int32    `json:"chainId"`
+	ChainName             string   `json:"chainName"`
+	ChainLogo             *string  `json:"chainLogo,omitempty"`
+	State                 string   `json:"state"`
+	Domains               []string `json:"domains,omitempty"`
+	Tags                  []string `json:"tags,omitempty"`
+	MetricsCountProposals int32    `json:"metricsCountProposals"`
+	MetricsCountMembers   int32    `json:"metricsCountMembers"`
+	MetricsSumPower       string   `json:"metricsSumPower"`
+	MetricsCountVote      int32    `json:"metricsCountVote"`
+}
+
+type daoDetailOutput struct {
+	DaoCode               string          `json:"daoCode"`
+	Name                  string          `json:"name"`
+	Logo                  *string         `json:"logo,omitempty"`
+	Endpoint              string          `json:"endpoint"`
+	ChainID               int32           `json:"chainId"`
+	ChainName             string          `json:"chainName"`
+	ChainLogo             *string         `json:"chainLogo,omitempty"`
+	State                 string          `json:"state"`
+	Domains               []string        `json:"domains,omitempty"`
+	Tags                  []string        `json:"tags,omitempty"`
+	MetricsCountProposals int32           `json:"metricsCountProposals"`
+	MetricsCountMembers   int32           `json:"metricsCountMembers"`
+	MetricsSumPower       string          `json:"metricsSumPower"`
+	MetricsCountVote      int32           `json:"metricsCountVote"`
+	Chips                 []daoChipOutput `json:"chips,omitempty"`
+}
+
+type daoChipOutput struct {
+	ChipCode string `json:"chipCode"`
+	Flag     string `json:"flag,omitempty"`
+}
+
+type daoConfigOutput struct {
+	DaoCode string `json:"daoCode"`
+	Format  string `json:"format"`
+	Content string `json:"content"`
+}


### PR DESCRIPTION
## Summary
feat(mcp): add read-only DAO tools

## Why
- Issue: [HBX-64](https://plane.kahub.in/endless/browse/HBX-64/)

## Changes
- Register list_daos, get_dao, and get_dao_config on the MCP server.
- Add stable MCP DTOs for public DAO metadata and config output instead of exposing raw GraphQL structs.
- Validate daoCode and config format input, returning structured JSON-RPC errors for invalid input and not-found cases.
- Reuse DaoService and DaoConfigService behind narrow interfaces for production wiring and unit tests.

## Impact
- backend/internal/mcp/server.go
- backend/internal/mcp/tools_dao.go
- backend/internal/mcp/types_dao.go
- backend/internal/mcp/tools_dao_test.go

## Verification
- cd backend && go test ./internal/mcp
- cd backend && just test
- cd backend && just build
- cd web && pnpm install --frozen-lockfile
- cd web && pnpm build

## Additional commits
- chore(mcp): sync DAO tools branch with main

## Links
- Issue: [HBX-64](https://plane.kahub.in/endless/browse/HBX-64/)
- Related PR: https://github.com/ringecosystem/degov-square/pull/254
- metadata
  ```yaml
  schema: conductor/pr-body/1
  repository: degov-square
  issue: HBX-64
  issue_url: "https://plane.kahub.in/endless/browse/HBX-64/"
  run_id: run-hbx-64-review-repair-1779935712560015431
  attempt_id: run-hbx-64-review-repair-1779935712560015431-attempt-1
  head_branch: fewensa/test/hbx-64-attempt-2/dao-read-only-tools
  base_branch: main
  commit_id: f83724f7087e4ab79bb8f1d4e1138dd748137bff
  metadata_attempt_id: run-hbx-64-review-repair-1779935712560015431-attempt-1
  primary_commit_id: ec8632246a446c72d40661dc94f70f157ca6330e
  primary_metadata_attempt_id: run-hbx-64-1779935225551682981-attempt-2
  attempt_result_recorded: true
  additional_commits:
    - commit_id: f83724f7087e4ab79bb8f1d4e1138dd748137bff
      attempt_id: run-hbx-64-review-repair-1779935712560015431-attempt-1
      summary: "chore(mcp): sync DAO tools branch with main"
  related_prs:
    - "https://github.com/ringecosystem/degov-square/pull/254"
  ```