### PR TITLE
feat(mcp): add Stytch OAuth authorize page

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -44,6 +44,16 @@ JWT_SECRET=your_jwt_secret
 # MCP_OAUTH_SCOPES_SUPPORTED=degov.mcp.read
 # MCP_OAUTH_REQUIRED_SCOPES=degov.mcp.read
 # MCP_OAUTH_ALLOW_STATIC_BEARER=false
+# Stytch Connected Apps authorize proxy. Disabled unless explicitly configured.
+# MCP_STYTCH_OAUTH_ENABLED=false
+# MCP_STYTCH_OAUTH_DOMAIN=https://test.stytch.com
+# MCP_STYTCH_OAUTH_PROJECT_ID=
+# MCP_STYTCH_OAUTH_SECRET=
+# MCP_STYTCH_OAUTH_KIND=consumer # consumer or b2b
+# MCP_STYTCH_OAUTH_USER_ID_PREFIX=degov-square:
+# MCP_STYTCH_OAUTH_USER_ID=
+# MCP_STYTCH_OAUTH_ORGANIZATION_ID=
+# MCP_STYTCH_OAUTH_MEMBER_ID=
 # Proposal summary MCP reads cached summaries by default. Set true to allow new external summary generation.
 # MCP_PROPOSAL_SUMMARY_GENERATE_ENABLED=false
 # MCP_PROPOSAL_SUMMARY_TIMEOUT=30s

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -158,6 +158,8 @@ func startServer() {
 	mux.Handle("/dao/config", middlewareChain.Then(http.HandlerFunc(daoRoute.ConfigHandler)))
 	mux.Handle("/dao/config/{dao}", middlewareChain.Then(http.HandlerFunc(daoRoute.ConfigHandler)))
 
+	registerStytchOAuthRoutes(mux, middlewareChain, cfg, nil)
+
 	if cfg.GetMCPEnabled() {
 		if cfg.GetMCPAuthMode() == mcpserver.AuthModeOAuth {
 			mcpserver.RegisterProtectedResourceMetadataHandlers(mux, mcpserver.Config{
@@ -194,6 +196,31 @@ func startServer() {
 	)
 	err := http.ListenAndServe(":"+port, httpHandler)
 	slog.Error("failed to listen server", "error", err)
+}
+
+func registerStytchOAuthRoutes(mux *http.ServeMux, middlewareChain *middleware.Chain, cfg *config.Config, httpClient *http.Client) {
+	if !cfg.GetMCPStytchOAuthEnabled() {
+		return
+	}
+
+	client := mcpserver.NewStytchOAuthClient(mcpserver.StytchOAuthClientConfig{
+		Domain:     cfg.GetMCPStytchOAuthDomain(),
+		ProjectID:  cfg.GetMCPStytchOAuthProjectID(),
+		Secret:     cfg.GetMCPStytchOAuthSecret(),
+		Kind:       mcpserver.StytchOAuthKind(cfg.GetMCPStytchOAuthKind()),
+		HTTPClient: httpClient,
+	})
+	handler := mcpserver.NewStytchOAuthHandler(mcpserver.StytchOAuthHandlerConfig{
+		Client:         client,
+		Kind:           mcpserver.StytchOAuthKind(cfg.GetMCPStytchOAuthKind()),
+		UserIDPrefix:   cfg.GetMCPStytchOAuthUserIDPrefix(),
+		UserID:         cfg.GetMCPStytchOAuthUserID(),
+		OrganizationID: cfg.GetMCPStytchOAuthOrganizationID(),
+		MemberID:       cfg.GetMCPStytchOAuthMemberID(),
+		OAuthResource:  cfg.GetMCPOAuthResource(),
+	})
+	mux.Handle("/api/oauth/stytch/authorize/start", middlewareChain.Then(http.HandlerFunc(handler.AuthorizeStart)))
+	mux.Handle("/api/oauth/stytch/authorize/submit", middlewareChain.Then(http.HandlerFunc(handler.AuthorizeSubmit)))
 }
 
 func getMCPVersion() string {

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -214,7 +214,6 @@ func registerStytchOAuthRoutes(mux *http.ServeMux, middlewareChain *middleware.C
 		Client:         client,
 		Kind:           mcpserver.StytchOAuthKind(cfg.GetMCPStytchOAuthKind()),
 		UserIDPrefix:   cfg.GetMCPStytchOAuthUserIDPrefix(),
-		UserID:         cfg.GetMCPStytchOAuthUserID(),
 		OrganizationID: cfg.GetMCPStytchOAuthOrganizationID(),
 		MemberID:       cfg.GetMCPStytchOAuthMemberID(),
 		OAuthResource:  cfg.GetMCPOAuthResource(),

--- a/backend/cmd/main_test.go
+++ b/backend/cmd/main_test.go
@@ -5,6 +5,9 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/ringecosystem/degov-square/internal/config"
+	"github.com/ringecosystem/degov-square/internal/middleware"
 )
 
 func TestCORSAllowsMCPStreamableHTTPHeaders(t *testing.T) {
@@ -29,5 +32,40 @@ func TestCORSAllowsMCPStreamableHTTPHeaders(t *testing.T) {
 		if !strings.Contains(allowedHeaders, header) {
 			t.Fatalf("expected Access-Control-Allow-Headers to contain %q, got %q", header, allowedHeaders)
 		}
+	}
+}
+
+func TestRegisterStytchOAuthRoutesOnlyWhenEnabled(t *testing.T) {
+	t.Setenv("MCP_STYTCH_OAUTH_ENABLED", "false")
+	if err := config.InitConfig(); err != nil {
+		t.Fatalf("InitConfig: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	registerStytchOAuthRoutes(mux, middleware.NewChain(), config.GetConfig(), nil)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/oauth/stytch/authorize/start", strings.NewReader(`{}`))
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("disabled route status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+
+	t.Setenv("MCP_STYTCH_OAUTH_ENABLED", "true")
+	t.Setenv("MCP_STYTCH_OAUTH_DOMAIN", "https://test.stytch.com")
+	t.Setenv("MCP_STYTCH_OAUTH_PROJECT_ID", "project-test")
+	t.Setenv("MCP_STYTCH_OAUTH_SECRET", "secret-test")
+	if err := config.InitConfig(); err != nil {
+		t.Fatalf("InitConfig: %v", err)
+	}
+
+	mux = http.NewServeMux()
+	registerStytchOAuthRoutes(mux, middleware.NewChain(), config.GetConfig(), nil)
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/api/oauth/stytch/authorize/start", strings.NewReader(`{}`))
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("enabled route status = %d, want %d", rec.Code, http.StatusUnauthorized)
 	}
 }

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -118,6 +118,15 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("MCP_OAUTH_SCOPES_SUPPORTED", "degov.mcp.read")
 	v.SetDefault("MCP_OAUTH_REQUIRED_SCOPES", "degov.mcp.read")
 	v.SetDefault("MCP_OAUTH_ALLOW_STATIC_BEARER", false)
+	v.SetDefault("MCP_STYTCH_OAUTH_ENABLED", false)
+	v.SetDefault("MCP_STYTCH_OAUTH_DOMAIN", "")
+	v.SetDefault("MCP_STYTCH_OAUTH_PROJECT_ID", "")
+	v.SetDefault("MCP_STYTCH_OAUTH_SECRET", "")
+	v.SetDefault("MCP_STYTCH_OAUTH_KIND", "consumer")
+	v.SetDefault("MCP_STYTCH_OAUTH_USER_ID_PREFIX", "degov-square:")
+	v.SetDefault("MCP_STYTCH_OAUTH_USER_ID", "")
+	v.SetDefault("MCP_STYTCH_OAUTH_ORGANIZATION_ID", "")
+	v.SetDefault("MCP_STYTCH_OAUTH_MEMBER_ID", "")
 	v.SetDefault("MCP_PROPOSAL_SUMMARY_GENERATE_ENABLED", false)
 	v.SetDefault("MCP_PROPOSAL_SUMMARY_TIMEOUT", "30s")
 
@@ -267,6 +276,46 @@ func (c *Config) GetMCPOAuthRequiredScopes() []string {
 
 func (c *Config) GetMCPOAuthAllowStaticBearer() bool {
 	return c.viper.GetBool("MCP_OAUTH_ALLOW_STATIC_BEARER")
+}
+
+func (c *Config) GetMCPStytchOAuthEnabled() bool {
+	return c.viper.GetBool("MCP_STYTCH_OAUTH_ENABLED")
+}
+
+func (c *Config) GetMCPStytchOAuthDomain() string {
+	return strings.TrimRight(c.viper.GetString("MCP_STYTCH_OAUTH_DOMAIN"), "/")
+}
+
+func (c *Config) GetMCPStytchOAuthProjectID() string {
+	return c.viper.GetString("MCP_STYTCH_OAUTH_PROJECT_ID")
+}
+
+func (c *Config) GetMCPStytchOAuthSecret() string {
+	return c.viper.GetString("MCP_STYTCH_OAUTH_SECRET")
+}
+
+func (c *Config) GetMCPStytchOAuthKind() string {
+	kind := strings.ToLower(strings.TrimSpace(c.viper.GetString("MCP_STYTCH_OAUTH_KIND")))
+	if kind == "b2b" {
+		return kind
+	}
+	return "consumer"
+}
+
+func (c *Config) GetMCPStytchOAuthUserIDPrefix() string {
+	return c.viper.GetString("MCP_STYTCH_OAUTH_USER_ID_PREFIX")
+}
+
+func (c *Config) GetMCPStytchOAuthUserID() string {
+	return c.viper.GetString("MCP_STYTCH_OAUTH_USER_ID")
+}
+
+func (c *Config) GetMCPStytchOAuthOrganizationID() string {
+	return c.viper.GetString("MCP_STYTCH_OAUTH_ORGANIZATION_ID")
+}
+
+func (c *Config) GetMCPStytchOAuthMemberID() string {
+	return c.viper.GetString("MCP_STYTCH_OAUTH_MEMBER_ID")
 }
 
 func (c *Config) GetMCPProposalSummaryGenerateEnabled() bool {

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -50,6 +50,33 @@ func TestMCPConfigDefaults(t *testing.T) {
 	if cfg.GetMCPOAuthAllowStaticBearer() {
 		t.Fatal("GetMCPOAuthAllowStaticBearer() = true, want false")
 	}
+	if cfg.GetMCPStytchOAuthEnabled() {
+		t.Fatal("GetMCPStytchOAuthEnabled() = true, want false")
+	}
+	if got := cfg.GetMCPStytchOAuthDomain(); got != "" {
+		t.Fatalf("GetMCPStytchOAuthDomain() = %q, want empty", got)
+	}
+	if got := cfg.GetMCPStytchOAuthProjectID(); got != "" {
+		t.Fatalf("GetMCPStytchOAuthProjectID() = %q, want empty", got)
+	}
+	if got := cfg.GetMCPStytchOAuthSecret(); got != "" {
+		t.Fatalf("GetMCPStytchOAuthSecret() = %q, want empty", got)
+	}
+	if got, want := cfg.GetMCPStytchOAuthKind(), "consumer"; got != want {
+		t.Fatalf("GetMCPStytchOAuthKind() = %q, want %q", got, want)
+	}
+	if got, want := cfg.GetMCPStytchOAuthUserIDPrefix(), "degov-square:"; got != want {
+		t.Fatalf("GetMCPStytchOAuthUserIDPrefix() = %q, want %q", got, want)
+	}
+	if got := cfg.GetMCPStytchOAuthUserID(); got != "" {
+		t.Fatalf("GetMCPStytchOAuthUserID() = %q, want empty", got)
+	}
+	if got := cfg.GetMCPStytchOAuthOrganizationID(); got != "" {
+		t.Fatalf("GetMCPStytchOAuthOrganizationID() = %q, want empty", got)
+	}
+	if got := cfg.GetMCPStytchOAuthMemberID(); got != "" {
+		t.Fatalf("GetMCPStytchOAuthMemberID() = %q, want empty", got)
+	}
 	if cfg.GetMCPProposalSummaryGenerateEnabled() {
 		t.Fatal("GetMCPProposalSummaryGenerateEnabled() = true, want false")
 	}
@@ -72,6 +99,15 @@ func TestMCPConfigReadsEnvironment(t *testing.T) {
 	t.Setenv("MCP_OAUTH_SCOPES_SUPPORTED", "degov.mcp.read, degov.mcp.write")
 	t.Setenv("MCP_OAUTH_REQUIRED_SCOPES", "degov.mcp.read")
 	t.Setenv("MCP_OAUTH_ALLOW_STATIC_BEARER", "false")
+	t.Setenv("MCP_STYTCH_OAUTH_ENABLED", "true")
+	t.Setenv("MCP_STYTCH_OAUTH_DOMAIN", "https://test.stytch.com")
+	t.Setenv("MCP_STYTCH_OAUTH_PROJECT_ID", "project-test")
+	t.Setenv("MCP_STYTCH_OAUTH_SECRET", "secret-test")
+	t.Setenv("MCP_STYTCH_OAUTH_KIND", "b2b")
+	t.Setenv("MCP_STYTCH_OAUTH_USER_ID_PREFIX", "square:")
+	t.Setenv("MCP_STYTCH_OAUTH_USER_ID", "user-fixed")
+	t.Setenv("MCP_STYTCH_OAUTH_ORGANIZATION_ID", "org-test")
+	t.Setenv("MCP_STYTCH_OAUTH_MEMBER_ID", "member-test")
 	t.Setenv("MCP_PROPOSAL_SUMMARY_GENERATE_ENABLED", "true")
 	t.Setenv("MCP_PROPOSAL_SUMMARY_TIMEOUT", "5s")
 	globalConfig = nil
@@ -117,6 +153,33 @@ func TestMCPConfigReadsEnvironment(t *testing.T) {
 	}
 	if cfg.GetMCPOAuthAllowStaticBearer() {
 		t.Fatal("GetMCPOAuthAllowStaticBearer() = true, want false")
+	}
+	if !cfg.GetMCPStytchOAuthEnabled() {
+		t.Fatal("GetMCPStytchOAuthEnabled() = false, want true")
+	}
+	if got, want := cfg.GetMCPStytchOAuthDomain(), "https://test.stytch.com"; got != want {
+		t.Fatalf("GetMCPStytchOAuthDomain() = %q, want %q", got, want)
+	}
+	if got, want := cfg.GetMCPStytchOAuthProjectID(), "project-test"; got != want {
+		t.Fatalf("GetMCPStytchOAuthProjectID() = %q, want %q", got, want)
+	}
+	if got, want := cfg.GetMCPStytchOAuthSecret(), "secret-test"; got != want {
+		t.Fatalf("GetMCPStytchOAuthSecret() = %q, want %q", got, want)
+	}
+	if got, want := cfg.GetMCPStytchOAuthKind(), "b2b"; got != want {
+		t.Fatalf("GetMCPStytchOAuthKind() = %q, want %q", got, want)
+	}
+	if got, want := cfg.GetMCPStytchOAuthUserIDPrefix(), "square:"; got != want {
+		t.Fatalf("GetMCPStytchOAuthUserIDPrefix() = %q, want %q", got, want)
+	}
+	if got, want := cfg.GetMCPStytchOAuthUserID(), "user-fixed"; got != want {
+		t.Fatalf("GetMCPStytchOAuthUserID() = %q, want %q", got, want)
+	}
+	if got, want := cfg.GetMCPStytchOAuthOrganizationID(), "org-test"; got != want {
+		t.Fatalf("GetMCPStytchOAuthOrganizationID() = %q, want %q", got, want)
+	}
+	if got, want := cfg.GetMCPStytchOAuthMemberID(), "member-test"; got != want {
+		t.Fatalf("GetMCPStytchOAuthMemberID() = %q, want %q", got, want)
 	}
 	if !cfg.GetMCPProposalSummaryGenerateEnabled() {
 		t.Fatal("GetMCPProposalSummaryGenerateEnabled() = false, want true")

--- a/backend/internal/mcp/stytch_oauth.go
+++ b/backend/internal/mcp/stytch_oauth.go
@@ -1,0 +1,354 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/ringecosystem/degov-square/internal/middleware"
+)
+
+const (
+	stytchOAuthResponseBodyLimit = 1 << 20
+)
+
+type StytchOAuthKind string
+
+const (
+	StytchOAuthKindConsumer StytchOAuthKind = "consumer"
+	StytchOAuthKindB2B      StytchOAuthKind = "b2b"
+)
+
+type StytchOAuthClientConfig struct {
+	Domain     string
+	ProjectID  string
+	Secret     string
+	Kind       StytchOAuthKind
+	HTTPClient *http.Client
+}
+
+type StytchOAuthAuthorizer interface {
+	AuthorizeStart(context.Context, StytchOAuthAuthorizeStartRequest) (StytchOAuthAuthorizeStartResponse, error)
+	AuthorizeSubmit(context.Context, StytchOAuthAuthorizeSubmitRequest) (StytchOAuthAuthorizeSubmitResponse, error)
+}
+
+type StytchOAuthClient struct {
+	cfg        StytchOAuthClientConfig
+	httpClient *http.Client
+}
+
+type StytchOAuthAuthorizeRequest struct {
+	ClientID            string   `json:"client_id"`
+	RedirectURI         string   `json:"redirect_uri"`
+	ResponseType        string   `json:"response_type"`
+	Scopes              []string `json:"scopes"`
+	UserID              string   `json:"user_id,omitempty"`
+	OrganizationID      string   `json:"organization_id,omitempty"`
+	MemberID            string   `json:"member_id,omitempty"`
+	State               string   `json:"state,omitempty"`
+	Nonce               string   `json:"nonce,omitempty"`
+	CodeChallenge       string   `json:"code_challenge,omitempty"`
+	CodeChallengeMethod string   `json:"code_challenge_method,omitempty"`
+	Resources           []string `json:"resources,omitempty"`
+}
+
+type StytchOAuthAuthorizeStartRequest struct {
+	StytchOAuthAuthorizeRequest
+}
+
+type StytchOAuthAuthorizeSubmitRequest struct {
+	StytchOAuthAuthorizeRequest
+	ConsentGranted bool `json:"consent_granted"`
+}
+
+type StytchOAuthAuthorizeStartResponse struct {
+	Client          StytchOAuthClientInfo    `json:"client"`
+	ConsentRequired bool                     `json:"consent_required"`
+	ScopeResults    []StytchOAuthScopeResult `json:"scope_results"`
+}
+
+type StytchOAuthClientInfo struct {
+	ClientID          string `json:"client_id"`
+	ClientName        string `json:"client_name"`
+	ClientDescription string `json:"client_description"`
+	ClientType        string `json:"client_type"`
+	LogoURL           string `json:"logo_url"`
+}
+
+type StytchOAuthScopeResult struct {
+	Scope       string `json:"scope"`
+	Description string `json:"description"`
+	IsGrantable bool   `json:"is_grantable"`
+}
+
+type StytchOAuthAuthorizeSubmitResponse struct {
+	RedirectURI string `json:"redirect_uri"`
+}
+
+type StytchOAuthHandlerConfig struct {
+	Client         StytchOAuthAuthorizer
+	Kind           StytchOAuthKind
+	UserIDPrefix   string
+	UserID         string
+	OrganizationID string
+	MemberID       string
+	OAuthResource  string
+}
+
+type StytchOAuthHandler struct {
+	cfg StytchOAuthHandlerConfig
+}
+
+type stytchOAuthWebRequest struct {
+	ClientID            string `json:"client_id"`
+	RedirectURI         string `json:"redirect_uri"`
+	ResponseType        string `json:"response_type"`
+	Scope               string `json:"scope"`
+	State               string `json:"state"`
+	Nonce               string `json:"nonce"`
+	CodeChallenge       string `json:"code_challenge"`
+	CodeChallengeMethod string `json:"code_challenge_method"`
+	ConsentGranted      bool   `json:"consent_granted"`
+}
+
+func NewStytchOAuthClient(cfg StytchOAuthClientConfig) *StytchOAuthClient {
+	cfg.Domain = strings.TrimRight(cfg.Domain, "/")
+	cfg.Kind = normalizeStytchOAuthKind(cfg.Kind)
+	client := cfg.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 10 * time.Second}
+	}
+	return &StytchOAuthClient{cfg: cfg, httpClient: client}
+}
+
+func (c *StytchOAuthClient) AuthorizeStart(ctx context.Context, req StytchOAuthAuthorizeStartRequest) (StytchOAuthAuthorizeStartResponse, error) {
+	var resp StytchOAuthAuthorizeStartResponse
+	err := c.post(ctx, c.authorizeStartPath(), req, &resp)
+	return resp, err
+}
+
+func (c *StytchOAuthClient) AuthorizeSubmit(ctx context.Context, req StytchOAuthAuthorizeSubmitRequest) (StytchOAuthAuthorizeSubmitResponse, error) {
+	var resp StytchOAuthAuthorizeSubmitResponse
+	err := c.post(ctx, c.authorizeSubmitPath(), req, &resp)
+	return resp, err
+}
+
+func (c *StytchOAuthClient) authorizeStartPath() string {
+	if c.cfg.Kind == StytchOAuthKindB2B {
+		return "/v1/b2b/idp/oauth/authorize/start"
+	}
+	return "/v1/idp/oauth/authorize/start"
+}
+
+func (c *StytchOAuthClient) authorizeSubmitPath() string {
+	if c.cfg.Kind == StytchOAuthKindB2B {
+		return "/v1/b2b/idp/oauth/authorize"
+	}
+	return "/v1/idp/oauth/authorize"
+}
+
+func (c *StytchOAuthClient) post(ctx context.Context, path string, payload any, target any) error {
+	if c.cfg.Domain == "" {
+		return errors.New("missing Stytch OAuth domain")
+	}
+	if c.cfg.ProjectID == "" {
+		return errors.New("missing Stytch OAuth project ID")
+	}
+	if c.cfg.Secret == "" {
+		return errors.New("missing Stytch OAuth secret")
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.cfg.Domain+path, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.SetBasicAuth(c.cfg.ProjectID, c.cfg.Secret)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := readLimitedResponseBody(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("Stytch OAuth request returned status %d: %s", resp.StatusCode, cleanStytchError(respBody))
+	}
+	if err := json.Unmarshal(respBody, target); err != nil {
+		return fmt.Errorf("decode Stytch OAuth response: %w", err)
+	}
+	return nil
+}
+
+func readLimitedResponseBody(body io.Reader) ([]byte, error) {
+	limited := io.LimitReader(body, stytchOAuthResponseBodyLimit+1)
+	respBody, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, err
+	}
+	if len(respBody) > stytchOAuthResponseBodyLimit {
+		return nil, errors.New("Stytch OAuth response body too large")
+	}
+	return respBody, nil
+}
+
+func cleanStytchError(body []byte) string {
+	var parsed struct {
+		ErrorMessage string `json:"error_message"`
+		ErrorType    string `json:"error_type"`
+	}
+	if err := json.Unmarshal(body, &parsed); err == nil {
+		switch {
+		case parsed.ErrorMessage != "":
+			return parsed.ErrorMessage
+		case parsed.ErrorType != "":
+			return parsed.ErrorType
+		}
+	}
+	message := strings.TrimSpace(string(body))
+	if message == "" {
+		return "empty response"
+	}
+	if len(message) > 300 {
+		return message[:300]
+	}
+	return message
+}
+
+func NewStytchOAuthHandler(cfg StytchOAuthHandlerConfig) *StytchOAuthHandler {
+	cfg.Kind = normalizeStytchOAuthKind(cfg.Kind)
+	if cfg.UserIDPrefix == "" {
+		cfg.UserIDPrefix = "degov-square:"
+	}
+	return &StytchOAuthHandler{cfg: cfg}
+}
+
+func (h *StytchOAuthHandler) AuthorizeStart(w http.ResponseWriter, r *http.Request) {
+	claims, ok := h.requireAuth(w, r)
+	if !ok {
+		return
+	}
+
+	var webReq stytchOAuthWebRequest
+	if !decodeJSONRequest(w, r, &webReq) {
+		return
+	}
+
+	req := h.buildAuthorizeRequest(webReq, claims)
+	resp, err := h.cfg.Client.AuthorizeStart(r.Context(), StytchOAuthAuthorizeStartRequest{
+		StytchOAuthAuthorizeRequest: req,
+	})
+	if err != nil {
+		writeJSONError(w, http.StatusBadGateway, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (h *StytchOAuthHandler) AuthorizeSubmit(w http.ResponseWriter, r *http.Request) {
+	claims, ok := h.requireAuth(w, r)
+	if !ok {
+		return
+	}
+
+	var webReq stytchOAuthWebRequest
+	if !decodeJSONRequest(w, r, &webReq) {
+		return
+	}
+
+	req := h.buildAuthorizeRequest(webReq, claims)
+	if h.cfg.OAuthResource != "" {
+		req.Resources = []string{h.cfg.OAuthResource}
+	}
+	resp, err := h.cfg.Client.AuthorizeSubmit(r.Context(), StytchOAuthAuthorizeSubmitRequest{
+		StytchOAuthAuthorizeRequest: req,
+		ConsentGranted:              webReq.ConsentGranted,
+	})
+	if err != nil {
+		writeJSONError(w, http.StatusBadGateway, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (h *StytchOAuthHandler) requireAuth(w http.ResponseWriter, r *http.Request) (*middleware.AuthClaims, bool) {
+	claims, err := middleware.RequireAuth(r.Context())
+	if err != nil || claims.User == nil || claims.User.Id == "" {
+		writeJSONError(w, http.StatusUnauthorized, "authentication required")
+		return nil, false
+	}
+	return claims, true
+}
+
+func (h *StytchOAuthHandler) buildAuthorizeRequest(webReq stytchOAuthWebRequest, claims *middleware.AuthClaims) StytchOAuthAuthorizeRequest {
+	responseType := strings.TrimSpace(webReq.ResponseType)
+	if responseType == "" {
+		responseType = "code"
+	}
+	req := StytchOAuthAuthorizeRequest{
+		ClientID:            webReq.ClientID,
+		RedirectURI:         webReq.RedirectURI,
+		ResponseType:        responseType,
+		Scopes:              strings.Fields(webReq.Scope),
+		State:               webReq.State,
+		Nonce:               webReq.Nonce,
+		CodeChallenge:       webReq.CodeChallenge,
+		CodeChallengeMethod: webReq.CodeChallengeMethod,
+	}
+
+	if h.cfg.Kind == StytchOAuthKindB2B {
+		req.OrganizationID = h.cfg.OrganizationID
+		req.MemberID = h.cfg.MemberID
+		return req
+	}
+
+	if h.cfg.UserID != "" {
+		req.UserID = h.cfg.UserID
+		return req
+	}
+	req.UserID = h.cfg.UserIDPrefix + claims.User.Id
+	return req
+}
+
+func decodeJSONRequest(w http.ResponseWriter, r *http.Request, target any) bool {
+	if r.Method != http.MethodPost {
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return false
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, stytchOAuthResponseBodyLimit)).Decode(target); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON request")
+		return false
+	}
+	return true
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func writeJSONError(w http.ResponseWriter, status int, message string) {
+	writeJSON(w, status, map[string]string{"error": message})
+}
+
+func normalizeStytchOAuthKind(kind StytchOAuthKind) StytchOAuthKind {
+	if kind == StytchOAuthKindB2B {
+		return StytchOAuthKindB2B
+	}
+	return StytchOAuthKindConsumer
+}

--- a/backend/internal/mcp/stytch_oauth.go
+++ b/backend/internal/mcp/stytch_oauth.go
@@ -7,7 +7,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -17,6 +19,8 @@ import (
 const (
 	stytchOAuthResponseBodyLimit = 1 << 20
 )
+
+var allowUnsafeStytchOAuthDomain bool
 
 type StytchOAuthKind string
 
@@ -157,6 +161,11 @@ func (c *StytchOAuthClient) post(ctx context.Context, path string, payload any, 
 	if c.cfg.Domain == "" {
 		return errors.New("missing Stytch OAuth domain")
 	}
+	if !allowUnsafeStytchOAuthDomain {
+		if err := validateStytchOAuthDomain(c.cfg.Domain); err != nil {
+			return err
+		}
+	}
 	if c.cfg.ProjectID == "" {
 		return errors.New("missing Stytch OAuth project ID")
 	}
@@ -192,6 +201,22 @@ func (c *StytchOAuthClient) post(ctx context.Context, path string, payload any, 
 		return fmt.Errorf("decode Stytch OAuth response: %w", err)
 	}
 	return nil
+}
+
+func validateStytchOAuthDomain(domain string) error {
+	parsed, err := url.Parse(domain)
+	if err != nil {
+		return fmt.Errorf("invalid Stytch OAuth domain: %w", err)
+	}
+	if parsed.Scheme != "https" {
+		return errors.New("Stytch OAuth domain must use https")
+	}
+	switch parsed.Hostname() {
+	case "api.stytch.com", "test.stytch.com":
+		return nil
+	default:
+		return errors.New("Stytch OAuth domain host is not allowed")
+	}
 }
 
 func readLimitedResponseBody(body io.Reader) ([]byte, error) {
@@ -242,6 +267,9 @@ func (h *StytchOAuthHandler) AuthorizeStart(w http.ResponseWriter, r *http.Reque
 	if !ok {
 		return
 	}
+	if !h.requireConsumerMode(w) {
+		return
+	}
 
 	var webReq stytchOAuthWebRequest
 	if !decodeJSONRequest(w, r, &webReq) {
@@ -253,7 +281,8 @@ func (h *StytchOAuthHandler) AuthorizeStart(w http.ResponseWriter, r *http.Reque
 		StytchOAuthAuthorizeRequest: req,
 	})
 	if err != nil {
-		writeJSONError(w, http.StatusBadGateway, err.Error())
+		slog.Error("Stytch OAuth authorize start failed", "error", err)
+		writeJSONError(w, http.StatusBadGateway, "Stytch authorization request failed")
 		return
 	}
 	writeJSON(w, http.StatusOK, resp)
@@ -262,6 +291,9 @@ func (h *StytchOAuthHandler) AuthorizeStart(w http.ResponseWriter, r *http.Reque
 func (h *StytchOAuthHandler) AuthorizeSubmit(w http.ResponseWriter, r *http.Request) {
 	claims, ok := h.requireAuth(w, r)
 	if !ok {
+		return
+	}
+	if !h.requireConsumerMode(w) {
 		return
 	}
 
@@ -279,7 +311,8 @@ func (h *StytchOAuthHandler) AuthorizeSubmit(w http.ResponseWriter, r *http.Requ
 		ConsentGranted:              webReq.ConsentGranted,
 	})
 	if err != nil {
-		writeJSONError(w, http.StatusBadGateway, err.Error())
+		slog.Error("Stytch OAuth authorize submit failed", "error", err)
+		writeJSONError(w, http.StatusBadGateway, "Stytch authorization submit failed")
 		return
 	}
 	writeJSON(w, http.StatusOK, resp)
@@ -292,6 +325,14 @@ func (h *StytchOAuthHandler) requireAuth(w http.ResponseWriter, r *http.Request)
 		return nil, false
 	}
 	return claims, true
+}
+
+func (h *StytchOAuthHandler) requireConsumerMode(w http.ResponseWriter) bool {
+	if h.cfg.Kind == StytchOAuthKindConsumer {
+		return true
+	}
+	writeJSONError(w, http.StatusBadRequest, "Stytch B2B authorization is disabled")
+	return false
 }
 
 func (h *StytchOAuthHandler) buildAuthorizeRequest(webReq stytchOAuthWebRequest, claims *middleware.AuthClaims) StytchOAuthAuthorizeRequest {
@@ -310,16 +351,6 @@ func (h *StytchOAuthHandler) buildAuthorizeRequest(webReq stytchOAuthWebRequest,
 		CodeChallengeMethod: webReq.CodeChallengeMethod,
 	}
 
-	if h.cfg.Kind == StytchOAuthKindB2B {
-		req.OrganizationID = h.cfg.OrganizationID
-		req.MemberID = h.cfg.MemberID
-		return req
-	}
-
-	if h.cfg.UserID != "" {
-		req.UserID = h.cfg.UserID
-		return req
-	}
 	req.UserID = h.cfg.UserIDPrefix + claims.User.Id
 	return req
 }

--- a/backend/internal/mcp/stytch_oauth_test.go
+++ b/backend/internal/mcp/stytch_oauth_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -13,6 +14,8 @@ import (
 )
 
 func TestStytchOAuthClientConsumerStartRequest(t *testing.T) {
+	allowUnsafeStytchOAuthTestDomain(t)
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got, want := r.URL.Path, "/v1/idp/oauth/authorize/start"; got != want {
 			t.Fatalf("path = %q, want %q", got, want)
@@ -72,6 +75,8 @@ func TestStytchOAuthClientConsumerStartRequest(t *testing.T) {
 }
 
 func TestStytchOAuthClientConsumerSubmitRequest(t *testing.T) {
+	allowUnsafeStytchOAuthTestDomain(t)
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got, want := r.URL.Path, "/v1/idp/oauth/authorize"; got != want {
 			t.Fatalf("path = %q, want %q", got, want)
@@ -126,6 +131,8 @@ func TestStytchOAuthClientConsumerSubmitRequest(t *testing.T) {
 }
 
 func TestStytchOAuthClientB2BStartRequest(t *testing.T) {
+	allowUnsafeStytchOAuthTestDomain(t)
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got, want := r.URL.Path, "/v1/b2b/idp/oauth/authorize/start"; got != want {
 			t.Fatalf("path = %q, want %q", got, want)
@@ -220,20 +227,171 @@ func TestStytchOAuthHandlerSubmitReturnsRedirectURI(t *testing.T) {
 	assertStringSlice(t, client.submitRequest.Resources, []string{"https://square.degov.ai/mcp"})
 }
 
+func TestStytchOAuthHandlerIgnoresConfiguredFixedUserID(t *testing.T) {
+	client := &fakeStytchOAuthClient{
+		startResponse: StytchOAuthAuthorizeStartResponse{
+			Client: StytchOAuthClientInfo{ClientID: "client-test"},
+		},
+	}
+	handler := NewStytchOAuthHandler(StytchOAuthHandlerConfig{
+		Client:       client,
+		Kind:         StytchOAuthKindConsumer,
+		UserIDPrefix: "degov-square:",
+		UserID:       "configured-static-user",
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/oauth/stytch/authorize/start", bytes.NewReader([]byte(`{"client_id":"client-test","redirect_uri":"https://client.example/callback"}`)))
+	req = req.WithContext(context.WithValue(req.Context(), middleware.UserClaimsKey, &middleware.AuthClaims{
+		User: &types.UserSessInfo{Id: "user-123"},
+	}))
+	rec := httptest.NewRecorder()
+	handler.AuthorizeStart(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body %q", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if got, want := client.startRequest.UserID, "degov-square:user-123"; got != want {
+		t.Fatalf("start user_id = %q, want %q", got, want)
+	}
+}
+
+func TestStytchOAuthHandlerB2BModeIsDisabled(t *testing.T) {
+	client := &fakeStytchOAuthClient{}
+	handler := NewStytchOAuthHandler(StytchOAuthHandlerConfig{
+		Client:         client,
+		Kind:           StytchOAuthKindB2B,
+		OrganizationID: "org-test",
+		MemberID:       "member-test",
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/oauth/stytch/authorize/start", bytes.NewReader([]byte(`{"client_id":"client-test","redirect_uri":"https://client.example/callback"}`)))
+	req = req.WithContext(context.WithValue(req.Context(), middleware.UserClaimsKey, &middleware.AuthClaims{
+		User: &types.UserSessInfo{Id: "user-123"},
+	}))
+	rec := httptest.NewRecorder()
+	handler.AuthorizeStart(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d, body %q", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	if client.startCalls != 0 {
+		t.Fatalf("startCalls = %d, want 0", client.startCalls)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got, want := body["error"], "Stytch B2B authorization is disabled"; got != want {
+		t.Fatalf("error = %q, want %q", got, want)
+	}
+}
+
+func TestStytchOAuthHandlerReturnsGenericStartError(t *testing.T) {
+	client := &fakeStytchOAuthClient{err: errors.New("project-test secret-test upstream detail")}
+	handler := NewStytchOAuthHandler(StytchOAuthHandlerConfig{
+		Client:       client,
+		Kind:         StytchOAuthKindConsumer,
+		UserIDPrefix: "degov-square:",
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/oauth/stytch/authorize/start", bytes.NewReader([]byte(`{"client_id":"client-test","redirect_uri":"https://client.example/callback"}`)))
+	req = req.WithContext(context.WithValue(req.Context(), middleware.UserClaimsKey, &middleware.AuthClaims{
+		User: &types.UserSessInfo{Id: "user-123"},
+	}))
+	rec := httptest.NewRecorder()
+	handler.AuthorizeStart(rec, req)
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d, body %q", rec.Code, http.StatusBadGateway, rec.Body.String())
+	}
+	var body map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got, want := body["error"], "Stytch authorization request failed"; got != want {
+		t.Fatalf("error = %q, want %q", got, want)
+	}
+}
+
+func TestStytchOAuthHandlerReturnsGenericSubmitError(t *testing.T) {
+	client := &fakeStytchOAuthClient{err: errors.New("project-test secret-test upstream detail")}
+	handler := NewStytchOAuthHandler(StytchOAuthHandlerConfig{
+		Client:       client,
+		Kind:         StytchOAuthKindConsumer,
+		UserIDPrefix: "degov-square:",
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/oauth/stytch/authorize/submit", bytes.NewReader([]byte(`{"client_id":"client-test","redirect_uri":"https://client.example/callback","consent_granted":true}`)))
+	req = req.WithContext(context.WithValue(req.Context(), middleware.UserClaimsKey, &middleware.AuthClaims{
+		User: &types.UserSessInfo{Id: "user-123"},
+	}))
+	rec := httptest.NewRecorder()
+	handler.AuthorizeSubmit(rec, req)
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d, body %q", rec.Code, http.StatusBadGateway, rec.Body.String())
+	}
+	var body map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got, want := body["error"], "Stytch authorization submit failed"; got != want {
+		t.Fatalf("error = %q, want %q", got, want)
+	}
+}
+
+func TestValidateStytchOAuthDomain(t *testing.T) {
+	t.Parallel()
+
+	for _, domain := range []string{"https://api.stytch.com", "https://test.stytch.com"} {
+		if err := validateStytchOAuthDomain(domain); err != nil {
+			t.Fatalf("validateStytchOAuthDomain(%q) returned error: %v", domain, err)
+		}
+	}
+
+	for _, domain := range []string{"", "http://api.stytch.com", "https://evil.example", "https://api.stytch.com.evil.example"} {
+		if err := validateStytchOAuthDomain(domain); err == nil {
+			t.Fatalf("validateStytchOAuthDomain(%q) returned nil, want error", domain)
+		}
+	}
+}
+
+func TestStytchOAuthClientRejectsUnsafeDomainBeforeRequest(t *testing.T) {
+	client := NewStytchOAuthClient(StytchOAuthClientConfig{
+		Domain:    "http://api.stytch.com",
+		ProjectID: "project-test",
+		Secret:    "secret-test",
+		Kind:      StytchOAuthKindConsumer,
+		HTTPClient: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			t.Fatal("HTTP client should not be called for unsafe domain")
+			return nil, nil
+		}).client(),
+	})
+
+	_, err := client.AuthorizeStart(context.Background(), StytchOAuthAuthorizeStartRequest{})
+	if err == nil {
+		t.Fatal("AuthorizeStart returned nil error, want unsafe domain error")
+	}
+}
+
 type fakeStytchOAuthClient struct {
 	startRequest   StytchOAuthAuthorizeStartRequest
 	startResponse  StytchOAuthAuthorizeStartResponse
 	submitRequest  StytchOAuthAuthorizeSubmitRequest
 	submitResponse StytchOAuthAuthorizeSubmitResponse
 	err            error
+	startCalls     int
+	submitCalls    int
 }
 
 func (c *fakeStytchOAuthClient) AuthorizeStart(_ context.Context, req StytchOAuthAuthorizeStartRequest) (StytchOAuthAuthorizeStartResponse, error) {
+	c.startCalls++
 	c.startRequest = req
 	return c.startResponse, c.err
 }
 
 func (c *fakeStytchOAuthClient) AuthorizeSubmit(_ context.Context, req StytchOAuthAuthorizeSubmitRequest) (StytchOAuthAuthorizeSubmitResponse, error) {
+	c.submitCalls++
 	c.submitRequest = req
 	return c.submitResponse, c.err
 }
@@ -279,4 +437,23 @@ func assertStringSlice(t *testing.T, got []string, want []string) {
 			t.Fatalf("slice = %v, want %v", got, want)
 		}
 	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func (f roundTripFunc) client() *http.Client {
+	return &http.Client{Transport: f}
+}
+
+func allowUnsafeStytchOAuthTestDomain(t *testing.T) {
+	t.Helper()
+	previous := allowUnsafeStytchOAuthDomain
+	allowUnsafeStytchOAuthDomain = true
+	t.Cleanup(func() {
+		allowUnsafeStytchOAuthDomain = previous
+	})
 }

--- a/backend/internal/mcp/stytch_oauth_test.go
+++ b/backend/internal/mcp/stytch_oauth_test.go
@@ -1,0 +1,282 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ringecosystem/degov-square/internal/middleware"
+	"github.com/ringecosystem/degov-square/types"
+)
+
+func TestStytchOAuthClientConsumerStartRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/v1/idp/oauth/authorize/start"; got != want {
+			t.Fatalf("path = %q, want %q", got, want)
+		}
+		if got, want := r.Method, http.MethodPost; got != want {
+			t.Fatalf("method = %q, want %q", got, want)
+		}
+		projectID, secret, ok := r.BasicAuth()
+		if !ok || projectID != "project-test" || secret != "secret-test" {
+			t.Fatalf("basic auth = %q/%q/%v, want project-test/secret-test/true", projectID, secret, ok)
+		}
+
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		assertJSONValue(t, body, "client_id", "client-test")
+		assertJSONValue(t, body, "redirect_uri", "https://client.example/callback")
+		assertJSONValue(t, body, "response_type", "code")
+		assertJSONValue(t, body, "user_id", "degov-square:user-123")
+		assertJSONArray(t, body, "scopes", []string{"openid", "degov.mcp.read"})
+		if _, ok := body["resources"]; ok {
+			t.Fatal("start request included resources; want resources only on submit")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"client":{"client_id":"client-test","client_name":"Test App"},"consent_required":true,"scope_results":[{"scope":"openid","description":"Profile","is_grantable":true}],"status_code":200}`))
+	}))
+	defer server.Close()
+
+	client := NewStytchOAuthClient(StytchOAuthClientConfig{
+		Domain:    server.URL,
+		ProjectID: "project-test",
+		Secret:    "secret-test",
+		Kind:      StytchOAuthKindConsumer,
+	})
+
+	resp, err := client.AuthorizeStart(context.Background(), StytchOAuthAuthorizeStartRequest{
+		StytchOAuthAuthorizeRequest: StytchOAuthAuthorizeRequest{
+			ClientID:     "client-test",
+			RedirectURI:  "https://client.example/callback",
+			ResponseType: "code",
+			Scopes:       []string{"openid", "degov.mcp.read"},
+			UserID:       "degov-square:user-123",
+		},
+	})
+	if err != nil {
+		t.Fatalf("AuthorizeStart returned error: %v", err)
+	}
+	if resp.Client.ClientName != "Test App" {
+		t.Fatalf("client_name = %q, want Test App", resp.Client.ClientName)
+	}
+	if !resp.ConsentRequired {
+		t.Fatal("consent_required = false, want true")
+	}
+}
+
+func TestStytchOAuthClientConsumerSubmitRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/v1/idp/oauth/authorize"; got != want {
+			t.Fatalf("path = %q, want %q", got, want)
+		}
+
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		assertJSONValue(t, body, "client_id", "client-test")
+		assertJSONValue(t, body, "state", "state-test")
+		assertJSONValue(t, body, "nonce", "nonce-test")
+		assertJSONValue(t, body, "code_challenge", "challenge-test")
+		assertJSONValue(t, body, "code_challenge_method", "S256")
+		assertJSONValue(t, body, "consent_granted", true)
+		assertJSONArray(t, body, "resources", []string{"https://square.degov.ai/mcp"})
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"redirect_uri":"https://client.example/callback?code=abc","status_code":200}`))
+	}))
+	defer server.Close()
+
+	client := NewStytchOAuthClient(StytchOAuthClientConfig{
+		Domain:    server.URL,
+		ProjectID: "project-test",
+		Secret:    "secret-test",
+		Kind:      StytchOAuthKindConsumer,
+	})
+
+	resp, err := client.AuthorizeSubmit(context.Background(), StytchOAuthAuthorizeSubmitRequest{
+		StytchOAuthAuthorizeRequest: StytchOAuthAuthorizeRequest{
+			ClientID:            "client-test",
+			RedirectURI:         "https://client.example/callback",
+			ResponseType:        "code",
+			Scopes:              []string{"openid"},
+			UserID:              "user-test",
+			State:               "state-test",
+			Nonce:               "nonce-test",
+			CodeChallenge:       "challenge-test",
+			CodeChallengeMethod: "S256",
+			Resources:           []string{"https://square.degov.ai/mcp"},
+		},
+		ConsentGranted: true,
+	})
+	if err != nil {
+		t.Fatalf("AuthorizeSubmit returned error: %v", err)
+	}
+	if got, want := resp.RedirectURI, "https://client.example/callback?code=abc"; got != want {
+		t.Fatalf("redirect_uri = %q, want %q", got, want)
+	}
+}
+
+func TestStytchOAuthClientB2BStartRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/v1/b2b/idp/oauth/authorize/start"; got != want {
+			t.Fatalf("path = %q, want %q", got, want)
+		}
+
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		assertJSONValue(t, body, "organization_id", "org-test")
+		assertJSONValue(t, body, "member_id", "member-test")
+		if _, ok := body["user_id"]; ok {
+			t.Fatal("b2b request included user_id")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"client":{"client_id":"client-test","client_name":"B2B App"},"consent_required":false,"scope_results":[],"status_code":200}`))
+	}))
+	defer server.Close()
+
+	client := NewStytchOAuthClient(StytchOAuthClientConfig{
+		Domain:    server.URL,
+		ProjectID: "project-test",
+		Secret:    "secret-test",
+		Kind:      StytchOAuthKindB2B,
+	})
+
+	_, err := client.AuthorizeStart(context.Background(), StytchOAuthAuthorizeStartRequest{
+		StytchOAuthAuthorizeRequest: StytchOAuthAuthorizeRequest{
+			ClientID:       "client-test",
+			RedirectURI:    "https://client.example/callback",
+			ResponseType:   "code",
+			Scopes:         []string{"openid"},
+			OrganizationID: "org-test",
+			MemberID:       "member-test",
+		},
+	})
+	if err != nil {
+		t.Fatalf("AuthorizeStart returned error: %v", err)
+	}
+}
+
+func TestStytchOAuthHandlerStartUnauthorized(t *testing.T) {
+	handler := NewStytchOAuthHandler(StytchOAuthHandlerConfig{
+		Client: &fakeStytchOAuthClient{},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/oauth/stytch/authorize/start", bytes.NewReader([]byte(`{}`)))
+	rec := httptest.NewRecorder()
+	handler.AuthorizeStart(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestStytchOAuthHandlerSubmitReturnsRedirectURI(t *testing.T) {
+	client := &fakeStytchOAuthClient{
+		submitResponse: StytchOAuthAuthorizeSubmitResponse{
+			RedirectURI: "https://client.example/callback?code=abc",
+		},
+	}
+	handler := NewStytchOAuthHandler(StytchOAuthHandlerConfig{
+		Client:        client,
+		Kind:          StytchOAuthKindConsumer,
+		UserIDPrefix:  "degov-square:",
+		OAuthResource: "https://square.degov.ai/mcp",
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/oauth/stytch/authorize/submit", bytes.NewReader([]byte(`{"client_id":"client-test","redirect_uri":"https://client.example/callback","scope":"openid degov.mcp.read","consent_granted":true}`)))
+	req = req.WithContext(context.WithValue(req.Context(), middleware.UserClaimsKey, &middleware.AuthClaims{
+		User: &types.UserSessInfo{Id: "user-123"},
+	}))
+	rec := httptest.NewRecorder()
+	handler.AuthorizeSubmit(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body %q", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var body StytchOAuthAuthorizeSubmitResponse
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got, want := body.RedirectURI, "https://client.example/callback?code=abc"; got != want {
+		t.Fatalf("redirect_uri = %q, want %q", got, want)
+	}
+	if got, want := client.submitRequest.UserID, "degov-square:user-123"; got != want {
+		t.Fatalf("submit user_id = %q, want %q", got, want)
+	}
+	assertStringSlice(t, client.submitRequest.Scopes, []string{"openid", "degov.mcp.read"})
+	assertStringSlice(t, client.submitRequest.Resources, []string{"https://square.degov.ai/mcp"})
+}
+
+type fakeStytchOAuthClient struct {
+	startRequest   StytchOAuthAuthorizeStartRequest
+	startResponse  StytchOAuthAuthorizeStartResponse
+	submitRequest  StytchOAuthAuthorizeSubmitRequest
+	submitResponse StytchOAuthAuthorizeSubmitResponse
+	err            error
+}
+
+func (c *fakeStytchOAuthClient) AuthorizeStart(_ context.Context, req StytchOAuthAuthorizeStartRequest) (StytchOAuthAuthorizeStartResponse, error) {
+	c.startRequest = req
+	return c.startResponse, c.err
+}
+
+func (c *fakeStytchOAuthClient) AuthorizeSubmit(_ context.Context, req StytchOAuthAuthorizeSubmitRequest) (StytchOAuthAuthorizeSubmitResponse, error) {
+	c.submitRequest = req
+	return c.submitResponse, c.err
+}
+
+func assertJSONValue(t *testing.T, body map[string]any, key string, want any) {
+	t.Helper()
+	got, ok := body[key]
+	if !ok {
+		t.Fatalf("body missing key %q", key)
+	}
+	if got != want {
+		t.Fatalf("body[%q] = %#v, want %#v", key, got, want)
+	}
+}
+
+func assertJSONArray(t *testing.T, body map[string]any, key string, want []string) {
+	t.Helper()
+	value, ok := body[key]
+	if !ok {
+		t.Fatalf("body missing key %q", key)
+	}
+	items, ok := value.([]any)
+	if !ok {
+		t.Fatalf("body[%q] = %#v, want JSON array", key, value)
+	}
+	if len(items) != len(want) {
+		t.Fatalf("body[%q] length = %d, want %d", key, len(items), len(want))
+	}
+	for i := range want {
+		if items[i] != want[i] {
+			t.Fatalf("body[%q][%d] = %#v, want %q", key, i, items[i], want[i])
+		}
+	}
+}
+
+func assertStringSlice(t *testing.T, got []string, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("slice = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("slice = %v, want %v", got, want)
+		}
+	}
+}

--- a/web/.env.example
+++ b/web/.env.example
@@ -4,6 +4,9 @@ NEXT_PUBLIC_PROJECT_ID=
 # GraphQL API Endpoint
 NEXT_PUBLIC_GRAPHQL_ENDPOINT=
 
+# REST API Endpoint. Optional; defaults to NEXT_PUBLIC_GRAPHQL_ENDPOINT without trailing /graphql.
+NEXT_PUBLIC_API_ENDPOINT=
+
 # Base Mini App Configuration
 NEXT_PUBLIC_OWNER_ADDRESS=
 

--- a/web/src/app/oauth/authorize/oauth-authorize-client.tsx
+++ b/web/src/app/oauth/authorize/oauth-authorize-client.tsx
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/button';
 import { useSiweAuth } from '@/hooks/useSiweAuth';
 import {
   getOAuthAuthorizeParams,
+  OAuthApiError,
   stytchAuthorizeStart,
   stytchAuthorizeSubmit,
   type StytchOAuthAuthorizeStartResponse,
@@ -33,6 +34,7 @@ export const OAuthAuthorizeClient = () => {
   const [isStarting, setIsStarting] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState('');
+  const [needsSignIn, setNeedsSignIn] = useState(false);
 
   const requestKey = `${token ?? ''}:${queryString}`;
   const hasRequiredParams = Boolean(authorizeParams.client_id && authorizeParams.redirect_uri);
@@ -46,11 +48,20 @@ export const OAuthAuthorizeClient = () => {
 
       setIsStarting(true);
       setError('');
+      setNeedsSignIn(false);
       setStartedKey(`${activeToken}:${queryString}`);
       try {
         const response = await stytchAuthorizeStart(authorizeParams, activeToken);
         setStartResponse(response);
-      } catch (err) {
+	    } catch (err) {
+	        if (err instanceof OAuthApiError && err.status === 401) {
+	          useAuthStore.getState().clearAuth();
+	          setStartResponse(null);
+	          setStartedKey('');
+	          setNeedsSignIn(true);
+	          setError('Session expired. Please sign in again.');
+          return;
+        }
         setError(err instanceof Error ? err.message : 'Failed to load authorization request');
       } finally {
         setIsStarting(false);
@@ -68,8 +79,10 @@ export const OAuthAuthorizeClient = () => {
 
   const signIn = useCallback(async () => {
     setError('');
+    setNeedsSignIn(false);
     const result = await authenticate();
     if (!result.success) {
+      setNeedsSignIn(true);
       setError(result.error || 'Sign in failed');
       return;
     }
@@ -86,6 +99,7 @@ export const OAuthAuthorizeClient = () => {
 
       setIsSubmitting(true);
       setError('');
+      setNeedsSignIn(false);
       try {
         const response = await stytchAuthorizeSubmit(authorizeParams, activeToken, consentGranted);
         if (!response.redirect_uri) {
@@ -93,7 +107,15 @@ export const OAuthAuthorizeClient = () => {
           return;
         }
         window.location.assign(response.redirect_uri);
-      } catch (err) {
+	      } catch (err) {
+	        if (err instanceof OAuthApiError && err.status === 401) {
+	          useAuthStore.getState().clearAuth();
+	          setStartResponse(null);
+	          setStartedKey('');
+	          setNeedsSignIn(true);
+	          setError('Session expired. Please sign in again.');
+          return;
+        }
         setError(err instanceof Error ? err.message : 'Authorization failed');
       } finally {
         setIsSubmitting(false);
@@ -148,7 +170,7 @@ export const OAuthAuthorizeClient = () => {
                 disabled={!canAuthenticate || isAuthenticating}
                 className="rounded-[100px]"
               >
-                {isAuthenticating ? 'Signing in...' : 'Sign in'}
+                {isAuthenticating ? 'Signing in...' : needsSignIn ? 'Sign in again' : 'Sign in'}
               </Button>
             </div>
           </div>

--- a/web/src/app/oauth/authorize/oauth-authorize-client.tsx
+++ b/web/src/app/oauth/authorize/oauth-authorize-client.tsx
@@ -1,0 +1,233 @@
+'use client';
+
+import { ShieldCheck } from 'lucide-react';
+import { useSearchParams } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { ConnectButton } from '@/components/connect-button';
+import { Button } from '@/components/ui/button';
+import { useSiweAuth } from '@/hooks/useSiweAuth';
+import {
+  getOAuthAuthorizeParams,
+  stytchAuthorizeStart,
+  stytchAuthorizeSubmit,
+  type StytchOAuthAuthorizeStartResponse,
+  type StytchOAuthScopeResult
+} from '@/lib/api/oauth';
+import { getToken, useAuthStore } from '@/stores/auth';
+
+export const OAuthAuthorizeClient = () => {
+  const searchParams = useSearchParams();
+  const queryString = searchParams.toString();
+  const authorizeParams = useMemo(
+    () => getOAuthAuthorizeParams(new URLSearchParams(queryString)),
+    [queryString]
+  );
+
+  const { token } = useAuthStore();
+  const { authenticate, isAuthenticating, canAuthenticate } = useSiweAuth();
+  const [startResponse, setStartResponse] = useState<StytchOAuthAuthorizeStartResponse | null>(
+    null
+  );
+  const [startedKey, setStartedKey] = useState('');
+  const [isStarting, setIsStarting] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState('');
+
+  const requestKey = `${token ?? ''}:${queryString}`;
+  const hasRequiredParams = Boolean(authorizeParams.client_id && authorizeParams.redirect_uri);
+
+  const startAuthorization = useCallback(
+    async (authToken?: string | null) => {
+      const activeToken = authToken || getToken() || token;
+      if (!activeToken || !hasRequiredParams) {
+        return;
+      }
+
+      setIsStarting(true);
+      setError('');
+      setStartedKey(`${activeToken}:${queryString}`);
+      try {
+        const response = await stytchAuthorizeStart(authorizeParams, activeToken);
+        setStartResponse(response);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load authorization request');
+      } finally {
+        setIsStarting(false);
+      }
+    },
+    [authorizeParams, hasRequiredParams, queryString, token]
+  );
+
+  useEffect(() => {
+    if (!token || !hasRequiredParams || startedKey === requestKey) {
+      return;
+    }
+    void startAuthorization(token);
+  }, [hasRequiredParams, requestKey, startAuthorization, startedKey, token]);
+
+  const signIn = useCallback(async () => {
+    setError('');
+    const result = await authenticate();
+    if (!result.success) {
+      setError(result.error || 'Sign in failed');
+      return;
+    }
+    await startAuthorization(result.token || getToken());
+  }, [authenticate, startAuthorization]);
+
+  const submitConsent = useCallback(
+    async (consentGranted: boolean) => {
+      const activeToken = getToken() || token;
+      if (!activeToken) {
+        setError('Please sign in first');
+        return;
+      }
+
+      setIsSubmitting(true);
+      setError('');
+      try {
+        const response = await stytchAuthorizeSubmit(authorizeParams, activeToken, consentGranted);
+        if (!response.redirect_uri) {
+          setError('Authorization response did not include a redirect URL');
+          return;
+        }
+        window.location.assign(response.redirect_uri);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Authorization failed');
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [authorizeParams, token]
+  );
+
+  const clientName =
+    startResponse?.client.client_name ||
+    startResponse?.client.client_id ||
+    authorizeParams.client_id ||
+    'Unknown app';
+  const scopes = startResponse?.scope_results?.length
+    ? startResponse.scope_results
+    : authorizeParams.scope
+      ? authorizeParams.scope.split(/\s+/).map((scope) => ({
+          scope,
+          description: '',
+          is_grantable: true
+        }))
+      : [];
+
+  return (
+    <div className="mx-auto flex w-full max-w-[520px] flex-col gap-[16px] px-[20px]">
+      <div className="bg-card border-border flex flex-col gap-[20px] rounded-[8px] border p-[24px] shadow-sm">
+        <div className="flex items-start gap-[12px]">
+          <div className="bg-secondary text-secondary-foreground flex size-[40px] flex-shrink-0 items-center justify-center rounded-[8px]">
+            <ShieldCheck size={20} />
+          </div>
+          <div className="min-w-0">
+            <h1 className="text-[20px] leading-[1.3] font-semibold">Authorize app</h1>
+            <p className="text-muted-foreground mt-[4px] text-[14px] leading-[1.5]">
+              {startResponse ? `${clientName} wants access to DeGov Square.` : clientName}
+            </p>
+          </div>
+        </div>
+
+        {!hasRequiredParams && (
+          <Notice message="Missing OAuth request details. Please return to the app and try again." />
+        )}
+
+        {hasRequiredParams && !token && (
+          <div className="flex flex-col gap-[14px]">
+            <p className="text-muted-foreground text-[14px] leading-[1.5]">
+              Connect your wallet and sign in to continue.
+            </p>
+            <div className="flex flex-wrap items-center gap-[10px]">
+              <ConnectButton />
+              <Button
+                onClick={signIn}
+                disabled={!canAuthenticate || isAuthenticating}
+                className="rounded-[100px]"
+              >
+                {isAuthenticating ? 'Signing in...' : 'Sign in'}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {hasRequiredParams && token && (
+          <div className="flex flex-col gap-[18px]">
+            {isStarting && (
+              <p className="text-muted-foreground text-[14px]">Loading authorization request...</p>
+            )}
+
+            {startResponse && (
+              <>
+                <div className="flex flex-col gap-[8px]">
+                  <p className="text-[14px] font-medium">Requested access</p>
+                  <ScopeList scopes={scopes} />
+                </div>
+
+                <div className="flex flex-col-reverse gap-[10px] sm:flex-row sm:justify-end">
+                  <Button
+                    variant="outline"
+                    onClick={() => submitConsent(false)}
+                    disabled={isSubmitting}
+                    className="rounded-[100px]"
+                  >
+                    Deny
+                  </Button>
+                  <Button
+                    onClick={() => submitConsent(true)}
+                    disabled={isSubmitting}
+                    className="rounded-[100px]"
+                  >
+                    {isSubmitting ? 'Submitting...' : 'Allow'}
+                  </Button>
+                </div>
+              </>
+            )}
+
+            {!isStarting && !startResponse && (
+              <Button
+                onClick={() => startAuthorization(token)}
+                disabled={isStarting}
+                className="self-start rounded-[100px]"
+              >
+                Load request
+              </Button>
+            )}
+          </div>
+        )}
+
+        {error && <Notice message={error} />}
+      </div>
+    </div>
+  );
+};
+
+const ScopeList = ({ scopes }: { scopes: StytchOAuthScopeResult[] }) => {
+  if (!scopes.length) {
+    return <p className="text-muted-foreground text-[14px]">No scopes requested.</p>;
+  }
+
+  return (
+    <div className="border-border divide-border overflow-hidden rounded-[8px] border">
+      {scopes.map((scope) => (
+        <div key={scope.scope} className="flex flex-col gap-[3px] px-[12px] py-[10px]">
+          <span className="text-[14px] font-medium">{scope.scope}</span>
+          {scope.description && (
+            <span className="text-muted-foreground text-[13px] leading-[1.4]">
+              {scope.description}
+            </span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const Notice = ({ message }: { message: string }) => (
+  <div className="border-destructive/30 bg-destructive/10 text-destructive rounded-[8px] border px-[12px] py-[10px] text-[14px] leading-[1.5]">
+    {message}
+  </div>
+);

--- a/web/src/app/oauth/authorize/page.tsx
+++ b/web/src/app/oauth/authorize/page.tsx
@@ -1,0 +1,19 @@
+import { Suspense } from 'react';
+
+import { OAuthAuthorizeClient } from './oauth-authorize-client';
+
+export default function OAuthAuthorizePage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="mx-auto flex w-full max-w-[520px] flex-col gap-[16px] px-[20px]">
+          <div className="bg-card border-border rounded-[8px] border p-[24px]">
+            <p className="text-muted-foreground text-[14px]">Loading authorization request...</p>
+          </div>
+        </div>
+      }
+    >
+      <OAuthAuthorizeClient />
+    </Suspense>
+  );
+}

--- a/web/src/lib/api/base.ts
+++ b/web/src/lib/api/base.ts
@@ -1,0 +1,19 @@
+const trimTrailingSlash = (value: string) => value.replace(/\/+$/, '');
+
+export const getApiBase = () => {
+  const apiEndpoint = process.env.NEXT_PUBLIC_API_ENDPOINT?.trim();
+  if (apiEndpoint) {
+    return trimTrailingSlash(apiEndpoint);
+  }
+
+  const graphqlEndpoint = process.env.NEXT_PUBLIC_GRAPHQL_ENDPOINT?.trim();
+  if (graphqlEndpoint) {
+    return trimTrailingSlash(graphqlEndpoint.replace(/\/graphql\/?$/, ''));
+  }
+
+  if (typeof window !== 'undefined') {
+    return window.location.origin;
+  }
+
+  return '';
+};

--- a/web/src/lib/api/oauth.ts
+++ b/web/src/lib/api/oauth.ts
@@ -1,0 +1,88 @@
+import { getApiBase } from './base';
+
+export interface OAuthAuthorizeParams {
+  client_id: string;
+  redirect_uri: string;
+  response_type: string;
+  scope: string;
+  state: string;
+  nonce: string;
+  code_challenge: string;
+  code_challenge_method: string;
+}
+
+export interface StytchOAuthClientInfo {
+  client_id: string;
+  client_name: string;
+  client_description?: string;
+  client_type?: string;
+  logo_url?: string;
+}
+
+export interface StytchOAuthScopeResult {
+  scope: string;
+  description?: string;
+  is_grantable: boolean;
+}
+
+export interface StytchOAuthAuthorizeStartResponse {
+  client: StytchOAuthClientInfo;
+  consent_required: boolean;
+  scope_results: StytchOAuthScopeResult[];
+}
+
+export interface StytchOAuthAuthorizeSubmitResponse {
+  redirect_uri: string;
+}
+
+export const getOAuthAuthorizeParams = (searchParams: URLSearchParams): OAuthAuthorizeParams => {
+  return {
+    client_id: searchParams.get('client_id') ?? '',
+    redirect_uri: searchParams.get('redirect_uri') ?? '',
+    response_type: searchParams.get('response_type') || 'code',
+    scope: searchParams.get('scope') ?? '',
+    state: searchParams.get('state') ?? '',
+    nonce: searchParams.get('nonce') ?? '',
+    code_challenge: searchParams.get('code_challenge') ?? '',
+    code_challenge_method: searchParams.get('code_challenge_method') ?? ''
+  };
+};
+
+export const stytchAuthorizeStart = async (
+  params: OAuthAuthorizeParams,
+  token: string
+): Promise<StytchOAuthAuthorizeStartResponse> => {
+  return postStytchOAuth('/api/oauth/stytch/authorize/start', params, token);
+};
+
+export const stytchAuthorizeSubmit = async (
+  params: OAuthAuthorizeParams,
+  token: string,
+  consentGranted: boolean
+): Promise<StytchOAuthAuthorizeSubmitResponse> => {
+  return postStytchOAuth(
+    '/api/oauth/stytch/authorize/submit',
+    { ...params, consent_granted: consentGranted },
+    token
+  );
+};
+
+const postStytchOAuth = async <T>(path: string, body: unknown, token: string): Promise<T> => {
+  const response = await fetch(`${getApiBase()}${path}`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(body)
+  });
+
+  const data = await response.json().catch(() => null);
+  if (!response.ok) {
+    const message =
+      typeof data?.error === 'string' ? data.error : `Request failed: ${response.status}`;
+    throw new Error(message);
+  }
+
+  return data as T;
+};

--- a/web/src/lib/api/oauth.ts
+++ b/web/src/lib/api/oauth.ts
@@ -35,6 +35,16 @@ export interface StytchOAuthAuthorizeSubmitResponse {
   redirect_uri: string;
 }
 
+export class OAuthApiError extends Error {
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = 'OAuthApiError';
+    this.status = status;
+  }
+}
+
 export const getOAuthAuthorizeParams = (searchParams: URLSearchParams): OAuthAuthorizeParams => {
   return {
     client_id: searchParams.get('client_id') ?? '',
@@ -81,7 +91,7 @@ const postStytchOAuth = async <T>(path: string, body: unknown, token: string): P
   if (!response.ok) {
     const message =
       typeof data?.error === 'string' ? data.error : `Request failed: ${response.status}`;
-    throw new Error(message);
+    throw new OAuthApiError(message, response.status);
   }
 
   return data as T;


### PR DESCRIPTION
## Summary
- Add a Square-hosted `/oauth/authorize` page for Stytch Connected Apps OAuth consent.
- Add authenticated backend proxy routes for Stytch `authorize/start` and `authorize` submit.
- Keep the active authorize flow consumer-only and bind grants to the authenticated Square user via `MCP_STYTCH_OAUTH_USER_ID_PREFIX + user id`.
- Return generic browser-facing Stytch errors, require allowed HTTPS Stytch domains, and clear stale auth state on 401.

## Security Notes
- B2B/static-principal authorization is intentionally not enabled in this PR because it needs an explicit per-user Stytch session/ownership binding.
- `MCP_STYTCH_OAUTH_SECRET` is backend-only and never exposed to the web app.

## Test Plan
- `cd backend && go test -count=1 ./internal/config ./internal/mcp ./cmd`
- `cd backend && just build`
- `cd web && pnpm exec tsc --noEmit`
- `cd web && pnpm build`

## Notes
`pnpm build` exits 0, but the project still prints the existing Next/ESLint circular-structure diagnostic during linting.