### PR TITLE
Make MCP proposal summary generation cancellable.

### DIFF
--- a/backend/internal/indexer.go
+++ b/backend/internal/indexer.go
@@ -212,6 +212,13 @@ func (d *DegovIndexer) QueryProposalsCount(scope ProposalScope) (int, error) {
 }
 
 func (d *DegovIndexer) InspectProposal(scope ProposalScope, proposalId string) (*Proposal, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	return d.InspectProposalWithContext(ctx, scope, proposalId)
+}
+
+func (d *DegovIndexer) InspectProposalWithContext(ctx context.Context, scope ProposalScope, proposalId string) (*Proposal, error) {
 	query := `
 		query QueryProposal($where: ProposalWhereInput!) {
 			proposals(where: $where) {
@@ -256,7 +263,7 @@ func (d *DegovIndexer) InspectProposal(scope ProposalScope, proposalId string) (
 		"proposalId_eq": proposalId,
 	}))
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	var response ProposalsResponse
 	if err := d.client.Run(ctx, req, &response); err != nil {

--- a/backend/internal/indexer_test.go
+++ b/backend/internal/indexer_test.go
@@ -1,9 +1,11 @@
 package internal
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 )
 
@@ -95,5 +97,31 @@ func TestQueryGlobalDataMetricsFallsBackToProposalsConnectionWhenGlobalProposalC
 				t.Fatalf("request count = %d, want %d", got, want)
 			}
 		})
+	}
+}
+
+func TestInspectProposalWithContextCancelsRequest(t *testing.T) {
+	var requestCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"proposals":[]}}`))
+	}))
+	defer server.Close()
+
+	indexer := NewDegovIndexer(server.URL)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := indexer.InspectProposalWithContext(ctx, ProposalScope{
+		ChainID:         46,
+		DaoCode:         "ring-dao",
+		GovernorAddress: "0xAbC123",
+	}, "0xcancel")
+	if err == nil {
+		t.Fatal("InspectProposalWithContext() error = nil, want cancellation error")
+	}
+	if got := requestCount.Load(); got != 0 {
+		t.Fatalf("request count = %d, want 0", got)
 	}
 }

