### PR TITLE
Add ENS read-only MCP tools

### DIFF
--- a/backend/internal/mcp/server.go
+++ b/backend/internal/mcp/server.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -19,11 +20,18 @@ type Config struct {
 	ProposalSummaryService           proposalSummaryService
 	ProposalSummaryGenerateEnabled   bool
 	ProposalSummaryGenerationTimeout time.Duration
+	ENSService                       ensService
+	ENSResolveTimeout                time.Duration
 }
 
 type proposalSummaryService interface {
 	GetCachedSummary(services.ProposalSummaryInput) (*dbmodels.ProposalSummary, error)
 	GetOrGenerateSummary(services.ProposalSummaryInput) (string, error)
+}
+
+type ensService interface {
+	Resolve(ctx context.Context, daoCode *string, address *string, name *string) (*services.ENSRecord, error)
+	ResolveRecords(ctx context.Context, name string) (*services.ENSPublicRecords, error)
 }
 
 func NewServer(cfg Config) *sdkmcp.Server {
@@ -36,8 +44,19 @@ func NewServer(cfg Config) *sdkmcp.Server {
 	addDaoTools(server, withDefaultDaoServices(cfg))
 	addProposalTools(server)
 	addProposalSummaryTool(server, withDefaultProposalSummaryServices(cfg))
+	addENSTools(server, withDefaultENSServices(cfg))
 
 	return server
+}
+
+func withDefaultENSServices(cfg Config) Config {
+	if cfg.ENSService == nil {
+		cfg.ENSService = services.NewENSService()
+	}
+	if cfg.ENSResolveTimeout <= 0 {
+		cfg.ENSResolveTimeout = 10 * time.Second
+	}
+	return cfg
 }
 
 func withDefaultDaoServices(cfg Config) Config {

--- a/backend/internal/mcp/tools_ens.go
+++ b/backend/internal/mcp/tools_ens.go
@@ -1,0 +1,201 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/ringecosystem/degov-square/services"
+	"github.com/wealdtech/go-ens/v3"
+)
+
+func addENSTools(server *sdkmcp.Server, cfg Config) {
+	sdkmcp.AddTool(server, &sdkmcp.Tool{
+		Name:        "resolve_ens",
+		Title:       "Resolve ENS",
+		Description: "Resolve an ENS name to an address or reverse-resolve an EVM address to an ENS name.",
+		Annotations: &sdkmcp.ToolAnnotations{
+			ReadOnlyHint: true,
+		},
+	}, func(ctx context.Context, req *sdkmcp.CallToolRequest, input resolveENSInput) (*sdkmcp.CallToolResult, resolveENSOutput, error) {
+		return resolveENSTool(ctx, cfg, input)
+	})
+
+	sdkmcp.AddTool(server, &sdkmcp.Tool{
+		Name:        "resolve_ens_records",
+		Title:       "Resolve ENS Records",
+		Description: "Return public records for an ENS name.",
+		Annotations: &sdkmcp.ToolAnnotations{
+			ReadOnlyHint: true,
+		},
+	}, func(ctx context.Context, req *sdkmcp.CallToolRequest, input resolveENSRecordsInput) (*sdkmcp.CallToolResult, resolveENSRecordsOutput, error) {
+		return resolveENSRecordsTool(ctx, cfg, input)
+	})
+}
+
+func resolveENSTool(ctx context.Context, cfg Config, input resolveENSInput) (*sdkmcp.CallToolResult, resolveENSOutput, error) {
+	name := strings.TrimSpace(input.Name)
+	address := strings.TrimSpace(input.Address)
+	if (name == "" && address == "") || (name != "" && address != "") {
+		return nil, resolveENSOutput{}, errors.New("invalid_ens_query: exactly one of name or address is required")
+	}
+
+	var normalizedName *string
+	var normalizedAddress *string
+	if name != "" {
+		value, err := normalizeENSName(name)
+		if err != nil {
+			return nil, resolveENSOutput{}, err
+		}
+		normalizedName = &value
+	}
+	if address != "" {
+		value, err := normalizeENSAddress(address)
+		if err != nil {
+			return nil, resolveENSOutput{}, err
+		}
+		normalizedAddress = &value
+	}
+
+	record, err := resolveENSWithTimeout(ctx, cfg, nil, normalizedAddress, normalizedName)
+	if err != nil {
+		return nil, resolveENSOutput{}, err
+	}
+	if record == nil || (record.Name == nil && record.Address == nil) {
+		return nil, resolveENSOutput{}, errors.New("ens_not_found: ENS resolution was not found")
+	}
+	if normalizedName != nil && record.Address == nil {
+		return nil, resolveENSOutput{}, fmt.Errorf("ens_not_found: ENS name %q was not found", *normalizedName)
+	}
+	if normalizedAddress != nil && record.Name == nil {
+		return nil, resolveENSOutput{}, fmt.Errorf("ens_not_found: ENS address %q was not found", *normalizedAddress)
+	}
+
+	return nil, ensRecordOutput(record), nil
+}
+
+func resolveENSRecordsTool(ctx context.Context, cfg Config, input resolveENSRecordsInput) (*sdkmcp.CallToolResult, resolveENSRecordsOutput, error) {
+	name, err := normalizeENSName(input.Name)
+	if err != nil {
+		return nil, resolveENSRecordsOutput{}, err
+	}
+
+	records, err := resolveENSRecordsWithTimeout(ctx, cfg, name)
+	if err != nil {
+		return nil, resolveENSRecordsOutput{}, err
+	}
+	if records == nil || (records.Address == nil && records.Contenthash == nil && len(records.Text) == 0) {
+		return nil, resolveENSRecordsOutput{}, fmt.Errorf("ens_records_not_found: ENS records for %q were not found", name)
+	}
+
+	return nil, ensRecordsOutput(records), nil
+}
+
+func resolveENSWithTimeout(ctx context.Context, cfg Config, daoCode *string, address *string, name *string) (*services.ENSRecord, error) {
+	timeout := cfg.ENSResolveTimeout
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	type result struct {
+		record *services.ENSRecord
+		err    error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		record, err := cfg.ENSService.Resolve(ctx, daoCode, address, name)
+		resultCh <- result{record: record, err: err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return nil, fmt.Errorf("ens_resolution_timeout: exceeded %s", timeout)
+		}
+		return nil, fmt.Errorf("ens_resolution_cancelled: %w", ctx.Err())
+	case result := <-resultCh:
+		if result.err != nil {
+			return nil, fmt.Errorf("ens_resolution_failed: %w", result.err)
+		}
+		return result.record, nil
+	}
+}
+
+func resolveENSRecordsWithTimeout(ctx context.Context, cfg Config, name string) (*services.ENSPublicRecords, error) {
+	timeout := cfg.ENSResolveTimeout
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	type result struct {
+		records *services.ENSPublicRecords
+		err     error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		records, err := cfg.ENSService.ResolveRecords(ctx, name)
+		resultCh <- result{records: records, err: err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return nil, fmt.Errorf("ens_records_timeout: exceeded %s", timeout)
+		}
+		return nil, fmt.Errorf("ens_records_cancelled: %w", ctx.Err())
+	case result := <-resultCh:
+		if result.err != nil {
+			return nil, fmt.Errorf("ens_records_failed: %w", result.err)
+		}
+		return result.records, nil
+	}
+}
+
+func normalizeENSAddress(address string) (string, error) {
+	normalized := strings.ToLower(strings.TrimSpace(address))
+	if !common.IsHexAddress(normalized) {
+		return "", errors.New("invalid_ens_address: address must be a valid EVM address")
+	}
+	return normalized, nil
+}
+
+func normalizeENSName(name string) (string, error) {
+	normalized, err := ens.NormaliseDomainStrict(strings.TrimSpace(name))
+	if err != nil {
+		return "", fmt.Errorf("invalid_ens_name: %w", err)
+	}
+	if normalized == "" || !strings.Contains(normalized, ".") || strings.HasPrefix(normalized, ".") || strings.HasSuffix(normalized, ".") {
+		return "", errors.New("invalid_ens_name: name must be a fully-qualified ENS name")
+	}
+	labels := strings.Split(normalized, ".")
+	for _, label := range labels {
+		if label == "" || label == "*" || len(label) > 63 || strings.HasPrefix(label, "-") || strings.HasSuffix(label, "-") {
+			return "", errors.New("invalid_ens_name: name contains invalid labels")
+		}
+	}
+	return normalized, nil
+}
+
+func ensRecordOutput(record *services.ENSRecord) resolveENSOutput {
+	return resolveENSOutput{
+		Name:    record.Name,
+		Address: record.Address,
+	}
+}
+
+func ensRecordsOutput(records *services.ENSPublicRecords) resolveENSRecordsOutput {
+	return resolveENSRecordsOutput{
+		Name:        records.Name,
+		Address:     records.Address,
+		Contenthash: records.Contenthash,
+		Text:        records.Text,
+	}
+}

--- a/backend/internal/mcp/tools_ens_test.go
+++ b/backend/internal/mcp/tools_ens_test.go
@@ -1,0 +1,257 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ringecosystem/degov-square/services"
+)
+
+type fakeENSService struct {
+	resolveRecord  *services.ENSRecord
+	resolveRecords *services.ENSPublicRecords
+	resolveErr     error
+	recordsErr     error
+	delay          time.Duration
+	resolveCalls   int
+	recordsCalls   int
+	daoCode        *string
+	address        *string
+	name           *string
+	recordsName    string
+}
+
+func (s *fakeENSService) Resolve(ctx context.Context, daoCode *string, address *string, name *string) (*services.ENSRecord, error) {
+	s.resolveCalls++
+	s.daoCode = daoCode
+	s.address = address
+	s.name = name
+	if s.delay > 0 {
+		select {
+		case <-time.After(s.delay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	return s.resolveRecord, s.resolveErr
+}
+
+func (s *fakeENSService) ResolveRecords(ctx context.Context, name string) (*services.ENSPublicRecords, error) {
+	s.recordsCalls++
+	s.recordsName = name
+	if s.delay > 0 {
+		select {
+		case <-time.After(s.delay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	return s.resolveRecords, s.recordsErr
+}
+
+func TestResolveENSToolResolvesName(t *testing.T) {
+	address := "0x0000000000000000000000000000000000000001"
+	service := &fakeENSService{
+		resolveRecord: &services.ENSRecord{
+			Name:    stringPtr("alice.eth"),
+			Address: &address,
+		},
+	}
+	server := NewServer(Config{Name: "degov-square", Version: "test-version", ENSService: service})
+
+	result := callProposalTool(t, server, "resolve_ens", map[string]any{"name": "Alice.ETH"})
+	content := requireStructuredContent(t, result)
+
+	if got, want := content["name"], "alice.eth"; got != want {
+		t.Fatalf("name = %v, want %v", got, want)
+	}
+	if got, want := content["address"], address; got != want {
+		t.Fatalf("address = %v, want %v", got, want)
+	}
+	if service.name == nil || *service.name != "alice.eth" {
+		t.Fatalf("service name = %#v, want alice.eth", service.name)
+	}
+	if service.address != nil {
+		t.Fatalf("service address = %#v, want nil", service.address)
+	}
+}
+
+func TestResolveENSToolResolvesAddress(t *testing.T) {
+	name := "alice.eth"
+	service := &fakeENSService{
+		resolveRecord: &services.ENSRecord{
+			Name:    &name,
+			Address: stringPtr("0x0000000000000000000000000000000000000001"),
+		},
+	}
+	server := NewServer(Config{Name: "degov-square", Version: "test-version", ENSService: service})
+
+	result := callProposalTool(t, server, "resolve_ens", map[string]any{
+		"address": "0x0000000000000000000000000000000000000001",
+	})
+	content := requireStructuredContent(t, result)
+
+	if got, want := content["name"], name; got != want {
+		t.Fatalf("name = %v, want %v", got, want)
+	}
+	if service.address == nil || *service.address != "0x0000000000000000000000000000000000000001" {
+		t.Fatalf("service address = %#v, want normalized address", service.address)
+	}
+	if service.name != nil {
+		t.Fatalf("service name = %#v, want nil", service.name)
+	}
+}
+
+func TestResolveENSRecordsToolReturnsPublicRecords(t *testing.T) {
+	service := &fakeENSService{
+		resolveRecords: &services.ENSPublicRecords{
+			Name:        "alice.eth",
+			Address:     stringPtr("0x0000000000000000000000000000000000000001"),
+			Contenthash: stringPtr("ipfs://bafybeigdyrzt"),
+			Text: map[string]string{
+				"avatar": "eip155:1/erc721:0xabc/1",
+				"url":    "https://alice.example",
+			},
+		},
+	}
+	server := NewServer(Config{Name: "degov-square", Version: "test-version", ENSService: service})
+
+	result := callProposalTool(t, server, "resolve_ens_records", map[string]any{"name": "Alice.ETH"})
+	content := requireStructuredContent(t, result)
+
+	if got, want := content["name"], "alice.eth"; got != want {
+		t.Fatalf("name = %v, want %v", got, want)
+	}
+	if got, want := content["address"], "0x0000000000000000000000000000000000000001"; got != want {
+		t.Fatalf("address = %v, want %v", got, want)
+	}
+	text := content["text"].(map[string]any)
+	if got, want := text["url"], "https://alice.example"; got != want {
+		t.Fatalf("url text = %v, want %v", got, want)
+	}
+	if got, want := service.recordsName, "alice.eth"; got != want {
+		t.Fatalf("records name = %q, want %q", got, want)
+	}
+}
+
+func TestENSToolsRejectInvalidInputBeforeServiceCall(t *testing.T) {
+	tests := []struct {
+		name      string
+		tool      string
+		arguments map[string]any
+		wantError string
+	}{
+		{
+			name:      "resolve requires one query",
+			tool:      "resolve_ens",
+			arguments: map[string]any{},
+			wantError: "invalid_ens_query",
+		},
+		{
+			name:      "resolve rejects both query types",
+			tool:      "resolve_ens",
+			arguments: map[string]any{"name": "alice.eth", "address": "0x0000000000000000000000000000000000000001"},
+			wantError: "invalid_ens_query",
+		},
+		{
+			name:      "resolve rejects invalid address",
+			tool:      "resolve_ens",
+			arguments: map[string]any{"address": "0x1234"},
+			wantError: "invalid_ens_address",
+		},
+		{
+			name:      "resolve rejects invalid name",
+			tool:      "resolve_ens",
+			arguments: map[string]any{"name": "-bad.eth"},
+			wantError: "invalid_ens_name",
+		},
+		{
+			name:      "records rejects invalid name",
+			tool:      "resolve_ens_records",
+			arguments: map[string]any{"name": "bad name.eth"},
+			wantError: "invalid_ens_name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := &fakeENSService{}
+			server := NewServer(Config{Name: "degov-square", Version: "test-version", ENSService: service})
+
+			result := callProposalTool(t, server, tt.tool, tt.arguments)
+
+			requireToolErrorContains(t, result, tt.wantError)
+			if service.resolveCalls != 0 || service.recordsCalls != 0 {
+				t.Fatalf("service calls = resolve:%d records:%d, want none", service.resolveCalls, service.recordsCalls)
+			}
+		})
+	}
+}
+
+func TestENSToolsReturnStructuredFailures(t *testing.T) {
+	tests := []struct {
+		name      string
+		tool      string
+		arguments map[string]any
+		service   *fakeENSService
+		wantError string
+	}{
+		{
+			name:      "resolve not found",
+			tool:      "resolve_ens",
+			arguments: map[string]any{"name": "missing.eth"},
+			service:   &fakeENSService{resolveRecord: &services.ENSRecord{Name: stringPtr("missing.eth")}},
+			wantError: "ens_not_found",
+		},
+		{
+			name:      "resolve service failure",
+			tool:      "resolve_ens",
+			arguments: map[string]any{"name": "alice.eth"},
+			service:   &fakeENSService{resolveErr: errors.New("rpc failed")},
+			wantError: "ens_resolution_failed",
+		},
+		{
+			name:      "records not found",
+			tool:      "resolve_ens_records",
+			arguments: map[string]any{"name": "missing.eth"},
+			service:   &fakeENSService{resolveRecords: &services.ENSPublicRecords{Name: "missing.eth"}},
+			wantError: "ens_records_not_found",
+		},
+		{
+			name:      "records service failure",
+			tool:      "resolve_ens_records",
+			arguments: map[string]any{"name": "alice.eth"},
+			service:   &fakeENSService{recordsErr: errors.New("rpc failed")},
+			wantError: "ens_records_failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := NewServer(Config{Name: "degov-square", Version: "test-version", ENSService: tt.service})
+
+			result := callProposalTool(t, server, tt.tool, tt.arguments)
+
+			requireToolErrorContains(t, result, tt.wantError)
+		})
+	}
+}
+
+func TestENSToolsBoundExternalCallsByTimeout(t *testing.T) {
+	server := NewServer(Config{
+		Name:              "degov-square",
+		Version:           "test-version",
+		ENSService:        &fakeENSService{delay: 100 * time.Millisecond},
+		ENSResolveTimeout: 10 * time.Millisecond,
+	})
+
+	started := time.Now()
+	result := callProposalTool(t, server, "resolve_ens", map[string]any{"name": "alice.eth"})
+
+	requireToolErrorContains(t, result, "ens_resolution_timeout")
+	if elapsed := time.Since(started); elapsed > 80*time.Millisecond {
+		t.Fatalf("resolve_ens elapsed = %s, want timeout before service delay", elapsed)
+	}
+}

--- a/backend/internal/mcp/types_ens.go
+++ b/backend/internal/mcp/types_ens.go
@@ -1,0 +1,22 @@
+package mcp
+
+type resolveENSInput struct {
+	Name    string `json:"name,omitempty" jsonschema:"ENS name to resolve."`
+	Address string `json:"address,omitempty" jsonschema:"EVM address to reverse-resolve."`
+}
+
+type resolveENSRecordsInput struct {
+	Name string `json:"name" jsonschema:"ENS name to inspect."`
+}
+
+type resolveENSOutput struct {
+	Name    *string `json:"name,omitempty"`
+	Address *string `json:"address,omitempty"`
+}
+
+type resolveENSRecordsOutput struct {
+	Name        string            `json:"name"`
+	Address     *string           `json:"address,omitempty"`
+	Contenthash *string           `json:"contenthash,omitempty"`
+	Text        map[string]string `json:"text,omitempty"`
+}

--- a/backend/services/ens.go
+++ b/backend/services/ens.go
@@ -26,6 +26,17 @@ const defaultENSCacheTTL = 3 * time.Hour
 const defaultENSCacheMaxEntries = 1000
 const mainnetChainID = 1
 
+var ensPublicTextRecordKeys = []string{
+	"avatar",
+	"description",
+	"email",
+	"notice",
+	"com.twitter",
+	"com.github",
+	"org.telegram",
+	"url",
+}
+
 type ENSRecord struct {
 	Address *string
 	Name    *string
@@ -35,6 +46,13 @@ type ENSRecordsInput struct {
 	DaoCode   *string
 	Addresses []string
 	Names     []string
+}
+
+type ENSPublicRecords struct {
+	Name        string
+	Address     *string
+	Contenthash *string
+	Text        map[string]string
 }
 
 type ensCacheEntry struct {
@@ -134,6 +152,20 @@ func (s *ENSService) ResolveBatch(ctx context.Context, input ENSRecordsInput) ([
 	}
 
 	return records, nil
+}
+
+func (s *ENSService) ResolveRecords(ctx context.Context, name string) (*ENSPublicRecords, error) {
+	normalizedName := strings.ToLower(strings.TrimSpace(name))
+	if normalizedName == "" {
+		return nil, fmt.Errorf("ENS name is required")
+	}
+
+	rpcURLs := s.ensRPCURLs(nil)
+	if len(rpcURLs) == 0 {
+		return nil, fmt.Errorf("no ENS RPC URL configured")
+	}
+
+	return resolveENSPublicRecordsWithRPCs(ctx, rpcURLs, normalizedName)
 }
 
 func (s *ENSService) getCached(key string) (ENSRecord, bool) {
@@ -279,6 +311,79 @@ func resolveENSAddressWithRPCs(ctx context.Context, rpcURLs []string, name strin
 		return nil, errors.New("all ENS RPCs failed")
 	}
 	return nil, nil
+}
+
+func resolveENSPublicRecordsWithRPCs(ctx context.Context, rpcURLs []string, name string) (*ENSPublicRecords, error) {
+	var lastErr error
+	for _, rpcURL := range rpcURLs {
+		records, err := resolveENSPublicRecordsViaRPC(ctx, rpcURL, name)
+		if err == nil {
+			return records, nil
+		}
+		if isNoENSResolutionError(err) {
+			return &ENSPublicRecords{Name: name, Text: map[string]string{}}, nil
+		}
+		lastErr = err
+		slog.Warn("Failed to resolve ENS records", "rpc", safeRPCLabel(rpcURL), "name", name, "errorName", errorName(err))
+	}
+	if lastErr != nil {
+		return nil, errors.New("all ENS RPCs failed")
+	}
+	return &ENSPublicRecords{Name: name, Text: map[string]string{}}, nil
+}
+
+var resolveENSPublicRecordsViaRPC = func(ctx context.Context, rpcURL string, name string) (*ENSPublicRecords, error) {
+	client, err := ethclient.DialContext(ctx, rpcURL)
+	if err != nil {
+		return nil, errors.New("failed to connect to ENS RPC")
+	}
+	defer client.Close()
+
+	resolver, err := ens.NewResolver(client, name)
+	if err != nil {
+		return nil, err
+	}
+
+	records := &ENSPublicRecords{
+		Name: name,
+		Text: map[string]string{},
+	}
+
+	address, err := resolver.Address()
+	if err != nil && !isNoENSResolutionError(err) {
+		return nil, err
+	}
+	if err == nil && address != (common.Address{}) {
+		resolvedAddress := strings.ToLower(address.Hex())
+		records.Address = &resolvedAddress
+	}
+
+	contenthashBytes, err := resolver.Contenthash()
+	if err != nil && !isNoENSResolutionError(err) {
+		return nil, err
+	}
+	if err == nil && len(contenthashBytes) > 0 {
+		contenthash, err := ens.ContenthashToString(contenthashBytes)
+		if err != nil {
+			contenthash = "0x" + common.Bytes2Hex(contenthashBytes)
+		}
+		records.Contenthash = &contenthash
+	}
+
+	for _, key := range ensPublicTextRecordKeys {
+		value, err := resolver.Text(key)
+		if err != nil {
+			if isNoENSResolutionError(err) {
+				continue
+			}
+			return nil, err
+		}
+		if strings.TrimSpace(value) != "" {
+			records.Text[key] = value
+		}
+	}
+
+	return records, nil
 }
 
 var resolveENSNameViaRPC = func(ctx context.Context, rpcURL string, address string) (*string, error) {

--- a/backend/services/ens_test.go
+++ b/backend/services/ens_test.go
@@ -256,3 +256,73 @@ func TestENSResolveBatchUsesCache(t *testing.T) {
 		t.Fatalf("expected one lookup call after cached batch, got %d", calls)
 	}
 }
+
+func TestENSResolveRecordsReturnsPublicRecords(t *testing.T) {
+	service := newTestENSService(t)
+	t.Setenv("RPC_URL_1", "https://env-rpc.example")
+
+	originalLookup := resolveENSPublicRecordsViaRPC
+	t.Cleanup(func() {
+		resolveENSPublicRecordsViaRPC = originalLookup
+	})
+
+	resolveENSPublicRecordsViaRPC = func(ctx context.Context, rpcURL string, name string) (*ENSPublicRecords, error) {
+		return &ENSPublicRecords{
+			Name:        name,
+			Address:     stringPtr("0x0000000000000000000000000000000000000001"),
+			Contenthash: stringPtr("ipfs://bafybeigdyrzt"),
+			Text: map[string]string{
+				"url": "https://alice.example",
+			},
+		}, nil
+	}
+
+	records, err := service.ResolveRecords(context.Background(), "alice.eth")
+	if err != nil {
+		t.Fatalf("ResolveRecords returned error: %v", err)
+	}
+	if records == nil {
+		t.Fatal("expected ENS public records, got nil")
+	}
+	if got, want := records.Name, "alice.eth"; got != want {
+		t.Fatalf("name = %q, want %q", got, want)
+	}
+	if records.Address == nil || *records.Address != "0x0000000000000000000000000000000000000001" {
+		t.Fatalf("address = %#v, want resolved address", records.Address)
+	}
+	if got, want := records.Text["url"], "https://alice.example"; got != want {
+		t.Fatalf("url text = %q, want %q", got, want)
+	}
+}
+
+func TestENSResolveRecordsReturnsEmptyRecordForMissingResolver(t *testing.T) {
+	service := newTestENSService(t)
+	t.Setenv("RPC_URL_1", "https://env-rpc.example")
+
+	originalLookup := resolveENSPublicRecordsViaRPC
+	t.Cleanup(func() {
+		resolveENSPublicRecordsViaRPC = originalLookup
+	})
+
+	resolveENSPublicRecordsViaRPC = func(ctx context.Context, rpcURL string, name string) (*ENSPublicRecords, error) {
+		return nil, errors.New("not a resolver")
+	}
+
+	records, err := service.ResolveRecords(context.Background(), "missing.eth")
+	if err != nil {
+		t.Fatalf("ResolveRecords returned error: %v", err)
+	}
+	if records == nil {
+		t.Fatal("expected empty ENS records, got nil")
+	}
+	if got, want := records.Name, "missing.eth"; got != want {
+		t.Fatalf("name = %q, want %q", got, want)
+	}
+	if records.Address != nil || records.Contenthash != nil || len(records.Text) != 0 {
+		t.Fatalf("expected empty public records, got %#v", records)
+	}
+}
+
+func stringPtr(value string) *string {
+	return &value
+}


### PR DESCRIPTION
## Summary
Add ENS read-only MCP tools

## Why
- Issue: [HBX-67](https://plane.kahub.in/endless/browse/HBX-67/)

## Changes
- Register resolve_ens and resolve_ens_records as read-only MCP tools.
- Add ENS name and EVM address validation with timeout-bound service calls.
- Add stable ENS DTOs and ENSService public records adapter for address, contenthash, and common text records.
- Cover success, invalid input, not found, service failure, timeout, and service records adapter behavior.

## Impact
- backend/internal/mcp/server.go
- backend/internal/mcp/tools_ens.go
- backend/internal/mcp/tools_ens_test.go
- backend/internal/mcp/types_ens.go
- backend/services/ens.go
- backend/services/ens_test.go

## Verification
- cd backend && go test ./internal/mcp ./services passed
- cd backend && just test passed
- cd backend && just build passed
- cd web && pnpm install --frozen-lockfile passed
- cd web && pnpm build passed

## Links
- Issue: [HBX-67](https://plane.kahub.in/endless/browse/HBX-67/)
- Related PR: https://github.com/ringecosystem/degov-square/pull/257
- metadata
  ```yaml
  schema: conductor/pr-body/1
  repository: degov-square
  issue: HBX-67
  issue_url: "https://plane.kahub.in/endless/browse/HBX-67/"
  run_id: run-hbx-67-1779943185053453425
  attempt_id: run-hbx-67-1779943185053453425-attempt-3
  head_branch: fewensa/test/hbx-67-attempt-3/add-ens-read-tools
  base_branch: main
  commit_id: 8d62e7b2d2f3e3d78d89a381450277d3eb3619e3
  metadata_attempt_id: run-hbx-67-1779943185053453425-attempt-3
  attempt_result_recorded: true
  related_prs:
    - "https://github.com/ringecosystem/degov-square/pull/257"
  ```