### PR TITLE
feat(mcp): add get_proposal_state tool

### DIFF
--- a/backend/internal/mcp/tools_proposal.go
+++ b/backend/internal/mcp/tools_proposal.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	gqlmodels "github.com/ringecosystem/degov-square/graph/models"
 	"github.com/ringecosystem/degov-square/services"
 	"github.com/ringecosystem/degov-square/types"
 	"gorm.io/gorm"
@@ -30,6 +31,15 @@ func addProposalTools(server *sdkmcp.Server) {
 			ReadOnlyHint: true,
 		},
 	}, getProposalTool)
+
+	sdkmcp.AddTool(server, &sdkmcp.Tool{
+		Name:        "get_proposal_state",
+		Title:       "Get Proposal State",
+		Description: "Return the cached governance proposal state for a DAO.",
+		Annotations: &sdkmcp.ToolAnnotations{
+			ReadOnlyHint: true,
+		},
+	}, getProposalStateTool)
 }
 
 func listProposalsTool(ctx context.Context, req *sdkmcp.CallToolRequest, input listProposalsInput) (*sdkmcp.CallToolResult, listProposalsOutput, error) {
@@ -108,6 +118,59 @@ func getProposalTool(ctx context.Context, req *sdkmcp.CallToolRequest, input get
 
 	return nil, getProposalOutput{
 		Proposal: proposalToolDTO(proposal),
+	}, nil
+}
+
+func getProposalStateTool(ctx context.Context, req *sdkmcp.CallToolRequest, input getProposalStateInput) (*sdkmcp.CallToolResult, getProposalStateOutput, error) {
+	daoCode, err := normalizeProposalDaoCode(input.DaoCode)
+	if err != nil {
+		return nil, getProposalStateOutput{}, err
+	}
+	proposalID := strings.TrimSpace(input.ProposalID)
+	if proposalID == "" {
+		return nil, getProposalStateOutput{}, errors.New("invalid_proposal_id: proposalId is required")
+	}
+	if err := requireDAO(daoCode); err != nil {
+		return nil, getProposalStateOutput{}, err
+	}
+
+	proposalService := services.NewProposalService()
+	state, err := proposalService.GetProposalState(gqlmodels.ProposalStateInput{
+		DaoCode:    daoCode,
+		ProposalID: proposalID,
+	})
+	if err != nil {
+		return nil, getProposalStateOutput{}, fmt.Errorf("proposal_state_lookup_failed: %w", err)
+	}
+	if state == nil {
+		return nil, getProposalStateOutput{}, fmt.Errorf("proposal_not_found: proposal %q was not found for DAO %q", proposalID, daoCode)
+	}
+	if strings.TrimSpace(string(*state)) == "" {
+		return nil, getProposalStateOutput{}, fmt.Errorf("proposal_state_unavailable: proposal %q has no cached state for DAO %q", proposalID, daoCode)
+	}
+
+	proposal, err := proposalService.InspectProposal(types.InspectProposalInput{
+		DaoCode:    daoCode,
+		ProposalID: proposalID,
+	})
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, getProposalStateOutput{}, fmt.Errorf("proposal_not_found: proposal %q was not found for DAO %q", proposalID, daoCode)
+		}
+		return nil, getProposalStateOutput{}, fmt.Errorf("proposal_lookup_failed: %w", err)
+	}
+
+	updatedAt := proposal.CTime
+	if proposal.UTime != nil {
+		updatedAt = *proposal.UTime
+	}
+	return nil, getProposalStateOutput{
+		DaoCode:           daoCode,
+		ProposalID:        proposalID,
+		State:             string(*state),
+		Source:            "tracked",
+		ProposalCreatedAt: proposal.ProposalCreatedAt,
+		UpdatedAt:         &updatedAt,
 	}, nil
 }
 

--- a/backend/internal/mcp/tools_proposal_test.go
+++ b/backend/internal/mcp/tools_proposal_test.go
@@ -298,6 +298,173 @@ func TestGetProposalToolReturnsDetail(t *testing.T) {
 	}
 }
 
