### PR TITLE
feat(web): add legal policy pages

### DIFF
--- a/web/src/app/privacy/page.tsx
+++ b/web/src/app/privacy/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
 
 import { LegalPage } from '@/components/legal-page';
 
@@ -61,7 +62,28 @@ const sections = [
     title: 'Your choices',
     body: [
       'You may choose not to connect a wallet or provide optional profile or notification information. You can also manage wallet connections, browser storage, and cookie settings through your browser, wallet, or device.',
-      'If you want to request access, correction, deletion, or other privacy assistance for non-public information you provided to DeGov Square, contact us through the Ring Ecosystem GitHub discussions or the public contact channels listed on helixbox.ai.'
+      <>
+        If you want to request access, correction, deletion, or other privacy assistance for
+        non-public information you provided to DeGov Square, contact us through{' '}
+        <Link
+          href="https://github.com/orgs/ringecosystem/discussions"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-foreground underline underline-offset-4 hover:opacity-80"
+        >
+          Ring Ecosystem GitHub discussions
+        </Link>{' '}
+        or the public contact channels listed on{' '}
+        <Link
+          href="https://helixbox.ai"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-foreground underline underline-offset-4 hover:opacity-80"
+        >
+          helixbox.ai
+        </Link>
+        .
+      </>
     ]
   },
   {
@@ -73,7 +95,27 @@ const sections = [
   {
     title: 'Contact',
     body: [
-      'For privacy questions, support, or commercial hosting inquiries, use Ring Ecosystem discussions at https://github.com/orgs/ringecosystem/discussions or the public contact channels listed at https://helixbox.ai.'
+      <>
+        For privacy questions, support, or commercial hosting inquiries, use{' '}
+        <Link
+          href="https://github.com/orgs/ringecosystem/discussions"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-foreground underline underline-offset-4 hover:opacity-80"
+        >
+          Ring Ecosystem GitHub discussions
+        </Link>{' '}
+        or the public contact channels listed at{' '}
+        <Link
+          href="https://helixbox.ai"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-foreground underline underline-offset-4 hover:opacity-80"
+        >
+          helixbox.ai
+        </Link>
+        .
+      </>
     ]
   }
 ];

--- a/web/src/app/privacy/page.tsx
+++ b/web/src/app/privacy/page.tsx
@@ -1,0 +1,93 @@
+import type { Metadata } from 'next';
+
+import { LegalPage } from '@/components/legal-page';
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy | DeGov Square',
+  description: 'Privacy policy for DeGov Square.'
+};
+
+const sections = [
+  {
+    title: 'Information we process',
+    body: [
+      'DeGov Square primarily displays public DAO governance information, including DAO metadata, proposal records, voting records, contributor activity, wallet addresses, transaction hashes, and other information that is already public on blockchains or DAO registries.',
+      'If you connect a wallet, sign in, subscribe to notifications, or use account-based features, we may process the wallet address, authentication status, notification preferences, email address or other contact details you choose to provide, and related service records needed to operate those features.'
+    ]
+  },
+  {
+    title: 'How we use information',
+    body: [
+      'We use information to provide DeGov Square, authenticate users, show DAO and proposal data, support notification features, protect the service, troubleshoot issues, improve reliability, and respond to support or governance inquiries.',
+      'Proposal summaries and other AI-assisted features are provided to help users understand public governance content. They are informational and may be generated from public proposal text, voting activity, and related governance data.'
+    ]
+  },
+  {
+    title: 'ChatGPT and MCP integrations',
+    body: [
+      'If you use DeGov Square through ChatGPT or another MCP client, the client may send tool requests to DeGov Square and receive responses that include public DAO, proposal, contributor, voting, and registry data.',
+      'The third-party client you use, including ChatGPT, may process your prompts, tool calls, and responses under its own terms and privacy policy. DeGov Square does not control those third-party clients.'
+    ]
+  },
+  {
+    title: 'Public blockchain data',
+    body: [
+      'Blockchain data is public by design. Wallet addresses, votes, proposal actions, delegation events, and transaction records may remain visible on public networks and third-party explorers even if they are no longer shown in DeGov Square.',
+      'We do not control public blockchains, DAO registries, wallet providers, or third-party websites linked from DeGov Square.'
+    ]
+  },
+  {
+    title: 'Cookies and analytics',
+    body: [
+      'DeGov Square may use cookies, local storage, and similar technologies to keep the application working, remember preferences, support wallet and mini app behavior, and understand aggregate usage.',
+      'We may use analytics tools, including Google Analytics, to measure traffic and improve the service. These providers may process technical information such as device, browser, page, referral, and usage data according to their own policies.'
+    ]
+  },
+  {
+    title: 'Service providers',
+    body: [
+      'We may use service providers for hosting, analytics, authentication, notifications, data indexing, AI processing, and infrastructure operations. These providers process information only as needed to provide their services to DeGov Square.',
+      'When you use external wallets, blockchain networks, DAO websites, explorers, or communication platforms, your use is governed by those third parties and their policies.'
+    ]
+  },
+  {
+    title: 'Data retention',
+    body: [
+      'We keep service records only for as long as needed for the purposes described in this policy, unless a longer period is required for security, troubleshooting, legal, or governance reasons.',
+      'Public blockchain records and public DAO data may remain available independently of DeGov Square and cannot be deleted by us.'
+    ]
+  },
+  {
+    title: 'Your choices',
+    body: [
+      'You may choose not to connect a wallet or provide optional profile or notification information. You can also manage wallet connections, browser storage, and cookie settings through your browser, wallet, or device.',
+      'If you want to request access, correction, deletion, or other privacy assistance for non-public information you provided to DeGov Square, contact us through the Ring Ecosystem GitHub discussions or the public contact channels listed on helixbox.ai.'
+    ]
+  },
+  {
+    title: 'Changes',
+    body: [
+      'We may update this Privacy Policy as DeGov Square evolves. The updated version will be posted on this page with a new last updated date.'
+    ]
+  },
+  {
+    title: 'Contact',
+    body: [
+      'For privacy questions, support, or commercial hosting inquiries, use Ring Ecosystem discussions at https://github.com/orgs/ringecosystem/discussions or the public contact channels listed at https://helixbox.ai.'
+    ]
+  }
+];
+
+export default function PrivacyPage() {
+  return (
+    <LegalPage
+      title="Privacy Policy"
+      updatedAt="June 15, 2026"
+      intro={[
+        'This Privacy Policy explains how DeGov Square handles information when you use the website, MCP tools, and related services.',
+        'DeGov Square is a hub for DAOs that use the DeGov governance toolkit. DeGov.AI is a RingDAO project supported by Helixbox Labs for research, development, and marketing services.'
+      ]}
+      sections={sections}
+    />
+  );
+}

