### PR TITLE
fix(backend): allow MCP CORS headers

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -169,14 +169,7 @@ func startServer() {
 		}))
 	}
 
-	corsHandler := cors.New(cors.Options{
-		AllowedOrigins:   []string{"*"},
-		AllowedMethods:   []string{"GET", "POST", "OPTIONS"},
-		AllowedHeaders:   []string{"Authorization", "Content-Type"},
-		AllowCredentials: true,
-		Debug:            config.GetAppEnv().IsDevelopment(),
-	})
-	httpHandler := corsHandler.Handler(mux)
+	httpHandler := newCORSHandler().Handler(mux)
 
 	slog.Info(
 		"Server is running",
@@ -192,4 +185,21 @@ func getMCPVersion() string {
 	}
 
 	return Version
+}
+
+func newCORSHandler() *cors.Cors {
+	return cors.New(cors.Options{
+		AllowedOrigins: []string{"*"},
+		AllowedMethods: []string{"GET", "POST", "OPTIONS"},
+		AllowedHeaders: []string{
+			"Accept",
+			"Authorization",
+			"Content-Type",
+			"Last-Event-ID",
+			"MCP-Protocol-Version",
+			"Mcp-Session-Id",
+		},
+		AllowCredentials: true,
+		Debug:            config.GetAppEnv().IsDevelopment(),
+	})
 }

--- a/backend/cmd/main_test.go
+++ b/backend/cmd/main_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestCORSAllowsMCPStreamableHTTPHeaders(t *testing.T) {
+	handler := newCORSHandler().Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := httptest.NewRequest(http.MethodOptions, "/mcp", nil)
+	req.Header.Set("Origin", "https://inspector.example")
+	req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+	req.Header.Set("Access-Control-Request-Headers", "accept,authorization,content-type,last-event-id,mcp-protocol-version,mcp-session-id")
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected preflight status %d, got %d", http.StatusNoContent, rec.Code)
+	}
+
+	allowedHeaders := rec.Header().Get("Access-Control-Allow-Headers")
+	for _, header := range []string{"accept", "authorization", "content-type", "last-event-id", "mcp-protocol-version", "mcp-session-id"} {
+		if !strings.Contains(allowedHeaders, header) {
+			t.Fatalf("expected Access-Control-Allow-Headers to contain %q, got %q", header, allowedHeaders)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
fix(backend): allow MCP CORS headers

## Why
- Issue: [HBX-79](https://plane.kahub.in/endless/browse/HBX-79/)

## Changes
- Extract the existing global CORS setup into a helper used by startServer.
- Allow Accept, MCP-Protocol-Version, Mcp-Session-Id, and Last-Event-ID while preserving Authorization and Content-Type.
- Add a regression test that verifies OPTIONS /mcp preflight accepts the MCP streamable HTTP headers.

## Impact
- backend/cmd/main.go
- backend/cmd/main_test.go

## Verification
- go test ./cmd -run TestCORSAllowsMCPStreamableHTTPHeaders -count=1
- just test
- cd web && pnpm install --frozen-lockfile && pnpm build

## Links
- Issue: [HBX-79](https://plane.kahub.in/endless/browse/HBX-79/)
- Related PR: https://github.com/ringecosystem/degov-square/pull/259
- metadata
  ```yaml
  schema: conductor/pr-body/1
  repository: degov-square
  issue: HBX-79
  issue_url: "https://plane.kahub.in/endless/browse/HBX-79/"
  run_id: run-hbx-79-1779961927184885118
  attempt_id: run-hbx-79-1779961927184885118-attempt-3
  head_branch: fewensa/fix/hbx-79-attempt-3/allow-mcp-cors-headers
  base_branch: main
  commit_id: 45dd9abbd2b09878a0cd1a43b9e1cb50aec0f64d
  metadata_attempt_id: run-hbx-79-1779961927184885118-attempt-3
  attempt_result_recorded: true
  related_prs:
    - "https://github.com/ringecosystem/degov-square/pull/259"
  ```