### PR TITLE
fix(mcp): create missing Stytch OAuth users

### DIFF
--- a/backend/internal/mcp/stytch_oauth.go
+++ b/backend/internal/mcp/stytch_oauth.go
@@ -118,7 +118,15 @@ func NewStytchOAuthClient(cfg StytchOAuthClientConfig) *StytchOAuthClient {
 
 func (c *StytchOAuthClient) AuthorizeStart(ctx context.Context, req StytchOAuthAuthorizeStartRequest) (StytchOAuthAuthorizeStartResponse, error) {
 	var resp StytchOAuthAuthorizeStartResponse
-	err := c.post(ctx, c.authorizeStartPath(), req.payload(), &resp)
+	payload := req.payload()
+	err := c.post(ctx, c.authorizeStartPath(), payload, &resp)
+	var requestErr *StytchOAuthRequestError
+	if errors.As(err, &requestErr) && requestErr.IsUserNotFound() && payload.UserID != "" {
+		if createErr := c.createUser(ctx, payload.UserID); createErr != nil {
+			return resp, createErr
+		}
+		err = c.post(ctx, c.authorizeStartPath(), payload, &resp)
+	}
 	return resp, err
 }
 
@@ -165,6 +173,18 @@ func (c *StytchOAuthClient) authorizeSubmitPath() string {
 	return "/v1/idp/oauth/authorize"
 }
 
+func (c *StytchOAuthClient) createUser(ctx context.Context, externalID string) error {
+	var resp struct {
+		UserID     string `json:"user_id"`
+		ExternalID string `json:"external_id"`
+	}
+	return c.post(ctx, "/v1/users", struct {
+		ExternalID string `json:"external_id"`
+	}{
+		ExternalID: externalID,
+	}, &resp)
+}
+
 func (c *StytchOAuthClient) post(ctx context.Context, path string, payload any, target any) error {
 	if c.cfg.Domain == "" {
 		return errors.New("missing Stytch OAuth domain")
@@ -203,12 +223,28 @@ func (c *StytchOAuthClient) post(ctx context.Context, path string, payload any, 
 		return err
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("Stytch OAuth request returned status %d: %s", resp.StatusCode, cleanStytchError(respBody))
+		return &StytchOAuthRequestError{
+			StatusCode: resp.StatusCode,
+			Message:    cleanStytchError(respBody),
+		}
 	}
 	if err := json.Unmarshal(respBody, target); err != nil {
 		return fmt.Errorf("decode Stytch OAuth response: %w", err)
 	}
 	return nil
+}
+
+type StytchOAuthRequestError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e *StytchOAuthRequestError) Error() string {
+	return fmt.Sprintf("Stytch OAuth request returned status %d: %s", e.StatusCode, e.Message)
+}
+
+func (e *StytchOAuthRequestError) IsUserNotFound() bool {
+	return e.StatusCode == http.StatusNotFound && strings.Contains(strings.ToLower(e.Message), "user could not be found")
 }
 
 func validateStytchOAuthDomain(domain string) error {

--- a/backend/internal/mcp/stytch_oauth_test.go
+++ b/backend/internal/mcp/stytch_oauth_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -77,6 +78,68 @@ func TestStytchOAuthClientConsumerStartRequest(t *testing.T) {
 	}
 	if !resp.ConsentRequired {
 		t.Fatal("consent_required = false, want true")
+	}
+}
+
+func TestStytchOAuthClientConsumerStartCreatesMissingExternalIDUser(t *testing.T) {
+	allowUnsafeStytchOAuthTestDomain(t)
+
+	var startCalls int
+	var createBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.Header.Get("Authorization"), "Basic "+base64.StdEncoding.EncodeToString([]byte("project-test:secret-test")); got != want {
+			t.Fatalf("authorization = %q, want %q", got, want)
+		}
+
+		switch r.URL.Path {
+		case "/v1/idp/oauth/authorize/start":
+			startCalls++
+			if startCalls == 1 {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"error_message":"User could not be found."}`))
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"client":{"client_id":"client-test","client_name":"Test App"},"consent_required":true,"scope_results":[],"status_code":200}`))
+		case "/v1/users":
+			if err := json.NewDecoder(r.Body).Decode(&createBody); err != nil {
+				t.Fatalf("decode create user body: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"user_id":"user-test","external_id":"degov-square:user-123","status_code":200}`))
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := NewStytchOAuthClient(StytchOAuthClientConfig{
+		Domain:    server.URL,
+		ProjectID: "project-test",
+		Secret:    "secret-test",
+	})
+
+	resp, err := client.AuthorizeStart(context.Background(), StytchOAuthAuthorizeStartRequest{
+		StytchOAuthAuthorizeRequest: StytchOAuthAuthorizeRequest{
+			ClientID:     "client-test",
+			RedirectURI:  "https://client.example/callback",
+			ResponseType: "code",
+			Scopes:       []string{"openid", "degov.mcp.read"},
+			UserID:       "degov-square:user-123",
+		},
+	})
+	if err != nil {
+		t.Fatalf("AuthorizeStart returned error: %v", err)
+	}
+	if got, want := startCalls, 2; got != want {
+		t.Fatalf("start calls = %d, want %d", got, want)
+	}
+	assertJSONValue(t, createBody, "external_id", "degov-square:user-123")
+	if resp.Client.ClientName != "Test App" {
+		t.Fatalf("client_name = %q, want Test App", resp.Client.ClientName)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Create a Stytch Consumer user on first OAuth authorization when Stytch reports the mapped external ID is missing.
- Use the existing Square user mapping as the Stytch `external_id` (`degov-square:<square-user-id>`), then retry `authorize/start` once.
- Keep this limited to the specific `404 User could not be found` response; other Stytch errors still fail normally.

## Root cause

After the Stytch domain and payload fixes, production reached Stytch successfully but failed with:

```text
Stytch OAuth request returned status 404: User could not be found.
```

DeGov Square users are wallet/SIWE users, not Stytch-native users. Stytch Connected Apps still require a Stytch user identity for `authorize/start`. Stytch supports `external_id` and allows it anywhere `user_id` is expected after the user exists, so the backend can create a minimal Stytch identity shell on first OAuth authorization without introducing full account synchronization.

## Validation

```bash
cd backend
go test ./internal/mcp -run "TestStytchOAuthClientConsumerStart(CreatesMissingExternalIDUser|Request)" -count=1
go test ./internal/mcp -count=1
go test ./...
```
