### PR TITLE
feat(mcp): add protected proposal summary tool

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -34,6 +34,9 @@ JWT_SECRET=your_jwt_secret
 # MCP_AUTH_MODE=bearer
 # Required when MCP_AUTH_MODE=bearer.
 # MCP_BEARER_TOKEN=
+# Proposal summary MCP reads cached summaries by default. Set true to allow new external summary generation.
+# MCP_PROPOSAL_SUMMARY_GENERATE_ENABLED=false
+# MCP_PROPOSAL_SUMMARY_TIMEOUT=30s
 
 # # Background Task Configuration
 # # DAO Sync Task

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -160,10 +160,12 @@ func startServer() {
 
 	if cfg.GetMCPEnabled() {
 		mux.Handle(cfg.GetMCPPath(), mcpserver.NewHTTPHandler(mcpserver.Config{
-			Name:        "degov-square",
-			Version:     getMCPVersion(),
-			AuthMode:    cfg.GetMCPAuthMode(),
-			BearerToken: cfg.GetMCPBearerToken(),
+			Name:                             "degov-square",
+			Version:                          getMCPVersion(),
+			AuthMode:                         cfg.GetMCPAuthMode(),
+			BearerToken:                      cfg.GetMCPBearerToken(),
+			ProposalSummaryGenerateEnabled:   cfg.GetMCPProposalSummaryGenerateEnabled(),
+			ProposalSummaryGenerationTimeout: cfg.GetMCPProposalSummaryTimeout(),
 		}))
 	}
 

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -109,6 +109,8 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("MCP_PATH", "/mcp")
 	v.SetDefault("MCP_AUTH_MODE", "bearer")
 	v.SetDefault("MCP_BEARER_TOKEN", "")
+	v.SetDefault("MCP_PROPOSAL_SUMMARY_GENERATE_ENABLED", false)
+	v.SetDefault("MCP_PROPOSAL_SUMMARY_TIMEOUT", "30s")
 
 	// Task defaults
 	v.SetDefault("TASK_DAO_SYNC_ENABLED", true)
@@ -220,6 +222,14 @@ func (c *Config) GetMCPAuthMode() string {
 
 func (c *Config) GetMCPBearerToken() string {
 	return c.viper.GetString("MCP_BEARER_TOKEN")
+}
+
+func (c *Config) GetMCPProposalSummaryGenerateEnabled() bool {
+	return c.viper.GetBool("MCP_PROPOSAL_SUMMARY_GENERATE_ENABLED")
+}
+
+func (c *Config) GetMCPProposalSummaryTimeout() time.Duration {
+	return c.viper.GetDuration("MCP_PROPOSAL_SUMMARY_TIMEOUT")
 }
 
 // Task configuration methods

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -1,6 +1,9 @@
 package config
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestMCPConfigDefaults(t *testing.T) {
 	globalConfig = nil
@@ -20,6 +23,12 @@ func TestMCPConfigDefaults(t *testing.T) {
 	if got := cfg.GetMCPBearerToken(); got != "" {
 		t.Fatalf("GetMCPBearerToken() = %q, want empty", got)
 	}
+	if cfg.GetMCPProposalSummaryGenerateEnabled() {
+		t.Fatal("GetMCPProposalSummaryGenerateEnabled() = true, want false")
+	}
+	if got, want := cfg.GetMCPProposalSummaryTimeout(), 30*time.Second; got != want {
+		t.Fatalf("GetMCPProposalSummaryTimeout() = %s, want 30s", got)
+	}
 }
 
 func TestMCPConfigReadsEnvironment(t *testing.T) {
@@ -27,6 +36,8 @@ func TestMCPConfigReadsEnvironment(t *testing.T) {
 	t.Setenv("MCP_PATH", "/api/mcp")
 	t.Setenv("MCP_AUTH_MODE", "none")
 	t.Setenv("MCP_BEARER_TOKEN", "test-token")
+	t.Setenv("MCP_PROPOSAL_SUMMARY_GENERATE_ENABLED", "true")
+	t.Setenv("MCP_PROPOSAL_SUMMARY_TIMEOUT", "5s")
 	globalConfig = nil
 	t.Cleanup(func() { globalConfig = nil })
 
@@ -43,5 +54,11 @@ func TestMCPConfigReadsEnvironment(t *testing.T) {
 	}
 	if got, want := cfg.GetMCPBearerToken(), "test-token"; got != want {
 		t.Fatalf("GetMCPBearerToken() = %q, want %q", got, want)
+	}
+	if !cfg.GetMCPProposalSummaryGenerateEnabled() {
+		t.Fatal("GetMCPProposalSummaryGenerateEnabled() = false, want true")
+	}
+	if got, want := cfg.GetMCPProposalSummaryTimeout(), 5*time.Second; got != want {
+		t.Fatalf("GetMCPProposalSummaryTimeout() = %s, want 5s", got)
 	}
 }

--- a/backend/internal/mcp/server.go
+++ b/backend/internal/mcp/server.go
@@ -2,18 +2,28 @@ package mcp
 
 import (
 	"net/http"
+	"time"
 
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	dbmodels "github.com/ringecosystem/degov-square/database/models"
 	"github.com/ringecosystem/degov-square/services"
 )
 
 type Config struct {
-	Name             string
-	Version          string
-	AuthMode         string
-	BearerToken      string
-	DaoService       daoService
-	DaoConfigService daoConfigService
+	Name                             string
+	Version                          string
+	AuthMode                         string
+	BearerToken                      string
+	DaoService                       daoService
+	DaoConfigService                 daoConfigService
+	ProposalSummaryService           proposalSummaryService
+	ProposalSummaryGenerateEnabled   bool
+	ProposalSummaryGenerationTimeout time.Duration
+}
+
+type proposalSummaryService interface {
+	GetCachedSummary(services.ProposalSummaryInput) (*dbmodels.ProposalSummary, error)
+	GetOrGenerateSummary(services.ProposalSummaryInput) (string, error)
 }
 
 func NewServer(cfg Config) *sdkmcp.Server {
@@ -25,6 +35,7 @@ func NewServer(cfg Config) *sdkmcp.Server {
 	addPingTool(server, cfg)
 	addDaoTools(server, withDefaultDaoServices(cfg))
 	addProposalTools(server)
+	addProposalSummaryTool(server, withDefaultProposalSummaryServices(cfg))
 
 	return server
 }
@@ -35,6 +46,16 @@ func withDefaultDaoServices(cfg Config) Config {
 	}
 	if cfg.DaoConfigService == nil {
 		cfg.DaoConfigService = services.NewDaoConfigService()
+	}
+	return cfg
+}
+
+func withDefaultProposalSummaryServices(cfg Config) Config {
+	if cfg.ProposalSummaryService == nil {
+		cfg.ProposalSummaryService = services.NewProposalSummaryService()
+	}
+	if cfg.ProposalSummaryGenerationTimeout <= 0 {
+		cfg.ProposalSummaryGenerationTimeout = 30 * time.Second
 	}
 	return cfg
 }

--- a/backend/internal/mcp/tools_proposal_test.go
+++ b/backend/internal/mcp/tools_proposal_test.go
@@ -81,6 +81,21 @@ func newTestProposalServer(t *testing.T) *sdkmcp.Server {
 	`).Error; err != nil {
 		t.Fatalf("create proposal tracking table: %v", err)
 	}
+	if err := db.Exec(`
+		CREATE TABLE dgv_proposal_summary (
+			id TEXT PRIMARY KEY,
+			dao_code TEXT,
+			chain_id INTEGER NOT NULL,
+			proposal_id TEXT NOT NULL,
+			indexer TEXT,
+			description TEXT NOT NULL,
+			summary TEXT NOT NULL,
+			ctime DATETIME NOT NULL,
+			utime DATETIME
+		)
+	`).Error; err != nil {
+		t.Fatalf("create proposal summary table: %v", err)
+	}
 	database.DB = db
 
 	seedMCPDao(t, db, "ring-dao")

--- a/backend/internal/mcp/tools_summary.go
+++ b/backend/internal/mcp/tools_summary.go
@@ -1,0 +1,165 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/ringecosystem/degov-square/services"
+	"github.com/ringecosystem/degov-square/types"
+	"gorm.io/gorm"
+)
+
+func addProposalSummaryTool(server *sdkmcp.Server, cfg Config) {
+	sdkmcp.AddTool(server, &sdkmcp.Tool{
+		Name:        "summarize_proposal",
+		Title:       "Summarize Proposal",
+		Description: "Return a cached proposal summary, or generate one only when MCP summary generation is enabled.",
+		Annotations: &sdkmcp.ToolAnnotations{
+			ReadOnlyHint: true,
+		},
+	}, func(ctx context.Context, req *sdkmcp.CallToolRequest, input summarizeProposalInput) (*sdkmcp.CallToolResult, summarizeProposalOutput, error) {
+		return summarizeProposalTool(ctx, cfg, input)
+	})
+}
+
+func summarizeProposalTool(ctx context.Context, cfg Config, input summarizeProposalInput) (*sdkmcp.CallToolResult, summarizeProposalOutput, error) {
+	start := time.Now()
+	cacheHit := false
+	failureReason := ""
+	defer func() {
+		attrs := []any{
+			"tool", "summarize_proposal",
+			"duration_ms", time.Since(start).Milliseconds(),
+			"cache_hit", cacheHit,
+		}
+		if failureReason != "" {
+			attrs = append(attrs, "failure_reason", failureReason)
+		}
+		slog.Info("[mcp] tool completed", attrs...)
+	}()
+
+	daoCode, err := normalizeProposalDaoCode(input.DaoCode)
+	if err != nil {
+		failureReason = "invalid_dao_code"
+		return nil, summarizeProposalOutput{}, err
+	}
+	proposalID := strings.TrimSpace(input.ProposalID)
+	if proposalID == "" {
+		failureReason = "invalid_proposal_id"
+		return nil, summarizeProposalOutput{}, errors.New("invalid_proposal_id: proposalId is required")
+	}
+
+	serviceInput := services.ProposalSummaryInput{
+		DaoCode:    daoCode,
+		ProposalID: proposalID,
+	}
+
+	if !input.ForceRefresh {
+		summary, err := cfg.ProposalSummaryService.GetCachedSummary(serviceInput)
+		if err == nil && summary != nil {
+			cacheHit = true
+			generatedAt := summary.CTime
+			if summary.UTime != nil {
+				generatedAt = *summary.UTime
+			}
+			return nil, summarizeProposalOutput{
+				DaoCode:     daoCode,
+				ProposalID:  proposalID,
+				Summary:     summary.Summary,
+				Source:      "cache",
+				CacheHit:    true,
+				GeneratedAt: &generatedAt,
+				Proposal:    lookupProposalMetadata(daoCode, proposalID),
+			}, nil
+		}
+		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) && !isNotFoundError(err) {
+			failureReason = "summary_cache_lookup_failed"
+			return nil, summarizeProposalOutput{}, fmt.Errorf("summary_cache_lookup_failed: %w", err)
+		}
+	}
+
+	if !cfg.ProposalSummaryGenerateEnabled {
+		failureReason = "summary_unavailable"
+		return nil, summarizeProposalOutput{}, errors.New("summary_unavailable: cached summary was not found and MCP summary generation is disabled")
+	}
+
+	summary, err := generateSummaryWithTimeout(ctx, cfg, serviceInput)
+	if err != nil {
+		failureReason = summaryFailureReason(err)
+		return nil, summarizeProposalOutput{}, err
+	}
+	generatedAt := time.Now()
+	return nil, summarizeProposalOutput{
+		DaoCode:     daoCode,
+		ProposalID:  proposalID,
+		Summary:     summary,
+		Source:      "generated",
+		CacheHit:    false,
+		GeneratedAt: &generatedAt,
+		Proposal:    lookupProposalMetadata(daoCode, proposalID),
+	}, nil
+}
+
+func generateSummaryWithTimeout(ctx context.Context, cfg Config, input services.ProposalSummaryInput) (string, error) {
+	timeout := cfg.ProposalSummaryGenerationTimeout
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	type result struct {
+		summary string
+		err     error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		summary, err := cfg.ProposalSummaryService.GetOrGenerateSummary(input)
+		resultCh <- result{summary: summary, err: err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return "", fmt.Errorf("summary_generation_timeout: exceeded %s", timeout)
+		}
+		return "", fmt.Errorf("summary_generation_cancelled: %w", ctx.Err())
+	case result := <-resultCh:
+		if result.err != nil {
+			return "", fmt.Errorf("summary_generation_failed: %w", result.err)
+		}
+		return result.summary, nil
+	}
+}
+
+func summaryFailureReason(err error) string {
+	if err == nil {
+		return ""
+	}
+	message := err.Error()
+	switch {
+	case strings.Contains(message, "summary_generation_timeout"):
+		return "summary_generation_timeout"
+	case strings.Contains(message, "summary_generation_cancelled"):
+		return "summary_generation_cancelled"
+	default:
+		return "summary_generation_failed"
+	}
+}
+
+func lookupProposalMetadata(daoCode, proposalID string) *proposalToolOutput {
+	proposal, err := services.NewProposalService().InspectProposal(types.InspectProposalInput{
+		DaoCode:    daoCode,
+		ProposalID: proposalID,
+	})
+	if err != nil || proposal == nil {
+		return nil
+	}
+	output := proposalToolDTO(proposal)
+	return &output
+}

--- a/backend/internal/mcp/tools_summary_test.go
+++ b/backend/internal/mcp/tools_summary_test.go
@@ -1,0 +1,202 @@
+package mcp
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ringecosystem/degov-square/database"
+	dbmodels "github.com/ringecosystem/degov-square/database/models"
+	"github.com/ringecosystem/degov-square/services"
+)
+
+type fakeProposalSummaryService struct {
+	cachedSummary    *dbmodels.ProposalSummary
+	cachedErr        error
+	generatedSummary string
+	generateErr      error
+	generateDelay    time.Duration
+	generateInput    services.ProposalSummaryInput
+	generateCalls    int
+}
+
+func (s *fakeProposalSummaryService) GetCachedSummary(input services.ProposalSummaryInput) (*dbmodels.ProposalSummary, error) {
+	return s.cachedSummary, s.cachedErr
+}
+
+func (s *fakeProposalSummaryService) GetOrGenerateSummary(input services.ProposalSummaryInput) (string, error) {
+	s.generateInput = input
+	s.generateCalls++
+	if s.generateDelay > 0 {
+		time.Sleep(s.generateDelay)
+	}
+	return s.generatedSummary, s.generateErr
+}
+
+func TestSummarizeProposalToolReturnsCachedSummary(t *testing.T) {
+	server := newTestProposalServer(t)
+	generatedAt := time.Now().Add(-time.Hour).UTC()
+	seedMCPProposal(t, dbmodels.ProposalTracking{
+		ID:           "proposal-cached",
+		DaoCode:      "ring-dao",
+		ChainId:      46,
+		Title:        "Cached proposal",
+		ProposalLink: "https://gov.ringdao.com/proposal/cached",
+		ProposalID:   "0xcached",
+		State:        dbmodels.ProposalStateExecuted,
+		CTime:        time.Now(),
+	})
+	seedMCPProposalSummary(t, dbmodels.ProposalSummary{
+		ID:          "summary-cached",
+		DaoCode:     stringPtr("ring-dao"),
+		ChainId:     46,
+		ProposalID:  "0xcached",
+		Description: "Proposal description",
+		Summary:     "Cached proposal summary",
+		CTime:       generatedAt,
+		UTime:       &generatedAt,
+	})
+
+	result := callProposalTool(t, server, "summarize_proposal", map[string]any{
+		"daoCode":    "ring-dao",
+		"proposalId": "0xcached",
+	})
+	content := requireStructuredContent(t, result)
+
+	if got, want := content["summary"], "Cached proposal summary"; got != want {
+		t.Fatalf("summary = %v, want %v", got, want)
+	}
+	if got, want := content["source"], "cache"; got != want {
+		t.Fatalf("source = %v, want %v", got, want)
+	}
+	if got, want := content["cacheHit"], true; got != want {
+		t.Fatalf("cacheHit = %v, want %v", got, want)
+	}
+	proposal := content["proposal"].(map[string]any)
+	if got, want := proposal["proposalId"], "0xcached"; got != want {
+		t.Fatalf("proposalId = %v, want %v", got, want)
+	}
+}
+
+func TestSummarizeProposalToolRejectsGenerationByDefault(t *testing.T) {
+	server := NewServer(Config{
+		Name:                   "degov-square",
+		Version:                "test-version",
+		ProposalSummaryService: &fakeProposalSummaryService{cachedErr: errors.New("record not found")},
+	})
+
+	result := callProposalTool(t, server, "summarize_proposal", map[string]any{
+		"daoCode":    "ring-dao",
+		"proposalId": "0xmissing",
+	})
+
+	requireToolErrorContains(t, result, "summary_unavailable")
+}
+
+func TestSummarizeProposalToolGeneratesWhenEnabled(t *testing.T) {
+	server := newTestProposalServer(t)
+	summaryService := &fakeProposalSummaryService{
+		cachedErr:        errors.New("record not found"),
+		generatedSummary: "Generated proposal summary",
+	}
+	server = NewServer(Config{
+		Name:                             "degov-square",
+		Version:                          "test-version",
+		ProposalSummaryGenerateEnabled:   true,
+		ProposalSummaryGenerationTimeout: time.Second,
+		ProposalSummaryService:           summaryService,
+	})
+	seedMCPProposal(t, dbmodels.ProposalTracking{
+		ID:           "proposal-generated",
+		DaoCode:      "ring-dao",
+		ChainId:      46,
+		Title:        "Generated proposal",
+		ProposalLink: "https://gov.ringdao.com/proposal/generated",
+		ProposalID:   "0xgenerated",
+		State:        dbmodels.ProposalStateActive,
+		CTime:        time.Now(),
+	})
+
+	result := callProposalTool(t, server, "summarize_proposal", map[string]any{
+		"daoCode":      "ring-dao",
+		"proposalId":   "0xgenerated",
+		"forceRefresh": true,
+	})
+	content := requireStructuredContent(t, result)
+
+	if got, want := content["summary"], "Generated proposal summary"; got != want {
+		t.Fatalf("summary = %v, want %v", got, want)
+	}
+	if got, want := content["source"], "generated"; got != want {
+		t.Fatalf("source = %v, want %v", got, want)
+	}
+	if got, want := content["cacheHit"], false; got != want {
+		t.Fatalf("cacheHit = %v, want %v", got, want)
+	}
+	if got, want := summaryService.generateInput.ProposalID, "0xgenerated"; got != want {
+		t.Fatalf("generated proposal id = %q, want %q", got, want)
+	}
+}
+
+func TestSummarizeProposalToolBoundsGenerationByTimeout(t *testing.T) {
+	server := NewServer(Config{
+		Name:                             "degov-square",
+		Version:                          "test-version",
+		ProposalSummaryGenerateEnabled:   true,
+		ProposalSummaryGenerationTimeout: 10 * time.Millisecond,
+		ProposalSummaryService: &fakeProposalSummaryService{
+			cachedErr:     errors.New("record not found"),
+			generateDelay: 100 * time.Millisecond,
+		},
+	})
+
+	result := callProposalTool(t, server, "summarize_proposal", map[string]any{
+		"daoCode":    "ring-dao",
+		"proposalId": "0xslow",
+	})
+
+	requireToolErrorContains(t, result, "summary_generation_timeout")
+}
+
+func TestSummarizeProposalToolReturnsStructuredFailure(t *testing.T) {
+	server := NewServer(Config{
+		Name:                             "degov-square",
+		Version:                          "test-version",
+		ProposalSummaryGenerateEnabled:   true,
+		ProposalSummaryGenerationTimeout: time.Second,
+		ProposalSummaryService: &fakeProposalSummaryService{
+			cachedErr:   errors.New("record not found"),
+			generateErr: errors.New("openrouter failed"),
+		},
+	})
+
+	result := callProposalTool(t, server, "summarize_proposal", map[string]any{
+		"daoCode":    "ring-dao",
+		"proposalId": "0xfail",
+	})
+
+	requireToolErrorContains(t, result, "summary_generation_failed")
+}
+
+func TestSummarizeProposalToolRejectsInvalidInput(t *testing.T) {
+	server := NewServer(Config{Name: "degov-square", Version: "test-version"})
+
+	result := callProposalTool(t, server, "summarize_proposal", map[string]any{
+		"daoCode":    "",
+		"proposalId": "0xproposal",
+	})
+
+	requireToolErrorContains(t, result, "invalid_dao_code")
+}
+
+func stringPtr(value string) *string {
+	return &value
+}
+
+func seedMCPProposalSummary(t *testing.T, summary dbmodels.ProposalSummary) {
+	t.Helper()
+
+	if err := database.DB.Create(&summary).Error; err != nil {
+		t.Fatalf("seed proposal summary: %v", err)
+	}
+}

--- a/backend/internal/mcp/types_summary.go
+++ b/backend/internal/mcp/types_summary.go
@@ -1,0 +1,19 @@
+package mcp
+
+import "time"
+
+type summarizeProposalInput struct {
+	DaoCode      string `json:"daoCode" jsonschema:"DAO code"`
+	ProposalID   string `json:"proposalId" jsonschema:"Proposal id"`
+	ForceRefresh bool   `json:"forceRefresh,omitempty" jsonschema:"Generate a fresh summary when generation is enabled"`
+}
+
+type summarizeProposalOutput struct {
+	DaoCode     string              `json:"daoCode"`
+	ProposalID  string              `json:"proposalId"`
+	Summary     string              `json:"summary"`
+	Source      string              `json:"source"`
+	CacheHit    bool                `json:"cacheHit"`
+	GeneratedAt *time.Time          `json:"generatedAt,omitempty"`
+	Proposal    *proposalToolOutput `json:"proposal,omitempty"`
+}

--- a/backend/services/proposal_summary.go
+++ b/backend/services/proposal_summary.go
@@ -58,6 +58,20 @@ type ProposalSummaryInput struct {
 	DaoCode    string `json:"daoCode"`
 }
 
+// GetCachedSummary returns a stored proposal summary without consulting external services.
+func (s *ProposalSummaryService) GetCachedSummary(input ProposalSummaryInput) (*dbmodels.ProposalSummary, error) {
+	var existingSummary dbmodels.ProposalSummary
+	err := s.db.Where(
+		"proposal_id = ? AND dao_code = ?",
+		input.ProposalID,
+		input.DaoCode,
+	).Order("ctime DESC").First(&existingSummary).Error
+	if err != nil {
+		return nil, err
+	}
+	return &existingSummary, nil
+}
+
 // GetOrGenerateSummary returns cached summary or generates a new one
 func (s *ProposalSummaryService) GetOrGenerateSummary(input ProposalSummaryInput) (string, error) {
 	daoConfig, err := s.daoConfigService.StandardConfig(input.DaoCode)


### PR DESCRIPTION
## Summary
feat(mcp): add protected proposal summary tool

## Why
- Issue: [HBX-68](https://plane.kahub.in/endless/browse/HBX-68/)

## Changes
- Register summarize_proposal with cache-first behavior and protected generation controls.
- Add MCP proposal summary configuration defaults, runtime wiring, timeout protection, and structured logging.
- Add a cache-only proposal summary service method without changing existing GraphQL generation behavior.
- Cover cache hit, disabled generation, enabled generation, timeout/failure, invalid input, and config parsing in tests.

## Impact
- backend/.env.example
- backend/cmd/main.go
- backend/internal/config/config.go
- backend/internal/config/config_test.go
- backend/internal/mcp/server.go
- backend/internal/mcp/tools_proposal_test.go
- backend/internal/mcp/tools_summary.go
- backend/internal/mcp/tools_summary_test.go
- backend/internal/mcp/types_summary.go
- backend/services/proposal_summary.go

## Verification
- cd backend && just test
- cd backend && just build
- cd web && pnpm install --frozen-lockfile
- cd web && pnpm build

## Links
- Issue: [HBX-68](https://plane.kahub.in/endless/browse/HBX-68/)
- Related PR: https://github.com/ringecosystem/degov-square/pull/255
- metadata
  ```yaml
  schema: conductor/pr-body/1
  repository: degov-square
  issue: HBX-68
  issue_url: "https://plane.kahub.in/endless/browse/HBX-68/"
  run_id: run-hbx-68-1779937827472773888
  attempt_id: run-hbx-68-1779937827472773888-attempt-2
  head_branch: fewensa/test/hbx-68-attempt-2/protected-summary-mcp-tool
  base_branch: main
  commit_id: 267c4ab056c3a464d435e3de125e51ac623987fd
  metadata_attempt_id: run-hbx-68-1779937827472773888-attempt-2
  attempt_result_recorded: true
  related_prs:
    - "https://github.com/ringecosystem/degov-square/pull/255"
  ```