--- a/backend/internal/mcp/server.go
+++ b/backend/internal/mcp/server.go
@@ -27,6 +27,7 @@ type Config struct {
 type proposalSummaryService interface {
 	GetCachedSummary(services.ProposalSummaryInput) (*dbmodels.ProposalSummary, error)
 	GetOrGenerateSummary(services.ProposalSummaryInput) (string, error)
+	GetOrGenerateSummaryWithContext(context.Context, services.ProposalSummaryInput) (string, error)
 }
 
 type ensService interface {

--- a/backend/internal/mcp/tools_summary.go
+++ b/backend/internal/mcp/tools_summary.go
@@ -113,28 +113,23 @@ func generateSummaryWithTimeout(ctx context.Context, cfg Config, input services.
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	type result struct {
-		summary string
-		err     error
+	summary, err := cfg.ProposalSummaryService.GetOrGenerateSummaryWithContext(ctx, input)
+	if err != nil {
+		if ctx.Err() != nil {
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				return "", fmt.Errorf("summary_generation_timeout: exceeded %s", timeout)
+			}
+			return "", fmt.Errorf("summary_generation_cancelled: %w", ctx.Err())
+		}
+		return "", fmt.Errorf("summary_generation_failed: %w", err)
 	}
-	resultCh := make(chan result, 1)
-	go func() {
-		summary, err := cfg.ProposalSummaryService.GetOrGenerateSummary(input)
-		resultCh <- result{summary: summary, err: err}
-	}()
-
-	select {
-	case <-ctx.Done():
+	if ctx.Err() != nil {
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return "", fmt.Errorf("summary_generation_timeout: exceeded %s", timeout)
 		}
 		return "", fmt.Errorf("summary_generation_cancelled: %w", ctx.Err())
-	case result := <-resultCh:
-		if result.err != nil {
-			return "", fmt.Errorf("summary_generation_failed: %w", result.err)
-		}
-		return result.summary, nil
 	}
+	return summary, nil
 }
 
 func summaryFailureReason(err error) string {

--- a/backend/internal/mcp/tools_summary_test.go
+++ b/backend/internal/mcp/tools_summary_test.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -18,6 +19,7 @@ type fakeProposalSummaryService struct {
 	generateDelay    time.Duration
 	generateInput    services.ProposalSummaryInput
 	generateCalls    int
+	ctxDone          chan error
 }
 
 func (s *fakeProposalSummaryService) GetCachedSummary(input services.ProposalSummaryInput) (*dbmodels.ProposalSummary, error) {
@@ -29,6 +31,27 @@ func (s *fakeProposalSummaryService) GetOrGenerateSummary(input services.Proposa
 	s.generateCalls++
 	if s.generateDelay > 0 {
 		time.Sleep(s.generateDelay)
+	}
+	return s.generatedSummary, s.generateErr
+}
+
+func (s *fakeProposalSummaryService) GetOrGenerateSummaryWithContext(ctx context.Context, input services.ProposalSummaryInput) (string, error) {
+	s.generateInput = input
+	s.generateCalls++
+	if s.ctxDone != nil {
+		<-ctx.Done()
+		err := ctx.Err()
+		s.ctxDone <- err
+		return "", err
+	}
+	if s.generateDelay > 0 {
+		timer := time.NewTimer(s.generateDelay)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-timer.C:
+		}
 	}
 	return s.generatedSummary, s.generateErr
 }
@@ -156,6 +179,37 @@ func TestSummarizeProposalToolBoundsGenerationByTimeout(t *testing.T) {
 	})
 
 	requireToolErrorContains(t, result, "summary_generation_timeout")
+}
+
+func TestSummarizeProposalToolCancelsGenerationOnTimeout(t *testing.T) {
+	ctxDone := make(chan error, 1)
+	summaryService := &fakeProposalSummaryService{
+		cachedErr:     errors.New("record not found"),
+		generateDelay: 200 * time.Millisecond,
+		ctxDone:       ctxDone,
+	}
+	server := NewServer(Config{
+		Name:                             "degov-square",
+		Version:                          "test-version",
+		ProposalSummaryGenerateEnabled:   true,
+		ProposalSummaryGenerationTimeout: 10 * time.Millisecond,
+		ProposalSummaryService:           summaryService,
+	})
+
+	result := callProposalTool(t, server, "summarize_proposal", map[string]any{
+		"daoCode":    "ring-dao",
+		"proposalId": "0xcancel",
+	})
+
+	requireToolErrorContains(t, result, "summary_generation_timeout")
+	select {
+	case err := <-ctxDone:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("generation context error = %v, want %v", err, context.DeadlineExceeded)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("generation did not observe timeout cancellation")
+	}
 }
 
 func TestSummarizeProposalToolReturnsStructuredFailure(t *testing.T) {

--- a/backend/services/proposal_summary.go
+++ b/backend/services/proposal_summary.go
@@ -74,6 +74,11 @@ func (s *ProposalSummaryService) GetCachedSummary(input ProposalSummaryInput) (*
 
 // GetOrGenerateSummary returns cached summary or generates a new one
 func (s *ProposalSummaryService) GetOrGenerateSummary(input ProposalSummaryInput) (string, error) {
+	return s.GetOrGenerateSummaryWithContext(context.Background(), input)
+}
+
+// GetOrGenerateSummaryWithContext returns cached summary or generates a new one with cancellation support.
+func (s *ProposalSummaryService) GetOrGenerateSummaryWithContext(ctx context.Context, input ProposalSummaryInput) (string, error) {
 	daoConfig, err := s.daoConfigService.StandardConfig(input.DaoCode)
 	if err != nil {
 		return "", fmt.Errorf("failed to get dao config for %s: %w", input.DaoCode, err)
@@ -85,7 +90,7 @@ func (s *ProposalSummaryService) GetOrGenerateSummary(input ProposalSummaryInput
 	slog.Info("[proposal-summary] Looking for cached summary", "proposal_id", input.ProposalID, "chain_id", chainID, "dao_code", input.DaoCode)
 
 	var existingSummary dbmodels.ProposalSummary
-	err = s.db.Where(
+	err = s.db.WithContext(ctx).Where(
 		"proposal_id = ? AND chain_id = ? AND dao_code = ?",
 		input.ProposalID,
 		chainID,
@@ -104,7 +109,7 @@ func (s *ProposalSummaryService) GetOrGenerateSummary(input ProposalSummaryInput
 	slog.Info("[proposal-summary] No cached summary found, generating new one", "proposal_id", input.ProposalID)
 
 	indexer := internal.NewDegovIndexer(indexerEndpoint)
-	proposal, err := indexer.InspectProposal(internal.ProposalScope{
+	proposal, err := indexer.InspectProposalWithContext(ctx, internal.ProposalScope{
 		ChainID:         chainID,
 		DaoCode:         input.DaoCode,
 		GovernorAddress: daoConfig.Contracts.Governor,
@@ -117,7 +122,7 @@ func (s *ProposalSummaryService) GetOrGenerateSummary(input ProposalSummaryInput
 		return "", fmt.Errorf("proposal with ID %s on chain %d not found", input.ProposalID, chainID)
 	}
 
-	summary, err := s.generateSummary(proposal.Description)
+	summary, err := s.generateSummaryWithContext(ctx, proposal.Description)
 	if err != nil {
 		return "", fmt.Errorf("failed to generate summary: %w", err)
 	}
@@ -137,9 +142,9 @@ func (s *ProposalSummaryService) GetOrGenerateSummary(input ProposalSummaryInput
 	}
 
 	slog.Info("[proposal-summary] Saving summary to database", "proposal_id", input.ProposalID, "dao_code", input.DaoCode)
-	if err := s.db.Create(&newSummary).Error; err != nil {
+	if err := s.db.WithContext(ctx).Create(&newSummary).Error; err != nil {
 		var existingRecord dbmodels.ProposalSummary
-		if queryErr := s.db.Where(
+		if queryErr := s.db.WithContext(ctx).Where(
 			"proposal_id = ? AND chain_id = ? AND dao_code = ?",
 			input.ProposalID,
 			chainID,
@@ -158,6 +163,11 @@ func (s *ProposalSummaryService) GetOrGenerateSummary(input ProposalSummaryInput
 
 // generateSummary uses AI to generate a summary of the proposal description
 func (s *ProposalSummaryService) generateSummary(description string) (string, error) {
+	return s.generateSummaryWithContext(context.Background(), description)
+}
+
+// generateSummaryWithContext uses AI to generate a summary of the proposal description with cancellation support.
+func (s *ProposalSummaryService) generateSummaryWithContext(ctx context.Context, description string) (string, error) {
 	var userPromptBuf bytes.Buffer
 	err := s.userTemplate.Execute(&userPromptBuf, map[string]string{
 		"Description": description,
@@ -166,7 +176,7 @@ func (s *ProposalSummaryService) generateSummary(description string) (string, er
 		return "", fmt.Errorf("failed to execute user prompt template: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
 	defer cancel()
 
 	response, err := s.openRouterClient.ChatCompletion(ctx, internal.ChatCompletionRequest{


### PR DESCRIPTION
## Summary
Make MCP proposal summary generation cancellable.

## Why
- Issue: [HBX-81](https://plane.kahub.in/endless/browse/HBX-81/)

## Changes
- Add context-aware proposal summary generation for MCP timeouts.
- Propagate cancellation into indexer requests, OpenRouter calls, and DB operations.
- Remove the MCP goroutine timeout wrapper so generation does not continue in the background.

## Impact
- backend/internal/indexer.go
- backend/internal/indexer_test.go
- backend/internal/mcp/server.go
- backend/internal/mcp/tools_summary.go
- backend/internal/mcp/tools_summary_test.go
- backend/services/proposal_summary.go

## Verification
- go test ./internal/mcp -run 'TestSummarizeProposalTool' -count=1 passed.
- go test ./internal -run 'Test(InspectProposalWithContextCancelsRequest|QueryGlobalDataMetricsFallsBackToProposalsConnectionWhenGlobalProposalCountUnavailable)' -count=1 passed.
- backend just test passed.
- web pnpm build passed.
- git diff --check passed.

## Links
- Issue: [HBX-81](https://plane.kahub.in/endless/browse/HBX-81/)
- Related PR: https://github.com/ringecosystem/degov-square/pull/261
- metadata
  ```yaml
  schema: conductor/pr-body/1
  repository: degov-square
  issue: HBX-81
  issue_url: "https://plane.kahub.in/endless/browse/HBX-81/"
  run_id: run-hbx-81-1779963325004491205
  attempt_id: run-hbx-81-1779963325004491205-attempt-2
  head_branch: fewensa/fix/hbx-81-attempt-2/make-mcp-proposal-summary-generation
  base_branch: main
  commit_id: 3fc74bbe34274741d20920cffb210171a41b9341
  metadata_attempt_id: run-hbx-81-1779963325004491205-attempt-2
  attempt_result_recorded: true
  related_prs:
    - "https://github.com/ringecosystem/degov-square/pull/261"
  ```