+func TestProposalToolsListIncludesGetProposalState(t *testing.T) {
+	server := newTestProposalServer(t)
+	session, closeSession := newProposalTestSession(t, server)
+	defer closeSession()
+
+	result, err := session.ListTools(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("ListTools() error = %v", err)
+	}
+
+	for _, tool := range result.Tools {
+		if tool.Name == "get_proposal_state" {
+			return
+		}
+	}
+	t.Fatal("get_proposal_state not found in tool listing")
+}
+
+func TestGetProposalStateToolReturnsTrackedState(t *testing.T) {
+	server := newTestProposalServer(t)
+	createdAt := time.Now().Add(-time.Hour).UTC()
+	updatedAt := time.Now().UTC()
+
+	seedMCPProposal(t, dbmodels.ProposalTracking{
+		ID:                "proposal-state",
+		DaoCode:           "ring-dao",
+		ChainId:           46,
+		Title:             "State proposal",
+		ProposalLink:      "https://gov.ringdao.com/proposal/state",
+		ProposalID:        "0xstate",
+		State:             dbmodels.ProposalStateQueued,
+		ProposalCreatedAt: &createdAt,
+		ProposalAtBlock:   23456,
+		CTime:             createdAt,
+		UTime:             &updatedAt,
+	})
+
+	result := callProposalTool(t, server, "get_proposal_state", map[string]any{
+		"daoCode":    " ring-dao ",
+		"proposalId": " 0xstate ",
+	})
+	content := requireStructuredContent(t, result)
+
+	if got, want := content["daoCode"], "ring-dao"; got != want {
+		t.Fatalf("daoCode = %v, want %v", got, want)
+	}
+	if got, want := content["proposalId"], "0xstate"; got != want {
+		t.Fatalf("proposalId = %v, want %v", got, want)
+	}
+	if got, want := content["state"], "QUEUED"; got != want {
+		t.Fatalf("state = %v, want %v", got, want)
+	}
+	if got, want := content["source"], "tracked"; got != want {
+		t.Fatalf("source = %v, want %v", got, want)
+	}
+	if _, ok := content["updatedAt"]; !ok {
+		t.Fatal("updatedAt is missing")
+	}
+}
+
+func TestGetProposalStateToolReturnsClearErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		arguments map[string]any
+		wantError string
+	}{
+		{
+			name:      "invalid dao code",
+			arguments: map[string]any{"daoCode": "", "proposalId": "0xstate"},
+			wantError: "invalid_dao_code",
+		},
+		{
+			name:      "invalid proposal id",
+			arguments: map[string]any{"daoCode": "ring-dao", "proposalId": ""},
+			wantError: "invalid_proposal_id",
+		},
+		{
+			name:      "unknown dao",
+			arguments: map[string]any{"daoCode": "missing-dao", "proposalId": "0xstate"},
+			wantError: "dao_not_found",
+		},
+		{
+			name:      "unknown proposal",
+			arguments: map[string]any{"daoCode": "ring-dao", "proposalId": "0xmissing"},
+			wantError: "proposal_not_found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := newTestProposalServer(t)
+
+			result := callProposalTool(t, server, "get_proposal_state", tt.arguments)
+
+			requireToolErrorContains(t, result, tt.wantError)
+		})
+	}
+}
+
+func TestGetProposalStateToolRejectsUnavailableState(t *testing.T) {
+	server := newTestProposalServer(t)
+	seedMCPProposal(t, dbmodels.ProposalTracking{
+		ID:           "proposal-state-unavailable",
+		DaoCode:      "ring-dao",
+		ChainId:      46,
+		Title:        "State unavailable proposal",
+		ProposalLink: "https://gov.ringdao.com/proposal/state-unavailable",
+		ProposalID:   "0xnostate",
+		State:        "",
+		CTime:        time.Now(),
+	})
+
+	result := callProposalTool(t, server, "get_proposal_state", map[string]any{
+		"daoCode":    "ring-dao",
+		"proposalId": "0xnostate",
+	})
+
+	requireToolErrorContains(t, result, "proposal_state_unavailable")
+}
+
+func TestGetProposalStateToolDoesNotMutateTrackingState(t *testing.T) {
+	server := newTestProposalServer(t)
+	nextTrackAt := time.Now().Add(time.Hour).UTC()
+	updatedAt := time.Now().Add(-time.Minute).UTC()
+	seedMCPProposal(t, dbmodels.ProposalTracking{
+		ID:                 "proposal-read-only",
+		DaoCode:            "ring-dao",
+		ChainId:            46,
+		Title:              "Read-only proposal",
+		ProposalLink:       "https://gov.ringdao.com/proposal/read-only",
+		ProposalID:         "0xreadonly",
+		State:              dbmodels.ProposalStateActive,
+		TimesTrack:         5,
+		TimeNextTrack:      &nextTrackAt,
+		Message:            "keep retry metadata",
+		OffsetTrackingVote: 9,
+		CTime:              time.Now().Add(-time.Hour).UTC(),
+		UTime:              &updatedAt,
+	})
+
+	result := callProposalTool(t, server, "get_proposal_state", map[string]any{
+		"daoCode":    "ring-dao",
+		"proposalId": "0xreadonly",
+	})
+	requireStructuredContent(t, result)
+
+	var proposal dbmodels.ProposalTracking
+	if err := database.DB.Where("dao_code = ? AND proposal_id = ?", "ring-dao", "0xreadonly").First(&proposal).Error; err != nil {
+		t.Fatalf("load proposal: %v", err)
+	}
+	if got, want := proposal.TimesTrack, 5; got != want {
+		t.Fatalf("TimesTrack = %d, want %d", got, want)
+	}
+	if proposal.TimeNextTrack == nil || !proposal.TimeNextTrack.Equal(nextTrackAt) {
+		t.Fatalf("TimeNextTrack = %v, want %v", proposal.TimeNextTrack, nextTrackAt)
+	}
+	if got, want := proposal.Message, "keep retry metadata"; got != want {
+		t.Fatalf("Message = %q, want %q", got, want)
+	}
+	if got, want := proposal.OffsetTrackingVote, 9; got != want {
+		t.Fatalf("OffsetTrackingVote = %d, want %d", got, want)
+	}
+	if proposal.UTime == nil || !proposal.UTime.Equal(updatedAt) {
+		t.Fatalf("UTime = %v, want %v", proposal.UTime, updatedAt)
+	}
+}
+
 func TestProposalToolsReturnClearErrors(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -345,5 +512,27 @@ func TestProposalToolsReturnClearErrors(t *testing.T) {
 
 			requireToolErrorContains(t, result, tt.wantError)
 		})
