### PR TITLE
fix(mcp): clarify Stytch OAuth account mapping

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -49,11 +49,7 @@ JWT_SECRET=your_jwt_secret
 # MCP_STYTCH_OAUTH_DOMAIN=https://test.stytch.com
 # MCP_STYTCH_OAUTH_PROJECT_ID=
 # MCP_STYTCH_OAUTH_SECRET=
-# MCP_STYTCH_OAUTH_KIND=consumer # consumer or b2b
 # MCP_STYTCH_OAUTH_USER_ID_PREFIX=degov-square:
-# MCP_STYTCH_OAUTH_USER_ID=
-# MCP_STYTCH_OAUTH_ORGANIZATION_ID=
-# MCP_STYTCH_OAUTH_MEMBER_ID=
 # Proposal summary MCP reads cached summaries by default. Set true to allow new external summary generation.
 # MCP_PROPOSAL_SUMMARY_GENERATE_ENABLED=false
 # MCP_PROPOSAL_SUMMARY_TIMEOUT=30s

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -207,16 +207,12 @@ func registerStytchOAuthRoutes(mux *http.ServeMux, middlewareChain *middleware.C
 		Domain:     cfg.GetMCPStytchOAuthDomain(),
 		ProjectID:  cfg.GetMCPStytchOAuthProjectID(),
 		Secret:     cfg.GetMCPStytchOAuthSecret(),
-		Kind:       mcpserver.StytchOAuthKind(cfg.GetMCPStytchOAuthKind()),
 		HTTPClient: httpClient,
 	})
 	handler := mcpserver.NewStytchOAuthHandler(mcpserver.StytchOAuthHandlerConfig{
-		Client:         client,
-		Kind:           mcpserver.StytchOAuthKind(cfg.GetMCPStytchOAuthKind()),
-		UserIDPrefix:   cfg.GetMCPStytchOAuthUserIDPrefix(),
-		OrganizationID: cfg.GetMCPStytchOAuthOrganizationID(),
-		MemberID:       cfg.GetMCPStytchOAuthMemberID(),
-		OAuthResource:  cfg.GetMCPOAuthResource(),
+		Client:        client,
+		UserIDPrefix:  cfg.GetMCPStytchOAuthUserIDPrefix(),
+		OAuthResource: cfg.GetMCPOAuthResource(),
 	})
 	mux.Handle("/api/oauth/stytch/authorize/start", middlewareChain.Then(http.HandlerFunc(handler.AuthorizeStart)))
 	mux.Handle("/api/oauth/stytch/authorize/submit", middlewareChain.Then(http.HandlerFunc(handler.AuthorizeSubmit)))

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -122,11 +122,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("MCP_STYTCH_OAUTH_DOMAIN", "")
 	v.SetDefault("MCP_STYTCH_OAUTH_PROJECT_ID", "")
 	v.SetDefault("MCP_STYTCH_OAUTH_SECRET", "")
-	v.SetDefault("MCP_STYTCH_OAUTH_KIND", "consumer")
 	v.SetDefault("MCP_STYTCH_OAUTH_USER_ID_PREFIX", "degov-square:")
-	v.SetDefault("MCP_STYTCH_OAUTH_USER_ID", "")
-	v.SetDefault("MCP_STYTCH_OAUTH_ORGANIZATION_ID", "")
-	v.SetDefault("MCP_STYTCH_OAUTH_MEMBER_ID", "")
 	v.SetDefault("MCP_PROPOSAL_SUMMARY_GENERATE_ENABLED", false)
 	v.SetDefault("MCP_PROPOSAL_SUMMARY_TIMEOUT", "30s")
 
@@ -294,28 +290,8 @@ func (c *Config) GetMCPStytchOAuthSecret() string {
 	return c.viper.GetString("MCP_STYTCH_OAUTH_SECRET")
 }
 
