### PR TITLE
fix(mcp): register oauth metadata for composite auth

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -161,7 +161,7 @@ func startServer() {
 	registerStytchOAuthRoutes(mux, middlewareChain, cfg, nil)
 
 	if cfg.GetMCPEnabled() {
-		if cfg.GetMCPAuthMode() == mcpserver.AuthModeOAuth {
+		if mcpserver.AuthModeIncludes(cfg.GetMCPAuthMode(), mcpserver.AuthModeOAuth) {
 			mcpserver.RegisterProtectedResourceMetadataHandlers(mux, mcpserver.Config{
 				OAuthResource:             cfg.GetMCPOAuthResource(),
 				OAuthResourceMetadataURL:  cfg.GetMCPOAuthResourceMetadataURL(),

--- a/backend/internal/mcp/auth.go
+++ b/backend/internal/mcp/auth.go
@@ -72,3 +72,20 @@ func parseAuthModes(authMode string) authModes {
 	}
 	return modes
 }
+
+func AuthModeIncludes(authMode string, mode string) bool {
+	modes := parseAuthModes(authMode)
+	if !modes.valid {
+		return false
+	}
+	switch mode {
+	case AuthModeBearer:
+		return modes.bearer
+	case AuthModeNone:
+		return modes.none
+	case AuthModeOAuth:
+		return modes.oauth
+	default:
+		return false
+	}
+}

--- a/backend/internal/mcp/auth_test.go
+++ b/backend/internal/mcp/auth_test.go
@@ -79,6 +79,18 @@ func TestBuildHTTPHandlerAllowsBearerInCompositeAuthMode(t *testing.T) {
 	}
 }
 
+func TestAuthModeIncludesCompositeOAuth(t *testing.T) {
+	if !AuthModeIncludes("oauth,bearer", AuthModeOAuth) {
+		t.Fatal("AuthModeIncludes(oauth,bearer, oauth) = false, want true")
+	}
+	if !AuthModeIncludes("oauth,bearer", AuthModeBearer) {
+		t.Fatal("AuthModeIncludes(oauth,bearer, bearer) = false, want true")
+	}
+	if AuthModeIncludes("oauth,bearer", AuthModeNone) {
+		t.Fatal("AuthModeIncludes(oauth,bearer, none) = true, want false")
+	}
+}
+
 func TestBuildHTTPHandlerAllowsExplicitNoAuth(t *testing.T) {
 	handler := NewHTTPHandler(Config{
 		Name:     "degov-square",


### PR DESCRIPTION
## Summary

- Register OAuth protected resource metadata routes when `MCP_AUTH_MODE` includes `oauth`, including composite values like `oauth,bearer`.
- Add `AuthModeIncludes` helper backed by the existing auth mode parser.
- Keep single-mode behavior unchanged.

## Why

Production uses `MCP_AUTH_MODE=oauth,bearer`. The MCP endpoint accepted the existing bearer token, but the OAuth metadata URL returned 404 because route registration only checked exact `oauth`.

## Tests

- `cd backend && go test ./internal/config ./internal/mcp ./cmd`