+	}
+}
+
+func newProposalTestSession(t *testing.T, server *sdkmcp.Server) (*sdkmcp.ClientSession, func()) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	clientTransport, serverTransport := sdkmcp.NewInMemoryTransports()
+	go func() {
+		_ = server.Run(ctx, serverTransport)
+	}()
+
+	client := sdkmcp.NewClient(&sdkmcp.Implementation{Name: "test-client"}, nil)
+	session, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		cancel()
+		t.Fatalf("Connect() error = %v", err)
+	}
+
+	return session, func() {
+		session.Close()
+		cancel()
 	}
 }

--- a/backend/internal/mcp/types_proposal.go
+++ b/backend/internal/mcp/types_proposal.go
@@ -25,6 +25,11 @@ type getProposalInput struct {
 	ProposalID string `json:"proposalId" jsonschema:"Proposal id"`
 }
 
+type getProposalStateInput struct {
+	DaoCode    string `json:"daoCode" jsonschema:"DAO code"`
+	ProposalID string `json:"proposalId" jsonschema:"Proposal id"`
+}
+
 type listProposalsOutput struct {
 	DaoCode   string               `json:"daoCode"`
 	State     string               `json:"state,omitempty"`
@@ -35,6 +40,15 @@ type listProposalsOutput struct {
 
 type getProposalOutput struct {
 	Proposal proposalToolOutput `json:"proposal"`
+}
+
+type getProposalStateOutput struct {
+	DaoCode           string     `json:"daoCode"`
+	ProposalID        string     `json:"proposalId"`
+	State             string     `json:"state"`
+	Source            string     `json:"source"`
+	ProposalCreatedAt *time.Time `json:"proposalCreatedAt,omitempty"`
+	UpdatedAt         *time.Time `json:"updatedAt,omitempty"`
 }
 
 type proposalToolOutput struct {


### PR DESCRIPTION
## Summary
feat(mcp): add get_proposal_state tool

## Why
- Issue: [HBX-78](https://plane.kahub.in/endless/browse/HBX-78/)

## Changes
- Register get_proposal_state as a read-only MCP proposal tool.
- Return cached tracked proposal state with source and timestamp metadata.
- Cover tool listing, success, validation errors, unavailable state, and read-only behavior.

## Impact
- backend/internal/mcp/tools_proposal.go
- backend/internal/mcp/types_proposal.go
- backend/internal/mcp/tools_proposal_test.go

## Verification
- go test ./internal/mcp
- just test
- pnpm install --frozen-lockfile
- pnpm build
- git diff --check

## Links
- Issue: [HBX-78](https://plane.kahub.in/endless/browse/HBX-78/)
- Related PR: https://github.com/ringecosystem/degov-square/pull/258
- metadata
  ```yaml
  schema: conductor/pr-body/1
  repository: degov-square
  issue: HBX-78
  issue_url: "https://plane.kahub.in/endless/browse/HBX-78/"
  run_id: run-hbx-78-1779961525205399275
  attempt_id: run-hbx-78-1779961525205399275-attempt-2
  head_branch: fewensa/fix/hbx-78-attempt-2/proposal-state-mcp-tool
  base_branch: main
  commit_id: 64b3f473f224c77d5bfb9060f1747d88629064cb
  metadata_attempt_id: run-hbx-78-1779961525205399275-attempt-2
  attempt_result_recorded: true
  related_prs:
    - "https://github.com/ringecosystem/degov-square/pull/258"
  ```