-func (c *Config) GetMCPStytchOAuthKind() string {
-	kind := strings.ToLower(strings.TrimSpace(c.viper.GetString("MCP_STYTCH_OAUTH_KIND")))
-	if kind == "b2b" {
-		return kind
-	}
-	return "consumer"
-}
-
 func (c *Config) GetMCPStytchOAuthUserIDPrefix() string {
 	return c.viper.GetString("MCP_STYTCH_OAUTH_USER_ID_PREFIX")
-}
-
-func (c *Config) GetMCPStytchOAuthUserID() string {
-	return c.viper.GetString("MCP_STYTCH_OAUTH_USER_ID")
-}
-
-func (c *Config) GetMCPStytchOAuthOrganizationID() string {
-	return c.viper.GetString("MCP_STYTCH_OAUTH_ORGANIZATION_ID")
-}
-
-func (c *Config) GetMCPStytchOAuthMemberID() string {
-	return c.viper.GetString("MCP_STYTCH_OAUTH_MEMBER_ID")
 }
 
 func (c *Config) GetMCPProposalSummaryGenerateEnabled() bool {

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -62,20 +62,8 @@ func TestMCPConfigDefaults(t *testing.T) {
 	if got := cfg.GetMCPStytchOAuthSecret(); got != "" {
 		t.Fatalf("GetMCPStytchOAuthSecret() = %q, want empty", got)
 	}
-	if got, want := cfg.GetMCPStytchOAuthKind(), "consumer"; got != want {
-		t.Fatalf("GetMCPStytchOAuthKind() = %q, want %q", got, want)
-	}
 	if got, want := cfg.GetMCPStytchOAuthUserIDPrefix(), "degov-square:"; got != want {
 		t.Fatalf("GetMCPStytchOAuthUserIDPrefix() = %q, want %q", got, want)
-	}
-	if got := cfg.GetMCPStytchOAuthUserID(); got != "" {
-		t.Fatalf("GetMCPStytchOAuthUserID() = %q, want empty", got)
-	}
-	if got := cfg.GetMCPStytchOAuthOrganizationID(); got != "" {
-		t.Fatalf("GetMCPStytchOAuthOrganizationID() = %q, want empty", got)
-	}
-	if got := cfg.GetMCPStytchOAuthMemberID(); got != "" {
-		t.Fatalf("GetMCPStytchOAuthMemberID() = %q, want empty", got)
 	}
 	if cfg.GetMCPProposalSummaryGenerateEnabled() {
 		t.Fatal("GetMCPProposalSummaryGenerateEnabled() = true, want false")
@@ -103,11 +91,7 @@ func TestMCPConfigReadsEnvironment(t *testing.T) {
 	t.Setenv("MCP_STYTCH_OAUTH_DOMAIN", "https://test.stytch.com")
 	t.Setenv("MCP_STYTCH_OAUTH_PROJECT_ID", "project-test")
 	t.Setenv("MCP_STYTCH_OAUTH_SECRET", "secret-test")
-	t.Setenv("MCP_STYTCH_OAUTH_KIND", "b2b")
 	t.Setenv("MCP_STYTCH_OAUTH_USER_ID_PREFIX", "square:")
-	t.Setenv("MCP_STYTCH_OAUTH_USER_ID", "user-fixed")
-	t.Setenv("MCP_STYTCH_OAUTH_ORGANIZATION_ID", "org-test")
-	t.Setenv("MCP_STYTCH_OAUTH_MEMBER_ID", "member-test")
 	t.Setenv("MCP_PROPOSAL_SUMMARY_GENERATE_ENABLED", "true")
 	t.Setenv("MCP_PROPOSAL_SUMMARY_TIMEOUT", "5s")
 	globalConfig = nil
@@ -166,20 +150,8 @@ func TestMCPConfigReadsEnvironment(t *testing.T) {
 	if got, want := cfg.GetMCPStytchOAuthSecret(), "secret-test"; got != want {
 		t.Fatalf("GetMCPStytchOAuthSecret() = %q, want %q", got, want)
 	}
-	if got, want := cfg.GetMCPStytchOAuthKind(), "b2b"; got != want {
-		t.Fatalf("GetMCPStytchOAuthKind() = %q, want %q", got, want)
-	}
 	if got, want := cfg.GetMCPStytchOAuthUserIDPrefix(), "square:"; got != want {
 		t.Fatalf("GetMCPStytchOAuthUserIDPrefix() = %q, want %q", got, want)
-	}
-	if got, want := cfg.GetMCPStytchOAuthUserID(), "user-fixed"; got != want {
-		t.Fatalf("GetMCPStytchOAuthUserID() = %q, want %q", got, want)
-	}
-	if got, want := cfg.GetMCPStytchOAuthOrganizationID(), "org-test"; got != want {
-		t.Fatalf("GetMCPStytchOAuthOrganizationID() = %q, want %q", got, want)
-	}
-	if got, want := cfg.GetMCPStytchOAuthMemberID(), "member-test"; got != want {
-		t.Fatalf("GetMCPStytchOAuthMemberID() = %q, want %q", got, want)
 	}
 	if !cfg.GetMCPProposalSummaryGenerateEnabled() {
 		t.Fatal("GetMCPProposalSummaryGenerateEnabled() = false, want true")

--- a/backend/internal/mcp/stytch_oauth.go
+++ b/backend/internal/mcp/stytch_oauth.go
@@ -22,18 +22,10 @@ const (
 
 var allowUnsafeStytchOAuthDomain bool
 
-type StytchOAuthKind string
-
-const (
-	StytchOAuthKindConsumer StytchOAuthKind = "consumer"
-	StytchOAuthKindB2B      StytchOAuthKind = "b2b"
-)
-
 type StytchOAuthClientConfig struct {
 	Domain     string
 	ProjectID  string
 	Secret     string
-	Kind       StytchOAuthKind
 	HTTPClient *http.Client
 }
 
@@ -53,8 +45,6 @@ type StytchOAuthAuthorizeRequest struct {
 	ResponseType        string   `json:"response_type"`
 	Scopes              []string `json:"scopes"`
 	UserID              string   `json:"user_id,omitempty"`
-	OrganizationID      string   `json:"organization_id,omitempty"`
-	MemberID            string   `json:"member_id,omitempty"`
 	State               string   `json:"state,omitempty"`
 	Nonce               string   `json:"nonce,omitempty"`
 	CodeChallenge       string   `json:"code_challenge,omitempty"`
@@ -96,13 +86,9 @@ type StytchOAuthAuthorizeSubmitResponse struct {
 }
 
 type StytchOAuthHandlerConfig struct {
-	Client         StytchOAuthAuthorizer
-	Kind           StytchOAuthKind
-	UserIDPrefix   string
-	UserID         string
-	OrganizationID string
-	MemberID       string
-	OAuthResource  string
+	Client        StytchOAuthAuthorizer
+	UserIDPrefix  string
+	OAuthResource string
 }
 
 type StytchOAuthHandler struct {
@@ -123,7 +109,6 @@ type stytchOAuthWebRequest struct {
 
 func NewStytchOAuthClient(cfg StytchOAuthClientConfig) *StytchOAuthClient {
 	cfg.Domain = strings.TrimRight(cfg.Domain, "/")
-	cfg.Kind = normalizeStytchOAuthKind(cfg.Kind)
 	client := cfg.HTTPClient
 	if client == nil {
 		client = &http.Client{Timeout: 10 * time.Second}
@@ -144,16 +129,10 @@ func (c *StytchOAuthClient) AuthorizeSubmit(ctx context.Context, req StytchOAuth
 }
 
 func (c *StytchOAuthClient) authorizeStartPath() string {
-	if c.cfg.Kind == StytchOAuthKindB2B {
-		return "/v1/b2b/idp/oauth/authorize/start"
-	}
 	return "/v1/idp/oauth/authorize/start"
 }
 
 func (c *StytchOAuthClient) authorizeSubmitPath() string {
-	if c.cfg.Kind == StytchOAuthKindB2B {
-		return "/v1/b2b/idp/oauth/authorize"
-	}
 	return "/v1/idp/oauth/authorize"
 }
 
@@ -255,7 +234,6 @@ func cleanStytchError(body []byte) string {
 }
 
 func NewStytchOAuthHandler(cfg StytchOAuthHandlerConfig) *StytchOAuthHandler {
-	cfg.Kind = normalizeStytchOAuthKind(cfg.Kind)
 	if cfg.UserIDPrefix == "" {
 		cfg.UserIDPrefix = "degov-square:"
 	}
@@ -265,9 +243,6 @@ func NewStytchOAuthHandler(cfg StytchOAuthHandlerConfig) *StytchOAuthHandler {
 func (h *StytchOAuthHandler) AuthorizeStart(w http.ResponseWriter, r *http.Request) {
 	claims, ok := h.requireAuth(w, r)
 	if !ok {
-		return
-	}
-	if !h.requireConsumerMode(w) {
 		return
 	}
 
@@ -291,9 +266,6 @@ func (h *StytchOAuthHandler) AuthorizeStart(w http.ResponseWriter, r *http.Reque
 func (h *StytchOAuthHandler) AuthorizeSubmit(w http.ResponseWriter, r *http.Request) {
 	claims, ok := h.requireAuth(w, r)
 	if !ok {
-		return
-	}
-	if !h.requireConsumerMode(w) {
 		return
 	}
 
@@ -325,14 +297,6 @@ func (h *StytchOAuthHandler) requireAuth(w http.ResponseWriter, r *http.Request)
 		return nil, false
 	}
 	return claims, true
-}
-
-func (h *StytchOAuthHandler) requireConsumerMode(w http.ResponseWriter) bool {
-	if h.cfg.Kind == StytchOAuthKindConsumer {
-		return true
-	}
-	writeJSONError(w, http.StatusBadRequest, "Stytch B2B authorization is disabled")
-	return false
 }
 
 func (h *StytchOAuthHandler) buildAuthorizeRequest(webReq stytchOAuthWebRequest, claims *middleware.AuthClaims) StytchOAuthAuthorizeRequest {
@@ -375,11 +339,4 @@ func writeJSON(w http.ResponseWriter, status int, payload any) {
 
 func writeJSONError(w http.ResponseWriter, status int, message string) {
 	writeJSON(w, status, map[string]string{"error": message})
-}
-
-func normalizeStytchOAuthKind(kind StytchOAuthKind) StytchOAuthKind {
-	if kind == StytchOAuthKindB2B {
-		return StytchOAuthKindB2B
-	}
-	return StytchOAuthKindConsumer
 }

--- a/backend/internal/mcp/stytch_oauth_test.go
+++ b/backend/internal/mcp/stytch_oauth_test.go
@@ -51,7 +51,6 @@ func TestStytchOAuthClientConsumerStartRequest(t *testing.T) {
 		Domain:    server.URL,
 		ProjectID: "project-test",
 		Secret:    "secret-test",
-		Kind:      StytchOAuthKindConsumer,
 	})
 
 	resp, err := client.AuthorizeStart(context.Background(), StytchOAuthAuthorizeStartRequest{
@@ -104,7 +103,6 @@ func TestStytchOAuthClientConsumerSubmitRequest(t *testing.T) {
 		Domain:    server.URL,
 		ProjectID: "project-test",
 		Secret:    "secret-test",
-		Kind:      StytchOAuthKindConsumer,
 	})
 
 	resp, err := client.AuthorizeSubmit(context.Background(), StytchOAuthAuthorizeSubmitRequest{
@@ -130,52 +128,6 @@ func TestStytchOAuthClientConsumerSubmitRequest(t *testing.T) {
 	}
 }
 
-func TestStytchOAuthClientB2BStartRequest(t *testing.T) {
-	allowUnsafeStytchOAuthTestDomain(t)
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if got, want := r.URL.Path, "/v1/b2b/idp/oauth/authorize/start"; got != want {
-			t.Fatalf("path = %q, want %q", got, want)
-		}
-
-		var body map[string]any
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatalf("decode body: %v", err)
-		}
-		assertJSONValue(t, body, "organization_id", "org-test")
-		assertJSONValue(t, body, "member_id", "member-test")
-		if _, ok := body["user_id"]; ok {
-			t.Fatal("b2b request included user_id")
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"client":{"client_id":"client-test","client_name":"B2B App"},"consent_required":false,"scope_results":[],"status_code":200}`))
-	}))
-	defer server.Close()
-
-	client := NewStytchOAuthClient(StytchOAuthClientConfig{
-		Domain:    server.URL,
-		ProjectID: "project-test",
-		Secret:    "secret-test",
-		Kind:      StytchOAuthKindB2B,
-	})
-
-	_, err := client.AuthorizeStart(context.Background(), StytchOAuthAuthorizeStartRequest{
-		StytchOAuthAuthorizeRequest: StytchOAuthAuthorizeRequest{
-			ClientID:       "client-test",
-			RedirectURI:    "https://client.example/callback",
-			ResponseType:   "code",
-			Scopes:         []string{"openid"},
-			OrganizationID: "org-test",
-			MemberID:       "member-test",
-		},
-	})
-	if err != nil {
-		t.Fatalf("AuthorizeStart returned error: %v", err)
-	}
-}
-
 func TestStytchOAuthHandlerStartUnauthorized(t *testing.T) {
 	handler := NewStytchOAuthHandler(StytchOAuthHandlerConfig{
 		Client: &fakeStytchOAuthClient{},
@@ -198,7 +150,6 @@ func TestStytchOAuthHandlerSubmitReturnsRedirectURI(t *testing.T) {
 	}
 	handler := NewStytchOAuthHandler(StytchOAuthHandlerConfig{
 		Client:        client,
-		Kind:          StytchOAuthKindConsumer,
 		UserIDPrefix:  "degov-square:",
 		OAuthResource: "https://square.degov.ai/mcp",
 	})
@@ -227,7 +178,7 @@ func TestStytchOAuthHandlerSubmitReturnsRedirectURI(t *testing.T) {
 	assertStringSlice(t, client.submitRequest.Resources, []string{"https://square.degov.ai/mcp"})
 }
 
-func TestStytchOAuthHandlerIgnoresConfiguredFixedUserID(t *testing.T) {
+func TestStytchOAuthHandlerStartUsesAuthenticatedSquareUserID(t *testing.T) {
 	client := &fakeStytchOAuthClient{
 		startResponse: StytchOAuthAuthorizeStartResponse{
 			Client: StytchOAuthClientInfo{ClientID: "client-test"},
@@ -235,9 +186,7 @@ func TestStytchOAuthHandlerIgnoresConfiguredFixedUserID(t *testing.T) {
 	}
 	handler := NewStytchOAuthHandler(StytchOAuthHandlerConfig{
 		Client:       client,
-		Kind:         StytchOAuthKindConsumer,
 		UserIDPrefix: "degov-square:",
-		UserID:       "configured-static-user",
 	})
 
 	req := httptest.NewRequest(http.MethodPost, "/api/oauth/stytch/authorize/start", bytes.NewReader([]byte(`{"client_id":"client-test","redirect_uri":"https://client.example/callback"}`)))
@@ -255,42 +204,10 @@ func TestStytchOAuthHandlerIgnoresConfiguredFixedUserID(t *testing.T) {
 	}
 }
 
-func TestStytchOAuthHandlerB2BModeIsDisabled(t *testing.T) {
-	client := &fakeStytchOAuthClient{}
-	handler := NewStytchOAuthHandler(StytchOAuthHandlerConfig{
-		Client:         client,
-		Kind:           StytchOAuthKindB2B,
-		OrganizationID: "org-test",
-		MemberID:       "member-test",
-	})
-
-	req := httptest.NewRequest(http.MethodPost, "/api/oauth/stytch/authorize/start", bytes.NewReader([]byte(`{"client_id":"client-test","redirect_uri":"https://client.example/callback"}`)))
-	req = req.WithContext(context.WithValue(req.Context(), middleware.UserClaimsKey, &middleware.AuthClaims{
-		User: &types.UserSessInfo{Id: "user-123"},
-	}))
-	rec := httptest.NewRecorder()
-	handler.AuthorizeStart(rec, req)
-
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("status = %d, want %d, body %q", rec.Code, http.StatusBadRequest, rec.Body.String())
-	}
-	if client.startCalls != 0 {
-		t.Fatalf("startCalls = %d, want 0", client.startCalls)
-	}
-	var body map[string]string
-	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
-	if got, want := body["error"], "Stytch B2B authorization is disabled"; got != want {
-		t.Fatalf("error = %q, want %q", got, want)
-	}
-}
-
 func TestStytchOAuthHandlerReturnsGenericStartError(t *testing.T) {
 	client := &fakeStytchOAuthClient{err: errors.New("project-test secret-test upstream detail")}
 	handler := NewStytchOAuthHandler(StytchOAuthHandlerConfig{
 		Client:       client,
-		Kind:         StytchOAuthKindConsumer,
 		UserIDPrefix: "degov-square:",
 	})
 
@@ -317,7 +234,6 @@ func TestStytchOAuthHandlerReturnsGenericSubmitError(t *testing.T) {
 	client := &fakeStytchOAuthClient{err: errors.New("project-test secret-test upstream detail")}
 	handler := NewStytchOAuthHandler(StytchOAuthHandlerConfig{
 		Client:       client,
-		Kind:         StytchOAuthKindConsumer,
 		UserIDPrefix: "degov-square:",
 	})
 
@@ -361,7 +277,6 @@ func TestStytchOAuthClientRejectsUnsafeDomainBeforeRequest(t *testing.T) {
 		Domain:    "http://api.stytch.com",
 		ProjectID: "project-test",
 		Secret:    "secret-test",
-		Kind:      StytchOAuthKindConsumer,
 		HTTPClient: roundTripFunc(func(*http.Request) (*http.Response, error) {
 			t.Fatal("HTTP client should not be called for unsafe domain")
 			return nil, nil

--- a/web/src/app/oauth/authorize/oauth-authorize-client.tsx
+++ b/web/src/app/oauth/authorize/oauth-authorize-client.tsx
@@ -53,13 +53,13 @@ export const OAuthAuthorizeClient = () => {
       try {
         const response = await stytchAuthorizeStart(authorizeParams, activeToken);
         setStartResponse(response);
-	    } catch (err) {
-	        if (err instanceof OAuthApiError && err.status === 401) {
-	          useAuthStore.getState().clearAuth();
-	          setStartResponse(null);
-	          setStartedKey('');
-	          setNeedsSignIn(true);
-	          setError('Session expired. Please sign in again.');
+      } catch (err) {
+        if (err instanceof OAuthApiError && err.status === 401) {
+          useAuthStore.getState().clearAuth();
+          setStartResponse(null);
+          setStartedKey('');
+          setNeedsSignIn(true);
+          setError('Session expired. Please sign in again.');
           return;
         }
         setError(err instanceof Error ? err.message : 'Failed to load authorization request');
@@ -107,13 +107,13 @@ export const OAuthAuthorizeClient = () => {
           return;
         }
         window.location.assign(response.redirect_uri);
-	      } catch (err) {
-	        if (err instanceof OAuthApiError && err.status === 401) {
-	          useAuthStore.getState().clearAuth();
-	          setStartResponse(null);
-	          setStartedKey('');
-	          setNeedsSignIn(true);
-	          setError('Session expired. Please sign in again.');
+      } catch (err) {
+        if (err instanceof OAuthApiError && err.status === 401) {
+          useAuthStore.getState().clearAuth();
+          setStartResponse(null);
+          setStartedKey('');
+          setNeedsSignIn(true);
+          setError('Session expired. Please sign in again.');
           return;
         }
         setError(err instanceof Error ? err.message : 'Authorization failed');


### PR DESCRIPTION
## Summary

- Align the Stytch MCP OAuth authorize proxy with the FNS model: DeGov Square SIWE wallet users remain the only account source.
- Remove misleading fixed-user and B2B Stytch OAuth configuration from the active config surface and `.env.example`.
- Keep the authorize proxy consumer-only and always derive Stytch `user_id` from the authenticated Square user id plus `MCP_STYTCH_OAUTH_USER_ID_PREFIX`.
- Fix formatting in the OAuth authorize page catch blocks.

## Notes

This PR intentionally does not sync or create Stytch users, add DB tables, or introduce a mapping table. The OAuth authorize page continues to require Square wallet/SIWE login first; new wallets are created through the existing `dgv_user` flow.

## Validation

- `cd backend && go test -count=1 ./internal/config ./internal/mcp ./cmd`
- `cd backend && just build`
- `cd web && pnpm exec tsc --noEmit`
- `cd web && pnpm build`

`pnpm build` exits successfully. It still prints the existing Next/ESLint circular-structure diagnostic during linting; that appears unrelated to this diff and does not fail the build.
