### PR TITLE
Adapt Datalens indexer schema queries

### DIFF
--- a/backend/internal/indexer.go
+++ b/backend/internal/indexer.go
@@ -13,7 +13,9 @@ import (
 // DataMetrics represents the data metrics structure from GraphQL response
 type DataMetrics struct {
 	ProposalsCount          *int   `json:"proposalsCount"`
-	MemberCount             int    `json:"memberCount"`
+	MemberCount             *int   `json:"memberCount"`
+	HoldersCount            *int   `json:"holdersCount"`
+	ContributorCount        *int   `json:"contributorCount"`
 	PowerSum                string `json:"powerSum"`
 	VotesCount              int    `json:"votesCount"`
 	VotesWeightAbstainSum   string `json:"votesWeightAbstainSum"`
@@ -24,17 +26,24 @@ type DataMetrics struct {
 	ID                      string `json:"id"`
 }
 
+func (m DataMetrics) MemberCountValue() *int {
+	if m.HoldersCount != nil {
+		return m.HoldersCount
+	}
+	return m.MemberCount
+}
+
 // DataMetricsResponse represents the GraphQL response structure
 type DataMetricsResponse struct {
 	DataMetrics []DataMetrics `json:"dataMetrics"`
 }
 
-type ProposalConnection struct {
+type ProposalPage struct {
 	TotalCount int `json:"totalCount"`
 }
 
-type ProposalConnectionResponse struct {
-	ProposalsConnection ProposalConnection `json:"proposalsConnection"`
+type ProposalPageResponse struct {
+	ProposalsPage ProposalPage `json:"proposalsPage"`
 }
 
 // Proposal represents the structure of a governance proposal.
@@ -154,6 +163,8 @@ func (d *DegovIndexer) QueryGlobalDataMetrics(scope ProposalScope) (*DataMetrics
 			dataMetrics(where: $where) {
 				proposalsCount
 				memberCount
+				holdersCount
+				contributorCount
 				powerSum
 				votesCount
 				votesWeightAbstainSum
@@ -202,25 +213,30 @@ func (d *DegovIndexer) QueryGlobalDataMetrics(scope ProposalScope) (*DataMetrics
 
 func (d *DegovIndexer) QueryProposalsCount(scope ProposalScope) (int, error) {
 	query := `
-		query QueryProposalsCount($where: ProposalWhereInput) {
-			proposalsConnection(orderBy: [id_ASC], where: $where) {
+		query QueryProposalsCount($where: ProposalWhereInput, $limit: Int!, $offset: Int!) {
+			proposalsPage(where: $where, limit: $limit, offset: $offset) {
 				totalCount
+				items {
+					id
+				}
 			}
 		}
 	`
 
 	req := graphql.NewRequest(query)
 	req.Var("where", scope.withScope(nil))
+	req.Var("limit", 1)
+	req.Var("offset", 0)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	var response ProposalConnectionResponse
+	var response ProposalPageResponse
 	if err := d.client.Run(ctx, req, &response); err != nil {
 		return 0, fmt.Errorf("failed to execute QueryProposalsCount: %w", err)
 	}
 
-	return response.ProposalsConnection.TotalCount, nil
+	return response.ProposalsPage.TotalCount, nil
 }
 
 func (d *DegovIndexer) InspectProposal(scope ProposalScope, proposalId string) (*Proposal, error) {
@@ -637,10 +653,10 @@ type DelegatesResponse struct {
 
 // QueryDelegatorsTo queries all delegators who delegated to the given address (excluding self-delegation)
 // Returns true if there are delegators other than the address itself
-func (d *DegovIndexer) QueryDelegatorsTo(ctx context.Context, toAddress string) ([]Delegate, error) {
+func (d *DegovIndexer) QueryDelegatorsTo(ctx context.Context, scope ProposalScope, toAddress string) ([]Delegate, error) {
 	query := `
-		query QueryDelegates($toDelegate: String!, $fromDelegate: String!) {
-			delegates(where: {toDelegate_eq: $toDelegate, fromDelegate_not_eq: $fromDelegate}) {
+		query QueryDelegates($where: DelegateWhereInput) {
+			delegates(where: $where) {
 				id
 				power
 				fromDelegate
@@ -650,8 +666,10 @@ func (d *DegovIndexer) QueryDelegatorsTo(ctx context.Context, toAddress string) 
 	`
 
 	req := graphql.NewRequest(query)
-	req.Var("toDelegate", toAddress)
-	req.Var("fromDelegate", toAddress)
+	req.Var("where", scope.withScope(map[string]any{
+		"toDelegate_eq":       toAddress,
+		"fromDelegate_not_eq": toAddress,
+	}))
 
 	var response DelegatesResponse
 	if err := d.client.Run(ctx, req, &response); err != nil {
@@ -662,8 +680,8 @@ func (d *DegovIndexer) QueryDelegatorsTo(ctx context.Context, toAddress string) 
 }
 
 // HasDelegatorsOtherThanSelf checks if there are any delegators to the given address (excluding self)
-func (d *DegovIndexer) HasDelegatorsOtherThanSelf(ctx context.Context, toAddress string) (bool, error) {
-	delegates, err := d.QueryDelegatorsTo(ctx, toAddress)
+func (d *DegovIndexer) HasDelegatorsOtherThanSelf(ctx context.Context, scope ProposalScope, toAddress string) (bool, error) {
+	delegates, err := d.QueryDelegatorsTo(ctx, scope, toAddress)
 	if err != nil {
 		return false, err
 	}

--- a/backend/internal/indexer_test.go
+++ b/backend/internal/indexer_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-func TestQueryGlobalDataMetricsFallsBackToProposalsConnectionWhenGlobalProposalCountUnavailable(t *testing.T) {
+func TestQueryGlobalDataMetricsFallsBackToProposalsPageWhenGlobalProposalCountUnavailable(t *testing.T) {
 	t.Parallel()
 
 	type graphqlRequest struct {
@@ -72,10 +72,22 @@ func TestQueryGlobalDataMetricsFallsBackToProposalsConnectionWhenGlobalProposalC
 					}
 					_, _ = w.Write([]byte(tt.dataMetricsResponse))
 				case 1:
+					if !strings.Contains(req.Query, "proposalsPage") {
+						t.Fatalf("query = %s, want proposalsPage", req.Query)
+					}
+					if strings.Contains(req.Query, "proposalsConnection") {
+						t.Fatalf("query = %s, want no proposalsConnection", req.Query)
+					}
 					if _, exists := where["id_eq"]; exists {
 						t.Fatalf("unexpected id_eq in proposal count fallback where: %#v", where)
 					}
-					_, _ = w.Write([]byte(`{"data":{"proposalsConnection":{"totalCount":10}}}`))
+					if got, want := req.Variables["limit"], float64(1); got != want {
+						t.Fatalf("limit = %#v, want %#v", got, want)
+					}
+					if got, want := req.Variables["offset"], float64(0); got != want {
+						t.Fatalf("offset = %#v, want %#v", got, want)
+					}
+					_, _ = w.Write([]byte(`{"data":{"proposalsPage":{"totalCount":10,"items":[]}}}`))
 				default:
 					t.Fatalf("unexpected request count %d", requestCount)
 				}
@@ -98,6 +110,113 @@ func TestQueryGlobalDataMetricsFallsBackToProposalsConnectionWhenGlobalProposalC
 				t.Fatalf("request count = %d, want %d", got, want)
 			}
 		})
+	}
+}
+
+func TestQueryGlobalDataMetricsPrefersHoldersCountForMembers(t *testing.T) {
+	type graphqlRequest struct {
+		Query string `json:"query"`
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req graphqlRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if !strings.Contains(req.Query, "holdersCount") {
+			t.Fatalf("query = %s, want holdersCount field", req.Query)
+		}
+		if !strings.Contains(req.Query, "contributorCount") {
+			t.Fatalf("query = %s, want contributorCount field", req.Query)
+		}
+		if !strings.Contains(req.Query, "memberCount") {
+			t.Fatalf("query = %s, want memberCount field", req.Query)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"dataMetrics":[{"proposalsCount":7,"memberCount":5,"holdersCount":6,"contributorCount":4,"powerSum":"8","votesCount":3,"votesWeightAbstainSum":"0","votesWeightAgainstSum":"0","votesWeightForSum":"8","votesWithParamsCount":0,"votesWithoutParamsCount":3,"id":"global"}]}}`))
+	}))
+	defer server.Close()
+
+	indexer := NewDegovIndexer(server.URL)
+	metrics, err := indexer.QueryGlobalDataMetrics(ProposalScope{DaoCode: "ring-dao"})
+	if err != nil {
+		t.Fatalf("QueryGlobalDataMetrics() error = %v", err)
+	}
+	if got, want := metrics.MemberCountValue(), 6; got == nil || *got != want {
+		t.Fatalf("member count = %#v, want %d", got, want)
+	}
+	if metrics.ContributorCount == nil || *metrics.ContributorCount != 4 {
+		t.Fatalf("contributor count = %#v, want 4", metrics.ContributorCount)
+	}
+}
+
+func TestQueryGlobalDataMetricsFallsBackToMemberCountForMembers(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"dataMetrics":[{"proposalsCount":7,"memberCount":5,"powerSum":"8","votesCount":3,"votesWeightAbstainSum":"0","votesWeightAgainstSum":"0","votesWeightForSum":"8","votesWithParamsCount":0,"votesWithoutParamsCount":3,"id":"global"}]}}`))
+	}))
+	defer server.Close()
+
+	indexer := NewDegovIndexer(server.URL)
+	metrics, err := indexer.QueryGlobalDataMetrics(ProposalScope{DaoCode: "ring-dao"})
+	if err != nil {
+		t.Fatalf("QueryGlobalDataMetrics() error = %v", err)
+	}
+	if got, want := metrics.MemberCountValue(), 5; got == nil || *got != want {
+		t.Fatalf("member count = %#v, want %d", got, want)
+	}
+}
+
+func TestQueryDelegatorsToScopesRequest(t *testing.T) {
+	type graphqlRequest struct {
+		Variables map[string]any `json:"variables"`
+	}
+
+	scope := ProposalScope{
+		ChainID:         46,
+		DaoCode:         "ring-dao",
+		GovernorAddress: "0xAbC123",
+	}
+	toAddress := "0xDelegate"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req graphqlRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		where, ok := req.Variables["where"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected where variables, got %#v", req.Variables)
+		}
+		if got, want := where["toDelegate_eq"], toAddress; got != want {
+			t.Fatalf("toDelegate_eq = %#v, want %#v", got, want)
+		}
+		if got, want := where["fromDelegate_not_eq"], toAddress; got != want {
+			t.Fatalf("fromDelegate_not_eq = %#v, want %#v", got, want)
+		}
+		if got, want := where["chainId_eq"], float64(scope.ChainID); got != want {
+			t.Fatalf("chainId_eq = %#v, want %#v", got, want)
+		}
+		if got, want := where["daoCode_eq"], scope.DaoCode; got != want {
+			t.Fatalf("daoCode_eq = %#v, want %#v", got, want)
+		}
+		if got, want := where["governorAddress_eq"], "0xabc123"; got != want {
+			t.Fatalf("governorAddress_eq = %#v, want %#v", got, want)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"delegates":[{"id":"1","power":"2","fromDelegate":"0xFrom","toDelegate":"0xDelegate"}]}}`))
+	}))
+	defer server.Close()
+
+	indexer := NewDegovIndexer(server.URL)
+	delegates, err := indexer.QueryDelegatorsTo(context.Background(), scope, toAddress)
+	if err != nil {
+		t.Fatalf("QueryDelegatorsTo() error = %v", err)
+	}
+	if len(delegates) != 1 {
+		t.Fatalf("len(delegates) = %d, want 1", len(delegates))
 	}
 }
 

--- a/backend/tasks/dao_sync.go
+++ b/backend/tasks/dao_sync.go
@@ -181,7 +181,7 @@ func (t *DaoSyncTask) processSingleDao(remoteLink GithubConfigLink, daoInfo DaoR
 	} else if metrics != nil {
 		// Set metrics data if available
 		input.MetricsCountProposals = metrics.ProposalsCount
-		input.MetricsCountMembers = &metrics.MemberCount
+		input.MetricsCountMembers = metrics.MemberCountValue()
 		input.MetricsSumPower = &metrics.PowerSum
 		input.MetricsCountVote = &metrics.VotesCount
 	}

--- a/web/src/utils/config.ts
+++ b/web/src/utils/config.ts
@@ -51,8 +51,12 @@ export async function loadConfig(): Promise<ConfigData> {
   }
 }
 
-export async function getProposalsCount(indexerUrl: string): Promise<number> {
+export async function getProposalsCount(indexerUrl: string, daoCode?: string): Promise<number> {
   try {
+    const where = {
+      id_eq: 'global',
+      ...(daoCode ? { daoCode_eq: daoCode } : {})
+    };
     const response = await fetch(indexerUrl, {
       method: 'POST',
       headers: {
@@ -60,12 +64,15 @@ export async function getProposalsCount(indexerUrl: string): Promise<number> {
       },
       body: JSON.stringify({
         query: `
-          query MyQuery {
-            dataMetrics {
+          query MyQuery($where: DataMetricWhereInput) {
+            dataMetrics(where: $where) {
               proposalsCount
             }
           }
-        `
+        `,
+        variables: {
+          where
+        }
       })
     });
 


### PR DESCRIPTION
## Summary
- Replace the proposal count fallback query with `proposalsPage { totalCount items { id } }` for the new Datalens indexer schema.
- Read `holdersCount` and `contributorCount` from `dataMetrics`, preferring `holdersCount` for DAO member metrics while falling back to `memberCount`.
- Scope delegator lookups and the frontend proposal-count helper for multi-DAO indexer endpoints.

## Verification
- `go test ./internal ./tasks ./services`
- `pnpm exec tsc --noEmit`

Note: `pnpm lint` currently fails in the project `next lint` wrapper with a circular ESLint config serialization error before linting files.