### PR TITLE
fix(mcp): use valid default Stytch user prefix

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -122,7 +122,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("MCP_STYTCH_OAUTH_DOMAIN", "")
 	v.SetDefault("MCP_STYTCH_OAUTH_PROJECT_ID", "")
 	v.SetDefault("MCP_STYTCH_OAUTH_SECRET", "")
-	v.SetDefault("MCP_STYTCH_OAUTH_USER_ID_PREFIX", "degov-square:")
+	v.SetDefault("MCP_STYTCH_OAUTH_USER_ID_PREFIX", "degov-square-")
 	v.SetDefault("MCP_PROPOSAL_SUMMARY_GENERATE_ENABLED", false)
 	v.SetDefault("MCP_PROPOSAL_SUMMARY_TIMEOUT", "30s")
 

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -62,7 +62,7 @@ func TestMCPConfigDefaults(t *testing.T) {
 	if got := cfg.GetMCPStytchOAuthSecret(); got != "" {
 		t.Fatalf("GetMCPStytchOAuthSecret() = %q, want empty", got)
 	}
-	if got, want := cfg.GetMCPStytchOAuthUserIDPrefix(), "degov-square:"; got != want {
+	if got, want := cfg.GetMCPStytchOAuthUserIDPrefix(), "degov-square-"; got != want {
 		t.Fatalf("GetMCPStytchOAuthUserIDPrefix() = %q, want %q", got, want)
 	}
 	if cfg.GetMCPProposalSummaryGenerateEnabled() {

--- a/backend/internal/mcp/stytch_oauth.go
+++ b/backend/internal/mcp/stytch_oauth.go
@@ -180,9 +180,15 @@ func (c *StytchOAuthClient) createUser(ctx context.Context, externalID string) e
 	}
 	return c.post(ctx, "/v1/users", struct {
 		ExternalID string `json:"external_id"`
+		Email      string `json:"email"`
 	}{
 		ExternalID: externalID,
+		Email:      stytchOAuthPlaceholderEmail(externalID),
 	}, &resp)
+}
+
+func stytchOAuthPlaceholderEmail(externalID string) string {
+	return externalID + "@mcp.degov.ai"
 }
 
 func (c *StytchOAuthClient) post(ctx context.Context, path string, payload any, target any) error {
@@ -304,7 +310,7 @@ func cleanStytchError(body []byte) string {
 
 func NewStytchOAuthHandler(cfg StytchOAuthHandlerConfig) *StytchOAuthHandler {
 	if cfg.UserIDPrefix == "" {
-		cfg.UserIDPrefix = "degov-square:"
+		cfg.UserIDPrefix = "degov-square-"
 	}
 	return &StytchOAuthHandler{cfg: cfg}
 }

--- a/backend/internal/mcp/stytch_oauth_test.go
+++ b/backend/internal/mcp/stytch_oauth_test.go
@@ -36,7 +36,7 @@ func TestStytchOAuthClientConsumerStartRequest(t *testing.T) {
 		assertJSONValue(t, body, "client_id", "client-test")
 		assertJSONValue(t, body, "redirect_uri", "https://client.example/callback")
 		assertJSONValue(t, body, "response_type", "code")
-		assertJSONValue(t, body, "user_id", "degov-square:user-123")
+		assertJSONValue(t, body, "user_id", "degov-square-user-123")
 		assertJSONArray(t, body, "scopes", []string{"openid", "degov.mcp.read"})
 		for _, key := range []string{"state", "nonce", "code_challenge", "code_challenge_method", "resources"} {
 			if _, ok := body[key]; ok {
@@ -62,7 +62,7 @@ func TestStytchOAuthClientConsumerStartRequest(t *testing.T) {
 			RedirectURI:         "https://client.example/callback",
 			ResponseType:        "code",
 			Scopes:              []string{"openid", "degov.mcp.read"},
-			UserID:              "degov-square:user-123",
+			UserID:              "degov-square-user-123",
 			State:               "state-test",
 			Nonce:               "nonce-test",
 			CodeChallenge:       "challenge-test",
@@ -109,7 +109,7 @@ func TestStytchOAuthClientConsumerStartCreatesMissingExternalIDUser(t *testing.T
 			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"user_id":"user-test","external_id":"degov-square:user-123","status_code":200}`))
+			_, _ = w.Write([]byte(`{"user_id":"user-test","external_id":"degov-square-user-123","status_code":200}`))
 		default:
 			t.Fatalf("unexpected path %q", r.URL.Path)
 		}
@@ -128,7 +128,7 @@ func TestStytchOAuthClientConsumerStartCreatesMissingExternalIDUser(t *testing.T
 			RedirectURI:  "https://client.example/callback",
 			ResponseType: "code",
 			Scopes:       []string{"openid", "degov.mcp.read"},
-			UserID:       "degov-square:user-123",
+			UserID:       "degov-square-user-123",
 		},
 	})
 	if err != nil {
@@ -137,7 +137,8 @@ func TestStytchOAuthClientConsumerStartCreatesMissingExternalIDUser(t *testing.T
 	if got, want := startCalls, 2; got != want {
 		t.Fatalf("start calls = %d, want %d", got, want)
 	}
-	assertJSONValue(t, createBody, "external_id", "degov-square:user-123")
+	assertJSONValue(t, createBody, "external_id", "degov-square-user-123")
+	assertJSONValue(t, createBody, "email", "degov-square-user-123@mcp.degov.ai")
 	if resp.Client.ClientName != "Test App" {
 		t.Fatalf("client_name = %q, want Test App", resp.Client.ClientName)
 	}
@@ -222,7 +223,7 @@ func TestStytchOAuthHandlerSubmitReturnsRedirectURI(t *testing.T) {
 	}
 	handler := NewStytchOAuthHandler(StytchOAuthHandlerConfig{
 		Client:        client,
-		UserIDPrefix:  "degov-square:",
+		UserIDPrefix:  "degov-square-",
 		OAuthResource: "https://square.degov.ai/mcp",
 	})
 
@@ -243,7 +244,7 @@ func TestStytchOAuthHandlerSubmitReturnsRedirectURI(t *testing.T) {
 	if got, want := body.RedirectURI, "https://client.example/callback?code=abc"; got != want {
 		t.Fatalf("redirect_uri = %q, want %q", got, want)
 	}
-	if got, want := client.submitRequest.UserID, "degov-square:user-123"; got != want {
+	if got, want := client.submitRequest.UserID, "degov-square-user-123"; got != want {
 		t.Fatalf("submit user_id = %q, want %q", got, want)
 	}
 	assertStringSlice(t, client.submitRequest.Scopes, []string{"openid", "degov.mcp.read"})
@@ -258,7 +259,7 @@ func TestStytchOAuthHandlerStartUsesAuthenticatedSquareUserID(t *testing.T) {
 	}
 	handler := NewStytchOAuthHandler(StytchOAuthHandlerConfig{
 		Client:       client,
-		UserIDPrefix: "degov-square:",
+		UserIDPrefix: "degov-square-",
 	})
 
 	req := httptest.NewRequest(http.MethodPost, "/api/oauth/stytch/authorize/start", bytes.NewReader([]byte(`{"client_id":"client-test","redirect_uri":"https://client.example/callback"}`)))
@@ -271,7 +272,7 @@ func TestStytchOAuthHandlerStartUsesAuthenticatedSquareUserID(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d, body %q", rec.Code, http.StatusOK, rec.Body.String())
 	}
-	if got, want := client.startRequest.UserID, "degov-square:user-123"; got != want {
+	if got, want := client.startRequest.UserID, "degov-square-user-123"; got != want {
 		t.Fatalf("start user_id = %q, want %q", got, want)
 	}
 }
@@ -280,7 +281,7 @@ func TestStytchOAuthHandlerReturnsGenericStartError(t *testing.T) {
 	client := &fakeStytchOAuthClient{err: errors.New("project-test secret-test upstream detail")}
 	handler := NewStytchOAuthHandler(StytchOAuthHandlerConfig{
 		Client:       client,
-		UserIDPrefix: "degov-square:",
+		UserIDPrefix: "degov-square-",
 	})
 
 	req := httptest.NewRequest(http.MethodPost, "/api/oauth/stytch/authorize/start", bytes.NewReader([]byte(`{"client_id":"client-test","redirect_uri":"https://client.example/callback"}`)))
@@ -306,7 +307,7 @@ func TestStytchOAuthHandlerReturnsGenericSubmitError(t *testing.T) {
 	client := &fakeStytchOAuthClient{err: errors.New("project-test secret-test upstream detail")}
 	handler := NewStytchOAuthHandler(StytchOAuthHandlerConfig{
 		Client:       client,
-		UserIDPrefix: "degov-square:",
+		UserIDPrefix: "degov-square-",
 	})
 
 	req := httptest.NewRequest(http.MethodPost, "/api/oauth/stytch/authorize/submit", bytes.NewReader([]byte(`{"client_id":"client-test","redirect_uri":"https://client.example/callback","consent_granted":true}`)))


### PR DESCRIPTION
## Summary
- use a Stytch-compatible default Square OAuth user external ID prefix (`degov-square-`)
- create missing Stytch users on authorize start using Square user IDs as external IDs
- include a deterministic placeholder email when creating Stytch users because Stytch requires email or phone_number

## Validation
- `go test ./internal/mcp -run TestStytchOAuthClientConsumerStartCreatesMissingExternalIDUser -count=1`
- `go test ./internal/config ./internal/mcp -count=1`
- `go test ./...`