### PR TITLE
feat(mcp): support composite auth modes

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -31,10 +31,10 @@ JWT_SECRET=your_jwt_secret
 # Disabled by default. Set MCP_ENABLED=true to expose the MCP streamable HTTP endpoint.
 # MCP_ENABLED=false
 # MCP_PATH=/mcp
-# MCP_AUTH_MODE=bearer # bearer, oauth, or none
-# Required when MCP_AUTH_MODE=bearer. Optional fallback when MCP_AUTH_MODE=oauth and MCP_OAUTH_ALLOW_STATIC_BEARER=true.
+# MCP_AUTH_MODE=bearer # bearer, oauth, oauth,bearer, or none
+# Required when MCP_AUTH_MODE includes bearer. Optional fallback when MCP_AUTH_MODE=oauth and MCP_OAUTH_ALLOW_STATIC_BEARER=true.
 # MCP_BEARER_TOKEN=
-# OAuth protected resource metadata and JWT verification settings for MCP_AUTH_MODE=oauth.
+# OAuth protected resource metadata and JWT verification settings for MCP_AUTH_MODE including oauth.
 # MCP_OAUTH_RESOURCE=https://square.degov.ai/mcp
 # MCP_OAUTH_RESOURCE_METADATA_URL=https://square.degov.ai/.well-known/oauth-protected-resource/mcp
 # MCP_OAUTH_AUTHORIZATION_SERVERS=https://issuer.example.com

--- a/backend/internal/mcp/auth.go
+++ b/backend/internal/mcp/auth.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"crypto/subtle"
 	"net/http"
+	"strings"
 )
 
 const (
@@ -37,4 +38,37 @@ func validBearerToken(r *http.Request, token string) bool {
 	}
 
 	return subtle.ConstantTimeCompare([]byte(got[len(prefix):]), []byte(token)) == 1
+}
+
+type authModes struct {
+	bearer bool
+	none   bool
+	oauth  bool
+	valid  bool
+}
+
+func parseAuthModes(authMode string) authModes {
+	modes := authModes{valid: true}
+	parts := strings.Split(authMode, ",")
+	for _, part := range parts {
+		switch strings.ToLower(strings.TrimSpace(part)) {
+		case "":
+			modes.valid = false
+		case AuthModeBearer:
+			modes.bearer = true
+		case AuthModeNone:
+			modes.none = true
+		case AuthModeOAuth:
+			modes.oauth = true
+		default:
+			modes.valid = false
+		}
+	}
+	if modes.none && (modes.bearer || modes.oauth) {
+		modes.valid = false
+	}
+	if !modes.bearer && !modes.none && !modes.oauth {
+		modes.valid = false
+	}
+	return modes
 }

--- a/backend/internal/mcp/auth_test.go
+++ b/backend/internal/mcp/auth_test.go
@@ -61,6 +61,24 @@ func TestBuildHTTPHandlerUsesBearerAuth(t *testing.T) {
 	}
 }
 
+func TestBuildHTTPHandlerAllowsBearerInCompositeAuthMode(t *testing.T) {
+	handler := NewHTTPHandler(Config{
+		Name:        "degov-square",
+		Version:     "test",
+		AuthMode:    "oauth,bearer",
+		BearerToken: "secret",
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer secret")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code == http.StatusUnauthorized {
+		t.Fatalf("status = %d, want non-auth response", rr.Code)
+	}
+}
+
 func TestBuildHTTPHandlerAllowsExplicitNoAuth(t *testing.T) {
 	handler := NewHTTPHandler(Config{
 		Name:     "degov-square",
@@ -100,6 +118,31 @@ func TestBuildHTTPHandlerRejectsEmptyBearerToken(t *testing.T) {
 	}
 	if !strings.Contains(logs.String(), "MCP bearer token is empty") {
 		t.Fatalf("logs = %q, want empty token diagnostic", logs.String())
+	}
+}
+
+func TestBuildHTTPHandlerRejectsCompositeAuthModeWithUnknownMode(t *testing.T) {
+	var logs bytes.Buffer
+	originalLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&logs, nil)))
+	t.Cleanup(func() {
+		slog.SetDefault(originalLogger)
+	})
+
+	handler := NewHTTPHandler(Config{
+		Name:     "degov-square",
+		Version:  "test",
+		AuthMode: "oauth,api-key",
+	})
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/mcp", nil))
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusUnauthorized)
+	}
+	if !strings.Contains(logs.String(), "Unsupported MCP auth mode") {
+		t.Fatalf("logs = %q, want unsupported auth mode diagnostic", logs.String())
 	}
 }
 

--- a/backend/internal/mcp/server.go
+++ b/backend/internal/mcp/server.go
@@ -95,15 +95,22 @@ func NewHTTPHandler(cfg Config) http.Handler {
 		return NewServer(cfg)
 	}, nil)
 
-	switch cfg.AuthMode {
-	case AuthModeBearer:
+	authModes := parseAuthModes(cfg.AuthMode)
+	switch {
+	case !authModes.valid:
+		slog.Error("Unsupported MCP auth mode; rejecting all MCP requests", "auth_mode", cfg.AuthMode)
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("WWW-Authenticate", "Bearer")
+			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+		})
+	case authModes.bearer && !authModes.oauth:
 		if cfg.BearerToken == "" {
 			slog.Error("MCP bearer token is empty; rejecting all bearer-authenticated MCP requests")
 		}
 		return BearerAuthMiddleware(cfg.BearerToken)(handler)
-	case AuthModeOAuth:
+	case authModes.oauth:
 		oauthHandler := OAuthAuthMiddleware(cfg)(handler)
-		if cfg.OAuthAllowStaticBearer && cfg.BearerToken != "" {
+		if (authModes.bearer || cfg.OAuthAllowStaticBearer) && cfg.BearerToken != "" {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if validBearerToken(r, cfg.BearerToken) {
 					handler.ServeHTTP(w, r)
@@ -113,7 +120,7 @@ func NewHTTPHandler(cfg Config) http.Handler {
 			})
 		}
 		return oauthHandler
-	case AuthModeNone:
+	case authModes.none:
 		return handler
 	default:
 		slog.Error("Unsupported MCP auth mode; rejecting all MCP requests", "auth_mode", cfg.AuthMode)


### PR DESCRIPTION
## Summary

- Support comma-separated `MCP_AUTH_MODE` values such as `oauth,bearer`.
- Keep existing single-mode values working: `bearer`, `oauth`, and `none`.
- Preserve the legacy `MCP_OAUTH_ALLOW_STATIC_BEARER=true` fallback for existing deployments.
- Update `.env.example` to document the composite auth mode format.

## Deployment Notes

Production can use `MCP_AUTH_MODE=oauth,bearer` after this change is released. This lets the MCP endpoint accept the existing static bearer token and OAuth access tokens through the same endpoint.

Staging can remain `MCP_AUTH_MODE=bearer`.

Do not deploy `MCP_AUTH_MODE=oauth,bearer` to an older image; older images treat it as an unsupported auth mode and reject MCP requests.

## Tests

- `cd backend && go test ./internal/config ./internal/mcp`