### PR TITLE
fix(mcp): allow Stytch customer OAuth domains

### DIFF
--- a/backend/internal/mcp/stytch_oauth.go
+++ b/backend/internal/mcp/stytch_oauth.go
@@ -190,10 +190,14 @@ func validateStytchOAuthDomain(domain string) error {
 	if parsed.Scheme != "https" {
 		return errors.New("Stytch OAuth domain must use https")
 	}
-	switch parsed.Hostname() {
+	hostname := strings.ToLower(parsed.Hostname())
+	switch hostname {
 	case "api.stytch.com", "test.stytch.com":
 		return nil
 	default:
+		if strings.HasSuffix(hostname, ".customers.stytch.com") {
+			return nil
+		}
 		return errors.New("Stytch OAuth domain host is not allowed")
 	}
 }

--- a/backend/internal/mcp/stytch_oauth_test.go
+++ b/backend/internal/mcp/stytch_oauth_test.go
@@ -259,13 +259,23 @@ func TestStytchOAuthHandlerReturnsGenericSubmitError(t *testing.T) {
 func TestValidateStytchOAuthDomain(t *testing.T) {
 	t.Parallel()
 
-	for _, domain := range []string{"https://api.stytch.com", "https://test.stytch.com"} {
+	for _, domain := range []string{
+		"https://api.stytch.com",
+		"https://test.stytch.com",
+		"https://splendid-pharaoh-6918.customers.stytch.com",
+	} {
 		if err := validateStytchOAuthDomain(domain); err != nil {
 			t.Fatalf("validateStytchOAuthDomain(%q) returned error: %v", domain, err)
 		}
 	}
 
-	for _, domain := range []string{"", "http://api.stytch.com", "https://evil.example", "https://api.stytch.com.evil.example"} {
+	for _, domain := range []string{
+		"",
+		"http://api.stytch.com",
+		"https://evil.example",
+		"https://api.stytch.com.evil.example",
+		"https://customers.stytch.com.evil.example",
+	} {
 		if err := validateStytchOAuthDomain(domain); err == nil {
 			t.Fatalf("validateStytchOAuthDomain(%q) returned nil, want error", domain)
 		}


### PR DESCRIPTION
## Summary

- Allow Stytch OAuth project customer domains such as `*.customers.stytch.com` in the backend OAuth authorizer client.
- Keep the existing HTTPS requirement and exact allowlist for `api.stytch.com` / `test.stytch.com`.
- Keep suffix spoofing blocked, for example `customers.stytch.com.evil.example`.

## Root cause

Production MCP OAuth is configured with the Stytch project domain `https://splendid-pharaoh-6918.customers.stytch.com`, which is also advertised by the Stytch OpenID metadata. The backend `authorize/start` request failed before calling Stytch because `validateStytchOAuthDomain` only allowed `api.stytch.com` and `test.stytch.com`. The production log showed:

```text
Stytch OAuth authorize start failed: Stytch OAuth domain host is not allowed
```

This caused `/api/oauth/stytch/authorize/start` to return 502 and the frontend authorize page to show `Failed to fetch`.

## Validation

```bash
cd backend
go test ./internal/mcp -run TestValidateStytchOAuthDomain -count=1
go test ./internal/mcp -count=1
go test ./...
```
