### PR TITLE
feat(mcp): add OAuth resource server auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ logs
 .data
 *.local.*
 _tmp
+.worktrees/

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -31,9 +31,19 @@ JWT_SECRET=your_jwt_secret
 # Disabled by default. Set MCP_ENABLED=true to expose the MCP streamable HTTP endpoint.
 # MCP_ENABLED=false
 # MCP_PATH=/mcp
-# MCP_AUTH_MODE=bearer
-# Required when MCP_AUTH_MODE=bearer.
+# MCP_AUTH_MODE=bearer # bearer, oauth, or none
+# Required when MCP_AUTH_MODE=bearer. Optional fallback when MCP_AUTH_MODE=oauth and MCP_OAUTH_ALLOW_STATIC_BEARER=true.
 # MCP_BEARER_TOKEN=
+# OAuth protected resource metadata and JWT verification settings for MCP_AUTH_MODE=oauth.
+# MCP_OAUTH_RESOURCE=https://square.degov.ai/mcp
+# MCP_OAUTH_RESOURCE_METADATA_URL=https://square.degov.ai/.well-known/oauth-protected-resource/mcp
+# MCP_OAUTH_AUTHORIZATION_SERVERS=https://issuer.example.com
+# MCP_OAUTH_ISSUER=https://issuer.example.com
+# MCP_OAUTH_JWKS_URL=https://issuer.example.com/.well-known/jwks.json
+# MCP_OAUTH_AUDIENCE=degov-square-mcp
+# MCP_OAUTH_SCOPES_SUPPORTED=degov.mcp.read
+# MCP_OAUTH_REQUIRED_SCOPES=degov.mcp.read
+# MCP_OAUTH_ALLOW_STATIC_BEARER=false
 # Proposal summary MCP reads cached summaries by default. Set true to allow new external summary generation.
 # MCP_PROPOSAL_SUMMARY_GENERATE_ENABLED=false
 # MCP_PROPOSAL_SUMMARY_TIMEOUT=30s

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -159,11 +159,28 @@ func startServer() {
 	mux.Handle("/dao/config/{dao}", middlewareChain.Then(http.HandlerFunc(daoRoute.ConfigHandler)))
 
 	if cfg.GetMCPEnabled() {
+		if cfg.GetMCPAuthMode() == mcpserver.AuthModeOAuth {
+			mcpserver.RegisterProtectedResourceMetadataHandlers(mux, mcpserver.Config{
+				OAuthResource:             cfg.GetMCPOAuthResource(),
+				OAuthResourceMetadataURL:  cfg.GetMCPOAuthResourceMetadataURL(),
+				OAuthAuthorizationServers: cfg.GetMCPOAuthAuthorizationServers(),
+				OAuthScopesSupported:      cfg.GetMCPOAuthScopesSupported(),
+			})
+		}
 		mux.Handle(cfg.GetMCPPath(), mcpserver.NewHTTPHandler(mcpserver.Config{
 			Name:                             "degov-square",
 			Version:                          getMCPVersion(),
 			AuthMode:                         cfg.GetMCPAuthMode(),
 			BearerToken:                      cfg.GetMCPBearerToken(),
+			OAuthResource:                    cfg.GetMCPOAuthResource(),
+			OAuthResourceMetadataURL:         cfg.GetMCPOAuthResourceMetadataURL(),
+			OAuthAuthorizationServers:        cfg.GetMCPOAuthAuthorizationServers(),
+			OAuthIssuer:                      cfg.GetMCPOAuthIssuer(),
+			OAuthJWKSURL:                     cfg.GetMCPOAuthJWKSURL(),
+			OAuthAudience:                    cfg.GetMCPOAuthAudience(),
+			OAuthScopesSupported:             cfg.GetMCPOAuthScopesSupported(),
+			OAuthRequiredScopes:              cfg.GetMCPOAuthRequiredScopes(),
+			OAuthAllowStaticBearer:           cfg.GetMCPOAuthAllowStaticBearer(),
 			ProposalSummaryGenerateEnabled:   cfg.GetMCPProposalSummaryGenerateEnabled(),
 			ProposalSummaryGenerationTimeout: cfg.GetMCPProposalSummaryTimeout(),
 		}))

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -109,6 +109,15 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("MCP_PATH", "/mcp")
 	v.SetDefault("MCP_AUTH_MODE", "bearer")
 	v.SetDefault("MCP_BEARER_TOKEN", "")
+	v.SetDefault("MCP_OAUTH_RESOURCE", "")
+	v.SetDefault("MCP_OAUTH_RESOURCE_METADATA_URL", "")
+	v.SetDefault("MCP_OAUTH_AUTHORIZATION_SERVERS", "")
+	v.SetDefault("MCP_OAUTH_ISSUER", "")
+	v.SetDefault("MCP_OAUTH_JWKS_URL", "")
+	v.SetDefault("MCP_OAUTH_AUDIENCE", "")
+	v.SetDefault("MCP_OAUTH_SCOPES_SUPPORTED", "degov.mcp.read")
+	v.SetDefault("MCP_OAUTH_REQUIRED_SCOPES", "degov.mcp.read")
+	v.SetDefault("MCP_OAUTH_ALLOW_STATIC_BEARER", false)
 	v.SetDefault("MCP_PROPOSAL_SUMMARY_GENERATE_ENABLED", false)
 	v.SetDefault("MCP_PROPOSAL_SUMMARY_TIMEOUT", "30s")
 
@@ -224,6 +233,42 @@ func (c *Config) GetMCPBearerToken() string {
 	return c.viper.GetString("MCP_BEARER_TOKEN")
 }
 
+func (c *Config) GetMCPOAuthResource() string {
+	return c.viper.GetString("MCP_OAUTH_RESOURCE")
+}
+
+func (c *Config) GetMCPOAuthResourceMetadataURL() string {
+	return c.viper.GetString("MCP_OAUTH_RESOURCE_METADATA_URL")
+}
+
+func (c *Config) GetMCPOAuthAuthorizationServers() []string {
+	return splitCommaSeparated(c.viper.GetString("MCP_OAUTH_AUTHORIZATION_SERVERS"))
+}
+
+func (c *Config) GetMCPOAuthIssuer() string {
+	return c.viper.GetString("MCP_OAUTH_ISSUER")
+}
+
+func (c *Config) GetMCPOAuthJWKSURL() string {
+	return c.viper.GetString("MCP_OAUTH_JWKS_URL")
+}
+
+func (c *Config) GetMCPOAuthAudience() string {
+	return c.viper.GetString("MCP_OAUTH_AUDIENCE")
+}
+
+func (c *Config) GetMCPOAuthScopesSupported() []string {
+	return splitCommaSeparated(c.viper.GetString("MCP_OAUTH_SCOPES_SUPPORTED"))
+}
+
+func (c *Config) GetMCPOAuthRequiredScopes() []string {
+	return splitCommaSeparated(c.viper.GetString("MCP_OAUTH_REQUIRED_SCOPES"))
+}
+
+func (c *Config) GetMCPOAuthAllowStaticBearer() bool {
+	return c.viper.GetBool("MCP_OAUTH_ALLOW_STATIC_BEARER")
+}
+
 func (c *Config) GetMCPProposalSummaryGenerateEnabled() bool {
 	return c.viper.GetBool("MCP_PROPOSAL_SUMMARY_GENERATE_ENABLED")
 }
@@ -326,6 +371,22 @@ func parseEnvironment(env string) Environment {
 	default:
 		return Production
 	}
+}
+
+func splitCommaSeparated(value string) []string {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+
+	parts := strings.Split(value, ",")
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			result = append(result, part)
+		}
+	}
+	return result
 }
 
 // Convenience functions for backward compatibility

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -23,6 +23,33 @@ func TestMCPConfigDefaults(t *testing.T) {
 	if got := cfg.GetMCPBearerToken(); got != "" {
 		t.Fatalf("GetMCPBearerToken() = %q, want empty", got)
 	}
+	if got := cfg.GetMCPOAuthResource(); got != "" {
+		t.Fatalf("GetMCPOAuthResource() = %q, want empty", got)
+	}
+	if got := cfg.GetMCPOAuthResourceMetadataURL(); got != "" {
+		t.Fatalf("GetMCPOAuthResourceMetadataURL() = %q, want empty", got)
+	}
+	if got := cfg.GetMCPOAuthAuthorizationServers(); len(got) != 0 {
+		t.Fatalf("GetMCPOAuthAuthorizationServers() = %v, want empty", got)
+	}
+	if got := cfg.GetMCPOAuthIssuer(); got != "" {
+		t.Fatalf("GetMCPOAuthIssuer() = %q, want empty", got)
+	}
+	if got := cfg.GetMCPOAuthJWKSURL(); got != "" {
+		t.Fatalf("GetMCPOAuthJWKSURL() = %q, want empty", got)
+	}
+	if got := cfg.GetMCPOAuthAudience(); got != "" {
+		t.Fatalf("GetMCPOAuthAudience() = %q, want empty", got)
+	}
+	if got, want := cfg.GetMCPOAuthScopesSupported(), []string{"degov.mcp.read"}; !equalStrings(got, want) {
+		t.Fatalf("GetMCPOAuthScopesSupported() = %v, want %v", got, want)
+	}
+	if got, want := cfg.GetMCPOAuthRequiredScopes(), []string{"degov.mcp.read"}; !equalStrings(got, want) {
+		t.Fatalf("GetMCPOAuthRequiredScopes() = %v, want %v", got, want)
+	}
+	if cfg.GetMCPOAuthAllowStaticBearer() {
+		t.Fatal("GetMCPOAuthAllowStaticBearer() = true, want false")
+	}
 	if cfg.GetMCPProposalSummaryGenerateEnabled() {
 		t.Fatal("GetMCPProposalSummaryGenerateEnabled() = true, want false")
 	}
@@ -36,6 +63,15 @@ func TestMCPConfigReadsEnvironment(t *testing.T) {
 	t.Setenv("MCP_PATH", "/api/mcp")
 	t.Setenv("MCP_AUTH_MODE", "none")
 	t.Setenv("MCP_BEARER_TOKEN", "test-token")
+	t.Setenv("MCP_OAUTH_RESOURCE", "https://mcp.example.com/mcp")
+	t.Setenv("MCP_OAUTH_RESOURCE_METADATA_URL", "https://mcp.example.com/.well-known/oauth-protected-resource/mcp")
+	t.Setenv("MCP_OAUTH_AUTHORIZATION_SERVERS", "https://issuer.example.com, https://issuer-2.example.com")
+	t.Setenv("MCP_OAUTH_ISSUER", "https://issuer.example.com")
+	t.Setenv("MCP_OAUTH_JWKS_URL", "https://issuer.example.com/.well-known/jwks.json")
+	t.Setenv("MCP_OAUTH_AUDIENCE", "degov-square-mcp")
+	t.Setenv("MCP_OAUTH_SCOPES_SUPPORTED", "degov.mcp.read, degov.mcp.write")
+	t.Setenv("MCP_OAUTH_REQUIRED_SCOPES", "degov.mcp.read")
+	t.Setenv("MCP_OAUTH_ALLOW_STATIC_BEARER", "false")
 	t.Setenv("MCP_PROPOSAL_SUMMARY_GENERATE_ENABLED", "true")
 	t.Setenv("MCP_PROPOSAL_SUMMARY_TIMEOUT", "5s")
 	globalConfig = nil
@@ -55,10 +91,49 @@ func TestMCPConfigReadsEnvironment(t *testing.T) {
 	if got, want := cfg.GetMCPBearerToken(), "test-token"; got != want {
 		t.Fatalf("GetMCPBearerToken() = %q, want %q", got, want)
 	}
+	if got, want := cfg.GetMCPOAuthResource(), "https://mcp.example.com/mcp"; got != want {
+		t.Fatalf("GetMCPOAuthResource() = %q, want %q", got, want)
+	}
+	if got, want := cfg.GetMCPOAuthResourceMetadataURL(), "https://mcp.example.com/.well-known/oauth-protected-resource/mcp"; got != want {
+		t.Fatalf("GetMCPOAuthResourceMetadataURL() = %q, want %q", got, want)
+	}
+	if got, want := cfg.GetMCPOAuthAuthorizationServers(), []string{"https://issuer.example.com", "https://issuer-2.example.com"}; !equalStrings(got, want) {
+		t.Fatalf("GetMCPOAuthAuthorizationServers() = %v, want %v", got, want)
+	}
+	if got, want := cfg.GetMCPOAuthIssuer(), "https://issuer.example.com"; got != want {
+		t.Fatalf("GetMCPOAuthIssuer() = %q, want %q", got, want)
+	}
+	if got, want := cfg.GetMCPOAuthJWKSURL(), "https://issuer.example.com/.well-known/jwks.json"; got != want {
+		t.Fatalf("GetMCPOAuthJWKSURL() = %q, want %q", got, want)
+	}
+	if got, want := cfg.GetMCPOAuthAudience(), "degov-square-mcp"; got != want {
+		t.Fatalf("GetMCPOAuthAudience() = %q, want %q", got, want)
+	}
+	if got, want := cfg.GetMCPOAuthScopesSupported(), []string{"degov.mcp.read", "degov.mcp.write"}; !equalStrings(got, want) {
+		t.Fatalf("GetMCPOAuthScopesSupported() = %v, want %v", got, want)
+	}
+	if got, want := cfg.GetMCPOAuthRequiredScopes(), []string{"degov.mcp.read"}; !equalStrings(got, want) {
+		t.Fatalf("GetMCPOAuthRequiredScopes() = %v, want %v", got, want)
+	}
+	if cfg.GetMCPOAuthAllowStaticBearer() {
+		t.Fatal("GetMCPOAuthAllowStaticBearer() = true, want false")
+	}
 	if !cfg.GetMCPProposalSummaryGenerateEnabled() {
 		t.Fatal("GetMCPProposalSummaryGenerateEnabled() = false, want true")
 	}
 	if got, want := cfg.GetMCPProposalSummaryTimeout(), 5*time.Second; got != want {
 		t.Fatalf("GetMCPProposalSummaryTimeout() = %s, want 5s", got)
 	}
+}
+
+func equalStrings(got []string, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/backend/internal/mcp/auth.go
+++ b/backend/internal/mcp/auth.go
@@ -8,6 +8,7 @@ import (
 const (
 	AuthModeBearer = "bearer"
 	AuthModeNone   = "none"
+	AuthModeOAuth  = "oauth"
 )
 
 func BearerAuthMiddleware(token string) func(http.Handler) http.Handler {

--- a/backend/internal/mcp/oauth.go
+++ b/backend/internal/mcp/oauth.go
@@ -30,7 +30,6 @@ type OAuthVerifierConfig struct {
 	Issuer         string
 	JWKSURL        string
 	Audience       string
-	RequiredScopes []string
 	Client         *http.Client
 	JWKSCacheTTL   time.Duration
 }
@@ -118,9 +117,6 @@ func (v *oauthTokenVerifier) Verify(ctx context.Context, tokenString string, _ *
 	issuer, _ := claims.GetIssuer()
 	audience, _ := claims.GetAudience()
 	scopes := tokenScopes(claims)
-	if missingScope(scopes, v.cfg.RequiredScopes) != "" {
-		return nil, invalidOAuthToken("token missing required scope")
-	}
 
 	return &sdkauth.TokenInfo{
 		UserID:     subject,
@@ -314,22 +310,6 @@ func tokenScopes(claims jwt.MapClaims) []string {
 	addList(claims["scp"])
 	addList(claims["permissions"])
 	return scopes
-}
-
-func missingScope(scopes []string, required []string) string {
-	for _, requiredScope := range required {
-		found := false
-		for _, scope := range scopes {
-			if scope == requiredScope {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return requiredScope
-		}
-	}
-	return ""
 }
 
 func invalidOAuthToken(message string) error {

--- a/backend/internal/mcp/oauth.go
+++ b/backend/internal/mcp/oauth.go
@@ -1,0 +1,337 @@
+package mcp
+
+import (
+	"context"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	sdkauth "github.com/modelcontextprotocol/go-sdk/auth"
+	"github.com/modelcontextprotocol/go-sdk/oauthex"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+const (
+	defaultOAuthResourceMetadataPath = "/.well-known/oauth-protected-resource/mcp"
+	defaultJWKSCacheTTL              = 5 * time.Minute
+	defaultOAuthHTTPTimeout          = 10 * time.Second
+)
+
+type OAuthVerifierConfig struct {
+	Issuer         string
+	JWKSURL        string
+	Audience       string
+	RequiredScopes []string
+	Client         *http.Client
+	JWKSCacheTTL   time.Duration
+}
+
+type oauthTokenVerifier struct {
+	cfg OAuthVerifierConfig
+
+	mu        sync.Mutex
+	keys      map[string]*rsa.PublicKey
+	fetchedAt time.Time
+}
+
+type jwksResponse struct {
+	Keys []jwkKey `json:"keys"`
+}
+
+type jwkKey struct {
+	KeyType string `json:"kty"`
+	KeyID   string `json:"kid"`
+	Use     string `json:"use"`
+	Alg     string `json:"alg"`
+	N       string `json:"n"`
+	E       string `json:"e"`
+}
+
+func NewOAuthTokenVerifier(cfg OAuthVerifierConfig) sdkauth.TokenVerifier {
+	if cfg.Client == nil {
+		cfg.Client = &http.Client{Timeout: defaultOAuthHTTPTimeout}
+	}
+	if cfg.JWKSCacheTTL <= 0 {
+		cfg.JWKSCacheTTL = defaultJWKSCacheTTL
+	}
+
+	verifier := &oauthTokenVerifier{cfg: cfg}
+	return verifier.Verify
+}
+
+func OAuthAuthMiddleware(cfg Config) func(http.Handler) http.Handler {
+	verifier := NewOAuthTokenVerifier(OAuthVerifierConfig{
+		Issuer:   cfg.OAuthIssuer,
+		JWKSURL:  cfg.OAuthJWKSURL,
+		Audience: cfg.OAuthAudience,
+		Client:   cfg.OAuthHTTPClient,
+	})
+	return sdkauth.RequireBearerToken(verifier, &sdkauth.RequireBearerTokenOptions{
+		ResourceMetadataURL: oauthResourceMetadataURL(cfg),
+		Scopes:              cfg.OAuthRequiredScopes,
+	})
+}
+
+func (v *oauthTokenVerifier) Verify(ctx context.Context, tokenString string, _ *http.Request) (*sdkauth.TokenInfo, error) {
+	if v.cfg.Issuer == "" {
+		return nil, invalidOAuthToken("missing issuer configuration")
+	}
+	if v.cfg.JWKSURL == "" {
+		return nil, invalidOAuthToken("missing JWKS URL configuration")
+	}
+	if v.cfg.Audience == "" {
+		return nil, invalidOAuthToken("missing audience configuration")
+	}
+
+	claims := jwt.MapClaims{}
+	token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (any, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
+			return nil, fmt.Errorf("unexpected signing method %v", token.Header["alg"])
+		}
+		kid, _ := token.Header["kid"].(string)
+		if kid == "" {
+			return nil, errors.New("token missing kid")
+		}
+		return v.keyForKID(ctx, kid)
+	}, jwt.WithValidMethods([]string{jwt.SigningMethodRS256.Alg()}), jwt.WithIssuer(v.cfg.Issuer), jwt.WithAudience(v.cfg.Audience), jwt.WithExpirationRequired())
+	if err != nil || token == nil || !token.Valid {
+		if err == nil {
+			err = errors.New("token is invalid")
+		}
+		return nil, invalidOAuthToken(err.Error())
+	}
+
+	expiration, err := claims.GetExpirationTime()
+	if err != nil || expiration == nil {
+		return nil, invalidOAuthToken("token missing expiration")
+	}
+	subject, _ := claims.GetSubject()
+	issuer, _ := claims.GetIssuer()
+	audience, _ := claims.GetAudience()
+	scopes := tokenScopes(claims)
+	if missingScope(scopes, v.cfg.RequiredScopes) != "" {
+		return nil, invalidOAuthToken("token missing required scope")
+	}
+
+	return &sdkauth.TokenInfo{
+		UserID:     subject,
+		Scopes:     scopes,
+		Expiration: expiration.Time,
+		Extra: map[string]any{
+			"issuer":   issuer,
+			"audience": []string(audience),
+		},
+	}, nil
+}
+
+func (v *oauthTokenVerifier) keyForKID(ctx context.Context, kid string) (*rsa.PublicKey, error) {
+	v.mu.Lock()
+	if fresh := v.cacheFresh(); fresh {
+		key := v.keys[kid]
+		v.mu.Unlock()
+		if key == nil {
+			return nil, fmt.Errorf("unknown key id %q", kid)
+		}
+		return key, nil
+	}
+	v.mu.Unlock()
+
+	keys, err := v.fetchKeys(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	v.mu.Lock()
+	v.keys = keys
+	v.fetchedAt = time.Now()
+	key := v.keys[kid]
+	v.mu.Unlock()
+
+	if key != nil {
+		return key, nil
+	}
+	return nil, fmt.Errorf("unknown key id %q", kid)
+}
+
+func (v *oauthTokenVerifier) cacheFresh() bool {
+	return v.keys != nil && time.Since(v.fetchedAt) < v.cfg.JWKSCacheTTL
+}
+
+func (v *oauthTokenVerifier) fetchKeys(ctx context.Context) (map[string]*rsa.PublicKey, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, v.cfg.JWKSURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := v.cfg.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("JWKS request returned status %d", resp.StatusCode)
+	}
+
+	var jwks jwksResponse
+	if err := json.NewDecoder(resp.Body).Decode(&jwks); err != nil {
+		return nil, err
+	}
+	keys := make(map[string]*rsa.PublicKey, len(jwks.Keys))
+	for _, key := range jwks.Keys {
+		publicKey, usable, err := key.rsaPublicKey()
+		if err != nil {
+			continue
+		}
+		if !usable {
+			continue
+		}
+		keys[key.KeyID] = publicKey
+	}
+	if len(keys) == 0 {
+		return nil, errors.New("JWKS did not contain usable RSA signing keys")
+	}
+	return keys, nil
+}
+
+func (k jwkKey) rsaPublicKey() (*rsa.PublicKey, bool, error) {
+	if k.KeyID == "" {
+		return nil, false, nil
+	}
+	if k.KeyType != "RSA" {
+		return nil, false, nil
+	}
+	if k.Use != "" && k.Use != "sig" {
+		return nil, false, nil
+	}
+	if k.Alg != "" && k.Alg != jwt.SigningMethodRS256.Alg() {
+		return nil, false, nil
+	}
+	nBytes, err := base64.RawURLEncoding.DecodeString(k.N)
+	if err != nil {
+		return nil, false, fmt.Errorf("invalid JWK modulus: %w", err)
+	}
+	eBytes, err := base64.RawURLEncoding.DecodeString(k.E)
+	if err != nil {
+		return nil, false, fmt.Errorf("invalid JWK exponent: %w", err)
+	}
+	exponent := int(new(big.Int).SetBytes(eBytes).Int64())
+	if exponent == 0 {
+		return nil, false, errors.New("invalid JWK exponent")
+	}
+	return &rsa.PublicKey{
+		N: new(big.Int).SetBytes(nBytes),
+		E: exponent,
+	}, true, nil
+}
+
+func NewProtectedResourceMetadataHandler(cfg Config) http.Handler {
+	return sdkauth.ProtectedResourceMetadataHandler(NewProtectedResourceMetadata(cfg))
+}
+
+func RegisterProtectedResourceMetadataHandlers(mux *http.ServeMux, cfg Config) {
+	handler := NewProtectedResourceMetadataHandler(cfg)
+	registered := map[string]bool{}
+	register := func(path string) {
+		if path == "" || registered[path] {
+			return
+		}
+		mux.Handle(path, handler)
+		registered[path] = true
+	}
+
+	register("/.well-known/oauth-protected-resource")
+	register(defaultOAuthResourceMetadataPath)
+	register(configuredResourceMetadataPath(cfg.OAuthResourceMetadataURL))
+}
+
+func NewProtectedResourceMetadata(cfg Config) *oauthex.ProtectedResourceMetadata {
+	return &oauthex.ProtectedResourceMetadata{
+		Resource:               cfg.OAuthResource,
+		AuthorizationServers:   cfg.OAuthAuthorizationServers,
+		ScopesSupported:        cfg.OAuthScopesSupported,
+		BearerMethodsSupported: []string{"header"},
+		ResourceName:           "DeGov Square MCP",
+	}
+}
+
+func oauthResourceMetadataURL(cfg Config) string {
+	if cfg.OAuthResourceMetadataURL != "" {
+		return cfg.OAuthResourceMetadataURL
+	}
+	return defaultOAuthResourceMetadataPath
+}
+
+func configuredResourceMetadataPath(metadataURL string) string {
+	if metadataURL == "" {
+		return ""
+	}
+	parsed, err := url.Parse(metadataURL)
+	if err != nil || parsed.Path == "" || parsed.Path[0] != '/' {
+		return ""
+	}
+	return parsed.Path
+}
+
+func tokenScopes(claims jwt.MapClaims) []string {
+	seen := map[string]bool{}
+	var scopes []string
+	add := func(scope string) {
+		scope = strings.TrimSpace(scope)
+		if scope == "" || seen[scope] {
+			return
+		}
+		seen[scope] = true
+		scopes = append(scopes, scope)
+	}
+	addList := func(value any) {
+		switch value := value.(type) {
+		case string:
+			for _, scope := range strings.Fields(value) {
+				add(scope)
+			}
+		case []string:
+			for _, scope := range value {
+				add(scope)
+			}
+		case []any:
+			for _, item := range value {
+				if scope, ok := item.(string); ok {
+					add(scope)
+				}
+			}
+		}
+	}
+
+	addList(claims["scope"])
+	addList(claims["scp"])
+	addList(claims["permissions"])
+	return scopes
+}
+
+func missingScope(scopes []string, required []string) string {
+	for _, requiredScope := range required {
+		found := false
+		for _, scope := range scopes {
+			if scope == requiredScope {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return requiredScope
+		}
+	}
+	return ""
+}
+
+func invalidOAuthToken(message string) error {
+	return fmt.Errorf("%w: %s", sdkauth.ErrInvalidToken, message)
+}

--- a/backend/internal/mcp/oauth_test.go
+++ b/backend/internal/mcp/oauth_test.go
@@ -1,0 +1,441 @@
+package mcp
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func TestBuildHTTPHandlerOAuthRejectsMissingTokenWithResourceMetadata(t *testing.T) {
+	handler := NewHTTPHandler(Config{
+		Name:                     "degov-square",
+		Version:                  "test",
+		AuthMode:                 AuthModeOAuth,
+		OAuthResourceMetadataURL: "https://mcp.example.com/.well-known/oauth-protected-resource/mcp",
+		OAuthRequiredScopes:      []string{"degov.mcp.read"},
+	})
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/mcp", nil))
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusUnauthorized)
+	}
+	challenge := rr.Header().Get("WWW-Authenticate")
+	if !strings.Contains(challenge, `resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource/mcp"`) {
+		t.Fatalf("WWW-Authenticate = %q, want resource_metadata", challenge)
+	}
+	if !strings.Contains(challenge, `scope="degov.mcp.read"`) {
+		t.Fatalf("WWW-Authenticate = %q, want scope", challenge)
+	}
+}
+
+func TestBuildHTTPHandlerOAuthAllowsStaticBearerFallback(t *testing.T) {
+	handler := NewHTTPHandler(Config{
+		Name:                   "degov-square",
+		Version:                "test",
+		AuthMode:               AuthModeOAuth,
+		BearerToken:            "secret",
+		OAuthAllowStaticBearer: true,
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer secret")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code == http.StatusUnauthorized {
+		t.Fatalf("status = %d, want static bearer fallback to reach MCP handler", rr.Code)
+	}
+}
+
+func TestBuildHTTPHandlerOAuthRequiresExplicitStaticBearerFallback(t *testing.T) {
+	handler := NewHTTPHandler(Config{
+		Name:        "degov-square",
+		Version:     "test",
+		AuthMode:    AuthModeOAuth,
+		BearerToken: "secret",
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer secret")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestOAuthVerifierAcceptsValidRS256JWT(t *testing.T) {
+	jwks, key := newTestJWKSServer(t)
+	issuer := "https://issuer.example.com"
+	audience := "degov-square-mcp"
+	token := signTestJWT(t, key, "test-key", jwt.MapClaims{
+		"iss":   issuer,
+		"sub":   "user-123",
+		"aud":   audience,
+		"scope": "degov.mcp.read degov.mcp.write",
+		"exp":   time.Now().Add(time.Hour).Unix(),
+		"nbf":   time.Now().Add(-time.Minute).Unix(),
+	})
+	verifier := NewOAuthTokenVerifier(OAuthVerifierConfig{
+		Issuer:   issuer,
+		JWKSURL:  jwks.URL,
+		Audience: audience,
+		Client:   jwks.Client(),
+	})
+
+	info, err := verifier(context.Background(), token, httptest.NewRequest(http.MethodPost, "/mcp", nil))
+	if err != nil {
+		t.Fatalf("verifier returned error: %v", err)
+	}
+	if got, want := info.UserID, "user-123"; got != want {
+		t.Fatalf("UserID = %q, want %q", got, want)
+	}
+	if got, want := info.Scopes, []string{"degov.mcp.read", "degov.mcp.write"}; !sameStrings(got, want) {
+		t.Fatalf("Scopes = %v, want %v", got, want)
+	}
+	if info.Expiration.IsZero() {
+		t.Fatal("Expiration is zero")
+	}
+}
+
+func TestOAuthVerifierRejectsInvalidClaims(t *testing.T) {
+	jwks, key := newTestJWKSServer(t)
+	issuer := "https://issuer.example.com"
+	audience := "degov-square-mcp"
+	tests := []struct {
+		name   string
+		claims jwt.MapClaims
+	}{
+		{
+			name: "wrong audience",
+			claims: jwt.MapClaims{
+				"iss": issuer, "sub": "user-123", "aud": "other-audience",
+				"scope": "degov.mcp.read", "exp": time.Now().Add(time.Hour).Unix(),
+			},
+		},
+		{
+			name: "wrong issuer",
+			claims: jwt.MapClaims{
+				"iss": "https://other-issuer.example.com", "sub": "user-123", "aud": audience,
+				"scope": "degov.mcp.read", "exp": time.Now().Add(time.Hour).Unix(),
+			},
+		},
+		{
+			name: "expired",
+			claims: jwt.MapClaims{
+				"iss": issuer, "sub": "user-123", "aud": audience,
+				"scope": "degov.mcp.read", "exp": time.Now().Add(-time.Hour).Unix(),
+			},
+		},
+	}
+	verifier := NewOAuthTokenVerifier(OAuthVerifierConfig{
+		Issuer:   issuer,
+		JWKSURL:  jwks.URL,
+		Audience: audience,
+		Client:   jwks.Client(),
+	})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			token := signTestJWT(t, key, "test-key", tt.claims)
+			if _, err := verifier(context.Background(), token, httptest.NewRequest(http.MethodPost, "/mcp", nil)); err == nil {
+				t.Fatal("verifier returned nil error, want failure")
+			}
+		})
+	}
+}
+
+func TestOAuthVerifierDoesNotRefetchFreshJWKSForUnknownKID(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	requests := 0
+	jwks := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		writeTestJWKS(t, w, []jwkKey{testJWK("test-key", key, "RSA", "sig", "RS256")})
+	}))
+	t.Cleanup(jwks.Close)
+
+	issuer := "https://issuer.example.com"
+	audience := "degov-square-mcp"
+	verifier := NewOAuthTokenVerifier(OAuthVerifierConfig{
+		Issuer:       issuer,
+		JWKSURL:      jwks.URL,
+		Audience:     audience,
+		Client:       jwks.Client(),
+		JWKSCacheTTL: time.Hour,
+	})
+
+	validToken := signTestJWT(t, key, "test-key", jwt.MapClaims{
+		"iss": issuer, "sub": "user-123", "aud": audience,
+		"scope": "degov.mcp.read", "exp": time.Now().Add(time.Hour).Unix(),
+	})
+	if _, err := verifier(context.Background(), validToken, httptest.NewRequest(http.MethodPost, "/mcp", nil)); err != nil {
+		t.Fatalf("verifier returned error for valid token: %v", err)
+	}
+
+	unknownToken := signTestJWT(t, key, "unknown-key", jwt.MapClaims{
+		"iss": issuer, "sub": "user-123", "aud": audience,
+		"scope": "degov.mcp.read", "exp": time.Now().Add(time.Hour).Unix(),
+	})
+	if _, err := verifier(context.Background(), unknownToken, httptest.NewRequest(http.MethodPost, "/mcp", nil)); err == nil {
+		t.Fatal("verifier returned nil error, want unknown kid failure")
+	}
+	if requests != 1 {
+		t.Fatalf("JWKS requests = %d, want 1", requests)
+	}
+}
+
+func TestOAuthVerifierSkipsIrrelevantJWKs(t *testing.T) {
+	jwks, key := newTestJWKSServerWithKeys(t, func(key *rsa.PrivateKey) []jwkKey {
+		return []jwkKey{
+			testJWK("ec-key", key, "EC", "sig", "RS256"),
+			testJWK("enc-key", key, "RSA", "enc", "RS256"),
+			testJWK("wrong-alg-key", key, "RSA", "sig", "RS512"),
+			testJWK("test-key", key, "RSA", "sig", "RS256"),
+		}
+	})
+	issuer := "https://issuer.example.com"
+	audience := "degov-square-mcp"
+	token := signTestJWT(t, key, "test-key", jwt.MapClaims{
+		"iss": issuer, "sub": "user-123", "aud": audience,
+		"scope": "degov.mcp.read", "exp": time.Now().Add(time.Hour).Unix(),
+	})
+	verifier := NewOAuthTokenVerifier(OAuthVerifierConfig{
+		Issuer:   issuer,
+		JWKSURL:  jwks.URL,
+		Audience: audience,
+		Client:   jwks.Client(),
+	})
+
+	if _, err := verifier(context.Background(), token, httptest.NewRequest(http.MethodPost, "/mcp", nil)); err != nil {
+		t.Fatalf("verifier returned error: %v", err)
+	}
+}
+
+func TestOAuthVerifierSkipsMalformedJWKs(t *testing.T) {
+	jwks, key := newTestJWKSServerWithKeys(t, func(key *rsa.PrivateKey) []jwkKey {
+		malformed := testJWK("bad-key", key, "RSA", "sig", "RS256")
+		malformed.N = "not-base64"
+		return []jwkKey{
+			malformed,
+			testJWK("test-key", key, "RSA", "sig", "RS256"),
+		}
+	})
+	issuer := "https://issuer.example.com"
+	audience := "degov-square-mcp"
+	token := signTestJWT(t, key, "test-key", jwt.MapClaims{
+		"iss": issuer, "sub": "user-123", "aud": audience,
+		"scope": "degov.mcp.read", "exp": time.Now().Add(time.Hour).Unix(),
+	})
+	verifier := NewOAuthTokenVerifier(OAuthVerifierConfig{
+		Issuer:   issuer,
+		JWKSURL:  jwks.URL,
+		Audience: audience,
+		Client:   jwks.Client(),
+	})
+
+	if _, err := verifier(context.Background(), token, httptest.NewRequest(http.MethodPost, "/mcp", nil)); err != nil {
+		t.Fatalf("verifier returned error: %v", err)
+	}
+}
+
+func TestBuildHTTPHandlerOAuthRejectsMissingScope(t *testing.T) {
+	jwks, key := newTestJWKSServer(t)
+	issuer := "https://issuer.example.com"
+	audience := "degov-square-mcp"
+	token := signTestJWT(t, key, "test-key", jwt.MapClaims{
+		"iss":   issuer,
+		"sub":   "user-123",
+		"aud":   audience,
+		"scope": "degov.mcp.write",
+		"exp":   time.Now().Add(time.Hour).Unix(),
+	})
+	handler := NewHTTPHandler(Config{
+		Name:                   "degov-square",
+		Version:                "test",
+		AuthMode:               AuthModeOAuth,
+		OAuthIssuer:            issuer,
+		OAuthJWKSURL:           jwks.URL,
+		OAuthAudience:          audience,
+		OAuthRequiredScopes:    []string{"degov.mcp.read"},
+		OAuthAllowStaticBearer: false,
+		OAuthHTTPClient:        jwks.Client(),
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusForbidden)
+	}
+}
+
+func TestProtectedResourceMetadataHandlerReturnsOAuthMetadata(t *testing.T) {
+	handler := NewProtectedResourceMetadataHandler(Config{
+		OAuthResource:             "https://mcp.example.com/mcp",
+		OAuthAuthorizationServers: []string{"https://issuer.example.com"},
+		OAuthScopesSupported:      []string{"degov.mcp.read"},
+	})
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource/mcp", nil))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+	var got struct {
+		Resource               string   `json:"resource"`
+		AuthorizationServers   []string `json:"authorization_servers"`
+		ScopesSupported        []string `json:"scopes_supported"`
+		BearerMethodsSupported []string `json:"bearer_methods_supported"`
+		ResourceName           string   `json:"resource_name"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("metadata JSON decode failed: %v", err)
+	}
+	if got.Resource != "https://mcp.example.com/mcp" {
+		t.Fatalf("resource = %q, want configured resource", got.Resource)
+	}
+	if !sameStrings(got.AuthorizationServers, []string{"https://issuer.example.com"}) {
+		t.Fatalf("authorization_servers = %v, want issuer", got.AuthorizationServers)
+	}
+	if !sameStrings(got.ScopesSupported, []string{"degov.mcp.read"}) {
+		t.Fatalf("scopes_supported = %v, want read scope", got.ScopesSupported)
+	}
+	if !sameStrings(got.BearerMethodsSupported, []string{"header"}) {
+		t.Fatalf("bearer_methods_supported = %v, want header", got.BearerMethodsSupported)
+	}
+	if got.ResourceName != "DeGov Square MCP" {
+		t.Fatalf("resource_name = %q, want DeGov Square MCP", got.ResourceName)
+	}
+}
+
+func TestRegisterProtectedResourceMetadataHandlersRegistersWellKnownPaths(t *testing.T) {
+	mux := http.NewServeMux()
+	RegisterProtectedResourceMetadataHandlers(mux, Config{
+		OAuthResource:             "https://mcp.example.com/mcp",
+		OAuthAuthorizationServers: []string{"https://issuer.example.com"},
+		OAuthScopesSupported:      []string{"degov.mcp.read"},
+	})
+
+	for _, path := range []string{"/.well-known/oauth-protected-resource", "/.well-known/oauth-protected-resource/mcp"} {
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, path, nil))
+		if rr.Code != http.StatusOK {
+			t.Fatalf("%s status = %d, want %d", path, rr.Code, http.StatusOK)
+		}
+	}
+}
+
+func TestRegisterProtectedResourceMetadataHandlersRegistersConfiguredMetadataPath(t *testing.T) {
+	mux := http.NewServeMux()
+	RegisterProtectedResourceMetadataHandlers(mux, Config{
+		OAuthResourceMetadataURL:  "https://mcp.example.com/oauth/resource-metadata",
+		OAuthResource:             "https://mcp.example.com/mcp",
+		OAuthAuthorizationServers: []string{"https://issuer.example.com"},
+		OAuthScopesSupported:      []string{"degov.mcp.read"},
+	})
+
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/oauth/resource-metadata", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+}
+
+func TestRegisterProtectedResourceMetadataHandlersIgnoresInvalidMetadataURL(t *testing.T) {
+	mux := http.NewServeMux()
+	RegisterProtectedResourceMetadataHandlers(mux, Config{
+		OAuthResourceMetadataURL:  "://bad-url",
+		OAuthResource:             "https://mcp.example.com/mcp",
+		OAuthAuthorizationServers: []string{"https://issuer.example.com"},
+		OAuthScopesSupported:      []string{"degov.mcp.read"},
+	})
+
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource/mcp", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("well-known status = %d, want %d", rr.Code, http.StatusOK)
+	}
+}
+
+func newTestJWKSServer(t *testing.T) (*httptest.Server, *rsa.PrivateKey) {
+	return newTestJWKSServerWithKeys(t, func(key *rsa.PrivateKey) []jwkKey {
+		return []jwkKey{testJWK("test-key", key, "RSA", "sig", "RS256")}
+	})
+}
+
+func newTestJWKSServerWithKeys(t *testing.T, keys func(*rsa.PrivateKey) []jwkKey) (*httptest.Server, *rsa.PrivateKey) {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeTestJWKS(t, w, keys(key))
+	}))
+	t.Cleanup(server.Close)
+	return server, key
+}
+
+func writeTestJWKS(t *testing.T, w http.ResponseWriter, keys []jwkKey) {
+	t.Helper()
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]any{"keys": keys}); err != nil {
+		t.Fatalf("jwks encode error = %v", err)
+	}
+}
+
+func testJWK(kid string, key *rsa.PrivateKey, keyType string, use string, alg string) jwkKey {
+	return jwkKey{
+		KeyType: keyType,
+		Use:     use,
+		Alg:     alg,
+		KeyID:   kid,
+		N:       base64.RawURLEncoding.EncodeToString(key.PublicKey.N.Bytes()),
+		E:       base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.PublicKey.E)).Bytes()),
+	}
+}
+
+func signTestJWT(t *testing.T, key *rsa.PrivateKey, kid string, claims jwt.Claims) string {
+	t.Helper()
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = kid
+	signed, err := token.SignedString(key)
+	if err != nil {
+		t.Fatalf("SignedString() error = %v", err)
+	}
+	return signed
+}
+
+func sameStrings(got []string, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/backend/internal/mcp/server.go
+++ b/backend/internal/mcp/server.go
@@ -16,6 +16,16 @@ type Config struct {
 	Version                          string
 	AuthMode                         string
 	BearerToken                      string
+	OAuthResource                    string
+	OAuthResourceMetadataURL         string
+	OAuthAuthorizationServers        []string
+	OAuthIssuer                      string
+	OAuthJWKSURL                     string
+	OAuthAudience                    string
+	OAuthScopesSupported             []string
+	OAuthRequiredScopes              []string
+	OAuthAllowStaticBearer           bool
+	OAuthHTTPClient                  *http.Client
 	DaoService                       daoService
 	DaoConfigService                 daoConfigService
 	ProposalSummaryService           proposalSummaryService
@@ -91,6 +101,18 @@ func NewHTTPHandler(cfg Config) http.Handler {
 			slog.Error("MCP bearer token is empty; rejecting all bearer-authenticated MCP requests")
 		}
 		return BearerAuthMiddleware(cfg.BearerToken)(handler)
+	case AuthModeOAuth:
+		oauthHandler := OAuthAuthMiddleware(cfg)(handler)
+		if cfg.OAuthAllowStaticBearer && cfg.BearerToken != "" {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if validBearerToken(r, cfg.BearerToken) {
+					handler.ServeHTTP(w, r)
+					return
+				}
+				oauthHandler.ServeHTTP(w, r)
+			})
+		}
+		return oauthHandler
 	case AuthModeNone:
 		return handler
 	default:


### PR DESCRIPTION
## Summary
- Add `MCP_AUTH_MODE=oauth` for DeGov Square MCP.
- Serve OAuth Protected Resource Metadata for MCP discovery.
- Verify Stytch-compatible RS256 JWT access tokens using issuer, audience, JWKS, expiration, and scopes.
- Keep static bearer fallback available only as explicit opt-in via `MCP_OAUTH_ALLOW_STATIC_BEARER=true`.

## Notes
This PR implements only the OAuth Resource Server side. The Square-hosted Stytch authorize page will be handled in a follow-up PR.

## Test Plan
- `cd backend && go test -count=1 ./internal/config ./internal/mcp ./cmd`
- `cd backend && just build`
- `cd backend && git diff --check`