### PR TITLE
Fail closed for invalid MCP auth modes.

### DIFF
--- a/backend/internal/mcp/auth_test.go
+++ b/backend/internal/mcp/auth_test.go
@@ -1,8 +1,11 @@
 package mcp
 
 import (
+	"bytes"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -55,5 +58,72 @@ func TestBuildHTTPHandlerUsesBearerAuth(t *testing.T) {
 
 	if rr.Code != http.StatusUnauthorized {
 		t.Fatalf("status = %d, want %d", rr.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestBuildHTTPHandlerAllowsExplicitNoAuth(t *testing.T) {
+	handler := NewHTTPHandler(Config{
+		Name:     "degov-square",
+		Version:  "test",
+		AuthMode: AuthModeNone,
+	})
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/mcp", nil))
+
+	if rr.Code == http.StatusUnauthorized {
+		t.Fatalf("status = %d, want non-auth response", rr.Code)
+	}
+}
+
+func TestBuildHTTPHandlerRejectsEmptyBearerToken(t *testing.T) {
+	var logs bytes.Buffer
+	originalLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&logs, nil)))
+	t.Cleanup(func() {
+		slog.SetDefault(originalLogger)
+	})
+
+	handler := NewHTTPHandler(Config{
+		Name:     "degov-square",
+		Version:  "test",
+		AuthMode: AuthModeBearer,
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer secret")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusUnauthorized)
+	}
+	if !strings.Contains(logs.String(), "MCP bearer token is empty") {
+		t.Fatalf("logs = %q, want empty token diagnostic", logs.String())
+	}
+}
+
+func TestBuildHTTPHandlerRejectsUnknownAuthMode(t *testing.T) {
+	var logs bytes.Buffer
+	originalLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&logs, nil)))
+	t.Cleanup(func() {
+		slog.SetDefault(originalLogger)
+	})
+
+	handler := NewHTTPHandler(Config{
+		Name:     "degov-square",
+		Version:  "test",
+		AuthMode: "bearer-token",
+	})
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/mcp", nil))
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusUnauthorized)
+	}
+	if !strings.Contains(logs.String(), "Unsupported MCP auth mode") {
+		t.Fatalf("logs = %q, want unsupported auth mode diagnostic", logs.String())
 	}
 }

--- a/backend/internal/mcp/server.go
+++ b/backend/internal/mcp/server.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -84,9 +85,19 @@ func NewHTTPHandler(cfg Config) http.Handler {
 		return NewServer(cfg)
 	}, nil)
 
-	if cfg.AuthMode == AuthModeBearer {
+	switch cfg.AuthMode {
+	case AuthModeBearer:
+		if cfg.BearerToken == "" {
+			slog.Error("MCP bearer token is empty; rejecting all bearer-authenticated MCP requests")
+		}
 		return BearerAuthMiddleware(cfg.BearerToken)(handler)
+	case AuthModeNone:
+		return handler
+	default:
+		slog.Error("Unsupported MCP auth mode; rejecting all MCP requests", "auth_mode", cfg.AuthMode)
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("WWW-Authenticate", "Bearer")
+			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+		})
 	}
-
-	return handler
 }


### PR DESCRIPTION
## Summary
Fail closed for invalid MCP auth modes.

## Why
- Issue: [HBX-80](https://plane.kahub.in/endless/browse/HBX-80/)

## Changes
- Limit MCP auth mode handling to bearer and none explicitly.
- Return an always-rejecting HTTP handler for unknown auth modes so misconfiguration cannot expose MCP unauthenticated.
- Keep empty bearer tokens rejecting all requests and log a clear configuration error.
- Add tests for bearer, none, empty token, unknown auth mode, and diagnostic logs.

## Impact
- backend/internal/mcp/server.go
- backend/internal/mcp/auth_test.go

## Verification
- `go test ./internal/mcp -run 'Test(BuildHTTPHandler|BearerAuth)'` passed.
- `just test` passed.
- `pnpm install --frozen-lockfile` completed in web to satisfy the repository gate dependency state.
- `pnpm build` passed in web; it emitted an existing ESLint circular-config warning but exited 0.

## Links
- Issue: [HBX-80](https://plane.kahub.in/endless/browse/HBX-80/)
- Related PR: https://github.com/ringecosystem/degov-square/pull/260
- metadata
  ```yaml
  schema: conductor/pr-body/1
  repository: degov-square
  issue: HBX-80
  issue_url: "https://plane.kahub.in/endless/browse/HBX-80/"
  run_id: run-hbx-80-1779963220291329061
  attempt_id: run-hbx-80-1779963220291329061-attempt-3
  head_branch: fewensa/fix/hbx-80-attempt-3/mcp-auth-fail-closed
  base_branch: main
  commit_id: 9af6af17dc61b72726fd078855dc46898b45bf53
  metadata_attempt_id: run-hbx-80-1779963220291329061-attempt-3
  attempt_result_recorded: true
  related_prs:
    - "https://github.com/ringecosystem/degov-square/pull/260"
  ```