--- a/web/src/app/terms/page.tsx
+++ b/web/src/app/terms/page.tsx
@@ -1,0 +1,94 @@
+import type { Metadata } from 'next';
+
+import { LegalPage } from '@/components/legal-page';
+
+export const metadata: Metadata = {
+  title: 'Terms of Service | DeGov Square',
+  description: 'Terms of service for DeGov Square.'
+};
+
+const sections = [
+  {
+    title: 'Using DeGov Square',
+    body: [
+      'DeGov Square provides access to DAO governance information, including public DAO metadata, proposal data, proposal summaries, contributor activity, voting records, and related registry or indexer data.',
+      'You are responsible for how you use the information shown by DeGov Square. You must comply with applicable laws, wallet provider terms, blockchain network rules, and DAO governance rules.'
+    ]
+  },
+  {
+    title: 'No financial, legal, or governance advice',
+    body: [
+      'DeGov Square is provided for informational purposes only. Nothing in DeGov Square is financial, investment, legal, tax, security, or governance advice.',
+      'Proposal summaries, AI-assisted content, analytics, and governance data may be incomplete, delayed, or inaccurate. You should review original proposal text, on-chain records, DAO documentation, and other primary sources before making governance or financial decisions.'
+    ]
+  },
+  {
+    title: 'Wallets and transactions',
+    body: [
+      'Some DeGov experiences may let users connect wallets or navigate to DAO interfaces, wallets, explorers, or third-party services. You are solely responsible for any wallet action, signature, transaction, delegation, vote, or token transfer you initiate.',
+      'The DeGov Square MCP tools are designed for read-only access to governance data and do not execute blockchain transactions.'
+    ]
+  },
+  {
+    title: 'Public data and third-party services',
+    body: [
+      'DeGov Square uses public blockchain data, DAO registry data, indexers, analytics, AI services, wallet infrastructure, and third-party websites. We do not control public blockchains or third-party services and are not responsible for their availability, accuracy, security, or policies.',
+      'Links to external websites are provided for convenience and do not mean that RingDAO or Helixbox Labs endorses or controls those websites.'
+    ]
+  },
+  {
+    title: 'Software license',
+    body: [
+      'The DeGov Square source code is distributed under the license included in the repository. As of the last updated date of these Terms, the repository uses the Functional Source License, Version 1.1, Apache 2.0 Future License.',
+      'These Terms govern use of the DeGov Square website, MCP tools, and related hosted services. They do not replace the software license. If there is a conflict about use, copying, modification, distribution, self-hosting, or commercial hosting of the software, the repository license controls for the software.'
+    ]
+  },
+  {
+    title: 'Commercial hosting',
+    body: [
+      'The DeGov Square software license restricts unauthorized commercial Software-as-a-Service and Platform-as-a-Service hosting. Commercial hosting requires approval through RingDAO governance or another approval path described in the repository license.',
+      'Using the public DeGov Square service does not grant permission to offer DeGov Square or modified DeGov Square software as a commercial hosted service.'
+    ]
+  },
+  {
+    title: 'Acceptable use',
+    body: [
+      'You may not misuse DeGov Square, interfere with the service, attempt unauthorized access, bypass rate limits or security controls, scrape or overload the service in a way that harms availability, or use the service to violate laws or third-party rights.',
+      'We may limit, suspend, or block access when needed to protect users, infrastructure, DAO communities, or the service.'
+    ]
+  },
+  {
+    title: 'Availability and changes',
+    body: [
+      'DeGov Square is provided on an as-available basis. Features, data sources, MCP tools, supported DAOs, supported networks, and integrations may change, pause, or be removed.',
+      'We may update these Terms as DeGov Square evolves. The updated version will be posted on this page with a new last updated date.'
+    ]
+  },
+  {
+    title: 'Disclaimers',
+    body: [
+      'DeGov Square is provided "as is" and "as available" without warranties of any kind, whether express or implied, including warranties of merchantability, fitness for a particular purpose, non-infringement, accuracy, availability, or security.',
+      'To the maximum extent permitted by law, RingDAO, Helixbox Labs, contributors, and service providers will not be liable for indirect, incidental, special, consequential, punitive, or similar damages, or for loss of profits, data, goodwill, tokens, or other assets arising from use of DeGov Square.'
+    ]
+  },
+  {
+    title: 'Contact',
+    body: [
+      'For support, commercial hosting inquiries, or governance participation, use Ring Ecosystem discussions at https://github.com/orgs/ringecosystem/discussions or the public contact channels listed at https://helixbox.ai.'
+    ]
+  }
+];
+
+export default function TermsPage() {
+  return (
+    <LegalPage
+      title="Terms of Service"
+      updatedAt="June 15, 2026"
+      intro={[
+        'These Terms of Service explain the rules for using DeGov Square, including the website, MCP tools, and related hosted services.',
+        'DeGov Square is a hub for DAOs that use the DeGov governance toolkit. DeGov.AI is a RingDAO project supported by Helixbox Labs for research, development, and marketing services.'
+      ]}
+      sections={sections}
+    />
+  );
+}

