### PR TITLE
fix(mcp): send Stytch-compatible OAuth payloads

### DIFF
--- a/backend/internal/mcp/stytch_oauth.go
+++ b/backend/internal/mcp/stytch_oauth.go
@@ -118,14 +118,43 @@ func NewStytchOAuthClient(cfg StytchOAuthClientConfig) *StytchOAuthClient {
 
 func (c *StytchOAuthClient) AuthorizeStart(ctx context.Context, req StytchOAuthAuthorizeStartRequest) (StytchOAuthAuthorizeStartResponse, error) {
 	var resp StytchOAuthAuthorizeStartResponse
-	err := c.post(ctx, c.authorizeStartPath(), req, &resp)
+	err := c.post(ctx, c.authorizeStartPath(), req.payload(), &resp)
 	return resp, err
 }
 
 func (c *StytchOAuthClient) AuthorizeSubmit(ctx context.Context, req StytchOAuthAuthorizeSubmitRequest) (StytchOAuthAuthorizeSubmitResponse, error) {
 	var resp StytchOAuthAuthorizeSubmitResponse
-	err := c.post(ctx, c.authorizeSubmitPath(), req, &resp)
+	err := c.post(ctx, c.authorizeSubmitPath(), req.payload(), &resp)
 	return resp, err
+}
+
+func (r StytchOAuthAuthorizeStartRequest) payload() StytchOAuthAuthorizeRequest {
+	req := r.StytchOAuthAuthorizeRequest
+	return StytchOAuthAuthorizeRequest{
+		ClientID:     req.ClientID,
+		RedirectURI:  req.RedirectURI,
+		ResponseType: req.ResponseType,
+		Scopes:       append([]string(nil), req.Scopes...),
+		UserID:       req.UserID,
+	}
+}
+
+func (r StytchOAuthAuthorizeSubmitRequest) payload() StytchOAuthAuthorizeSubmitRequest {
+	req := r.StytchOAuthAuthorizeRequest
+	return StytchOAuthAuthorizeSubmitRequest{
+		StytchOAuthAuthorizeRequest: StytchOAuthAuthorizeRequest{
+			ClientID:      req.ClientID,
+			RedirectURI:   req.RedirectURI,
+			ResponseType:  req.ResponseType,
+			Scopes:        append([]string(nil), req.Scopes...),
+			UserID:        req.UserID,
+			State:         req.State,
+			Nonce:         req.Nonce,
+			CodeChallenge: req.CodeChallenge,
+			Resources:     append([]string(nil), req.Resources...),
+		},
+		ConsentGranted: r.ConsentGranted,
+	}
 }
 
 func (c *StytchOAuthClient) authorizeStartPath() string {

--- a/backend/internal/mcp/stytch_oauth_test.go
+++ b/backend/internal/mcp/stytch_oauth_test.go
@@ -37,8 +37,10 @@ func TestStytchOAuthClientConsumerStartRequest(t *testing.T) {
 		assertJSONValue(t, body, "response_type", "code")
 		assertJSONValue(t, body, "user_id", "degov-square:user-123")
 		assertJSONArray(t, body, "scopes", []string{"openid", "degov.mcp.read"})
-		if _, ok := body["resources"]; ok {
-			t.Fatal("start request included resources; want resources only on submit")
+		for _, key := range []string{"state", "nonce", "code_challenge", "code_challenge_method", "resources"} {
+			if _, ok := body[key]; ok {
+				t.Fatalf("start request included %q; want submit-only OAuth parameters omitted", key)
+			}
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -55,11 +57,16 @@ func TestStytchOAuthClientConsumerStartRequest(t *testing.T) {
 
 	resp, err := client.AuthorizeStart(context.Background(), StytchOAuthAuthorizeStartRequest{
 		StytchOAuthAuthorizeRequest: StytchOAuthAuthorizeRequest{
-			ClientID:     "client-test",
-			RedirectURI:  "https://client.example/callback",
-			ResponseType: "code",
-			Scopes:       []string{"openid", "degov.mcp.read"},
-			UserID:       "degov-square:user-123",
+			ClientID:            "client-test",
+			RedirectURI:         "https://client.example/callback",
+			ResponseType:        "code",
+			Scopes:              []string{"openid", "degov.mcp.read"},
+			UserID:              "degov-square:user-123",
+			State:               "state-test",
+			Nonce:               "nonce-test",
+			CodeChallenge:       "challenge-test",
+			CodeChallengeMethod: "S256",
+			Resources:           []string{"https://square.degov.ai/mcp"},
 		},
 	})
 	if err != nil {
@@ -89,9 +96,11 @@ func TestStytchOAuthClientConsumerSubmitRequest(t *testing.T) {
 		assertJSONValue(t, body, "state", "state-test")
 		assertJSONValue(t, body, "nonce", "nonce-test")
 		assertJSONValue(t, body, "code_challenge", "challenge-test")
-		assertJSONValue(t, body, "code_challenge_method", "S256")
 		assertJSONValue(t, body, "consent_granted", true)
 		assertJSONArray(t, body, "resources", []string{"https://square.degov.ai/mcp"})
+		if _, ok := body["code_challenge_method"]; ok {
+			t.Fatal("submit request included code_challenge_method; want Stytch-compatible payload")
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
## Summary

- Split the Stytch OAuth client payload by endpoint.
- `authorize/start` now sends only the fields Stytch accepts for loading consent details.
- `authorize/submit` keeps the OAuth continuation fields, but omits `code_challenge_method` to match Stytch/FNS behavior.

## Root cause

After deploying the customer-domain allowlist fix, production reached Stytch but failed on `authorize/start` with:

```text
Stytch OAuth request returned status 400: unknown field: "state"
```

The backend was forwarding the full OAuth request to both Stytch endpoints. Stytch `authorize/start` only accepts the initial consent lookup fields. This mirrors the working FNS implementation, where `state`, PKCE continuation data, and resource are submit-only.

## Validation

```bash
cd backend
go test ./internal/mcp -run "TestStytchOAuthClientConsumer(Start|Submit)Request" -count=1
go test ./...
```