--- a/web/src/app/terms/page.tsx
+++ b/web/src/app/terms/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
 
 import { LegalPage } from '@/components/legal-page';
 
@@ -74,7 +75,27 @@ const sections = [
   {
     title: 'Contact',
     body: [
-      'For support, commercial hosting inquiries, or governance participation, use Ring Ecosystem discussions at https://github.com/orgs/ringecosystem/discussions or the public contact channels listed at https://helixbox.ai.'
+      <>
+        For support, commercial hosting inquiries, or governance participation, use{' '}
+        <Link
+          href="https://github.com/orgs/ringecosystem/discussions"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-foreground underline underline-offset-4 hover:opacity-80"
+        >
+          Ring Ecosystem GitHub discussions
+        </Link>{' '}
+        or the public contact channels listed at{' '}
+        <Link
+          href="https://helixbox.ai"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-foreground underline underline-offset-4 hover:opacity-80"
+        >
+          helixbox.ai
+        </Link>
+        .
+      </>
     ]
   }
 ];

--- a/web/src/components/layout/footer.tsx
+++ b/web/src/components/layout/footer.tsx
@@ -57,6 +57,18 @@ export function Footer() {
                 >
                   Docs
                 </Link>
+                <Link
+                  href="/privacy"
+                  className="text-muted-foreground block text-[14px] leading-[1.2] font-normal transition-colors hover:opacity-80"
+                >
+                  Privacy Policy
+                </Link>
+                <Link
+                  href="/terms"
+                  className="text-muted-foreground block text-[14px] leading-[1.2] font-normal transition-colors hover:opacity-80"
+                >
+                  Terms of Service
+                </Link>
               </div>
             </div>
 
@@ -95,9 +107,7 @@ export function Footer() {
           </div>
 
           {/* Copyright at bottom on mobile */}
-          <p className="text-muted-foreground text-[14px] font-normal md:hidden">
-            ©{year} RingDAO
-          </p>
+          <p className="text-muted-foreground text-[14px] font-normal md:hidden">©{year} RingDAO</p>
         </div>
       </footer>
     </>

--- a/web/src/components/legal-page.tsx
+++ b/web/src/components/legal-page.tsx
@@ -1,0 +1,50 @@
+import Link from 'next/link';
+
+type LegalSection = {
+  title: string;
+  body: string[];
+};
+
+type LegalPageProps = {
+  title: string;
+  updatedAt: string;
+  intro: string[];
+  sections: LegalSection[];
+};
+
+export function LegalPage({ title, updatedAt, intro, sections }: LegalPageProps) {
+  return (
+    <div className="container max-w-[920px]">
+      <div className="flex flex-col gap-[30px]">
+        <div className="flex flex-col gap-[12px]">
+          <Link href="/" className="text-muted-foreground text-[14px] hover:opacity-80">
+            Back to DeGov Square
+          </Link>
+          <h1 className="text-[32px] leading-[1.15] font-semibold md:text-[44px]">{title}</h1>
+          <p className="text-muted-foreground text-[14px]">Last updated: {updatedAt}</p>
+        </div>
+
+        <div className="flex flex-col gap-[16px]">
+          {intro.map((paragraph) => (
+            <p key={paragraph} className="text-muted-foreground text-[16px] leading-[1.7]">
+              {paragraph}
+            </p>
+          ))}
+        </div>
+
+        <div className="flex flex-col gap-[28px]">
+          {sections.map((section) => (
+            <section key={section.title} className="flex flex-col gap-[12px]">
+              <h2 className="text-[22px] leading-[1.25] font-semibold">{section.title}</h2>
+              {section.body.map((paragraph) => (
+                <p key={paragraph} className="text-muted-foreground text-[16px] leading-[1.7]">
+                  {paragraph}
+                </p>
+              ))}
+            </section>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/legal-page.tsx
+++ b/web/src/components/legal-page.tsx
@@ -1,14 +1,15 @@
 import Link from 'next/link';
+import type { ReactNode } from 'react';
 
 type LegalSection = {
   title: string;
-  body: string[];
+  body: ReactNode[];
 };
 
 type LegalPageProps = {
   title: string;
   updatedAt: string;
-  intro: string[];
+  intro: ReactNode[];
   sections: LegalSection[];
 };
 
@@ -25,8 +26,8 @@ export function LegalPage({ title, updatedAt, intro, sections }: LegalPageProps)
         </div>
 
         <div className="flex flex-col gap-[16px]">
-          {intro.map((paragraph) => (
-            <p key={paragraph} className="text-muted-foreground text-[16px] leading-[1.7]">
+          {intro.map((paragraph, index) => (
+            <p key={index} className="text-muted-foreground text-[16px] leading-[1.7]">
               {paragraph}
             </p>
           ))}
@@ -36,8 +37,8 @@ export function LegalPage({ title, updatedAt, intro, sections }: LegalPageProps)
           {sections.map((section) => (
             <section key={section.title} className="flex flex-col gap-[12px]">
               <h2 className="text-[22px] leading-[1.25] font-semibold">{section.title}</h2>
-              {section.body.map((paragraph) => (
-                <p key={paragraph} className="text-muted-foreground text-[16px] leading-[1.7]">
+              {section.body.map((paragraph, index) => (
+                <p key={index} className="text-muted-foreground text-[16px] leading-[1.7]">
                   {paragraph}
                 </p>
               ))}


### PR DESCRIPTION
## Summary

- Add public `/privacy` and `/terms` routes for DeGov Square.
- Add a shared legal page layout component for policy-style pages.
- Link the new pages from the footer Resources section.

## Notes

- The Terms clarify that the hosted DeGov Square service terms do not replace the repository software license.
- The Privacy Policy covers public blockchain data, optional wallet/auth/notification data, analytics, service providers, and ChatGPT/MCP tool usage.

## Validation

- `pnpm exec prettier --check src/components/legal-page.tsx src/app/privacy/page.tsx src/app/terms/page.tsx src/components/layout/footer.tsx`
- `pnpm exec tsc --noEmit`
- `pnpm build`

`pnpm lint` currently fails before linting project files because `next lint` hits an existing circular JSON issue with the current flat ESLint config / Next lint integration.