### PR TITLE
fix(mcp): support OpenAI app verification

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -28,6 +29,11 @@ import (
 )
 
 var Version string
+
+const (
+	openAIAppsChallengePath     = "/.well-known/openai-apps-challenge"
+	openAIAppsChallengeTokenEnv = "OPENAI_APPS_CHALLENGE_TOKEN"
+)
 
 func main() {
 	if Version == "" {
@@ -143,6 +149,7 @@ func startServer() {
 	)
 
 	mux := http.NewServeMux()
+	registerOpenAIAppsChallengeRoute(mux)
 
 	graphiql := playground.Handler("GraphQL playground", "/graphql", playground.WithGraphiqlEnablePluginExplorer(true))
 	mux.Handle("/graphiql", graphiql)
@@ -196,6 +203,28 @@ func startServer() {
 	)
 	err := http.ListenAndServe(":"+port, httpHandler)
 	slog.Error("failed to listen server", "error", err)
+}
+
+func registerOpenAIAppsChallengeRoute(mux *http.ServeMux) {
+	mux.HandleFunc(openAIAppsChallengePath, openAIAppsChallengeHandler)
+}
+
+func openAIAppsChallengeHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		w.Header().Set("Allow", "GET, HEAD")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	token := strings.TrimSpace(os.Getenv(openAIAppsChallengeTokenEnv))
+	if token == "" {
+		http.NotFound(w, r)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	_, _ = w.Write([]byte(token))
 }
 
 func registerStytchOAuthRoutes(mux *http.ServeMux, middlewareChain *middleware.Chain, cfg *config.Config, httpClient *http.Client) {

--- a/backend/cmd/main_test.go
+++ b/backend/cmd/main_test.go
@@ -35,6 +35,31 @@ func TestCORSAllowsMCPStreamableHTTPHeaders(t *testing.T) {
 	}
 }
 
+func TestOpenAIAppsChallengeRoute(t *testing.T) {
+	mux := http.NewServeMux()
+	registerOpenAIAppsChallengeRoute(mux)
+
+	req := httptest.NewRequest(http.MethodGet, openAIAppsChallengePath, nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("missing token status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+
+	t.Setenv(openAIAppsChallengeTokenEnv, "challenge-token")
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("challenge status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if got := strings.TrimSpace(rec.Body.String()); got != "challenge-token" {
+		t.Fatalf("challenge body = %q, want %q", got, "challenge-token")
+	}
+	if got := rec.Header().Get("Content-Type"); !strings.HasPrefix(got, "text/plain") {
+		t.Fatalf("content type = %q, want text/plain", got)
+	}
+}
+
 func TestRegisterStytchOAuthRoutesOnlyWhenEnabled(t *testing.T) {
 	t.Setenv("MCP_STYTCH_OAUTH_ENABLED", "false")
 	if err := config.InitConfig(); err != nil {

--- a/backend/internal/mcp/tools_annotations.go
+++ b/backend/internal/mcp/tools_annotations.go
@@ -1,0 +1,15 @@
+package mcp
+
+import sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+func readOnlyToolAnnotations() *sdkmcp.ToolAnnotations {
+	return &sdkmcp.ToolAnnotations{
+		ReadOnlyHint:    true,
+		OpenWorldHint:   boolPtr(false),
+		DestructiveHint: boolPtr(false),
+	}
+}
+
+func boolPtr(value bool) *bool {
+	return &value
+}

--- a/backend/internal/mcp/tools_dao.go
+++ b/backend/internal/mcp/tools_dao.go
@@ -126,23 +126,20 @@ func listDaosInputSchema() *jsonschema.Schema {
 				MaxItems: jsonschema.Ptr(20),
 			},
 			"state": {
-				Type:        "array",
-				Description: "Optional DAO states to filter by.",
-				Items: &jsonschema.Schema{
-					Type: "string",
-					Enum: []any{
-						string(dbmodels.DaoStateActive),
-						string(dbmodels.DaoStateDraft),
-						string(dbmodels.DaoStateInactive),
-					},
+				Type:        "string",
+				Description: "Optional DAO state to filter by.",
+				Enum: []any{
+					string(dbmodels.DaoStateActive),
+					string(dbmodels.DaoStateDraft),
+					string(dbmodels.DaoStateInactive),
+					strings.ToLower(string(dbmodels.DaoStateActive)),
+					strings.ToLower(string(dbmodels.DaoStateDraft)),
+					strings.ToLower(string(dbmodels.DaoStateInactive)),
 				},
-				MaxItems: jsonschema.Ptr(3),
 			},
 			"limit": {
 				Type:        "integer",
 				Description: "Maximum number of DAOs to return. Values above 100 are capped.",
-				Minimum:     jsonschema.Ptr(1.0),
-				Maximum:     jsonschema.Ptr(float64(maxListDaosLimit)),
 			},
 		},
 	}
@@ -191,18 +188,15 @@ func toListDaosServiceInput(input listDaosInput) (*types.ListDaosInput, error) {
 		}
 		serviceInput.Codes = &codes
 	}
-	if len(input.State) > 0 {
-		states := make([]dbmodels.DaoState, 0, len(input.State))
-		for _, state := range input.State {
-			normalized := dbmodels.DaoState(strings.ToUpper(strings.TrimSpace(state)))
-			switch normalized {
-			case dbmodels.DaoStateActive, dbmodels.DaoStateDraft, dbmodels.DaoStateInactive:
-				states = append(states, normalized)
-			default:
-				return nil, invalidParamsError("state must be ACTIVE, DRAFT, or INACTIVE")
-			}
+	if strings.TrimSpace(input.State) != "" {
+		normalized := dbmodels.DaoState(strings.ToUpper(strings.TrimSpace(input.State)))
+		switch normalized {
+		case dbmodels.DaoStateActive, dbmodels.DaoStateDraft, dbmodels.DaoStateInactive:
+			states := []dbmodels.DaoState{normalized}
+			serviceInput.State = &states
+		default:
+			return nil, invalidParamsError("state must be ACTIVE, DRAFT, or INACTIVE")
 		}
-		serviceInput.State = &states
 	}
 	return serviceInput, nil
 }

--- a/backend/internal/mcp/tools_dao.go
+++ b/backend/internal/mcp/tools_dao.go
@@ -20,9 +20,7 @@ func addDaoTools(server *sdkmcp.Server, cfg Config) {
 		Name:        "list_daos",
 		Title:       "List DAOs",
 		Description: "Return a bounded list of public DAO summaries.",
-		Annotations: &sdkmcp.ToolAnnotations{
-			ReadOnlyHint: true,
-		},
+		Annotations: readOnlyToolAnnotations(),
 	}, func(ctx context.Context, req *sdkmcp.CallToolRequest, input listDaosInput) (*sdkmcp.CallToolResult, listDaosOutput, error) {
 		serviceInput, err := toListDaosServiceInput(input)
 		if err != nil {
@@ -60,9 +58,7 @@ func addDaoTools(server *sdkmcp.Server, cfg Config) {
 		Name:        "get_dao",
 		Title:       "Get DAO",
 		Description: "Return public DAO metadata for one DAO code.",
-		Annotations: &sdkmcp.ToolAnnotations{
-			ReadOnlyHint: true,
-		},
+		Annotations: readOnlyToolAnnotations(),
 	}, func(ctx context.Context, req *sdkmcp.CallToolRequest, input getDaoInput) (*sdkmcp.CallToolResult, daoDetailOutput, error) {
 		daoCode, err := normalizeDaoCode(input.DaoCode)
 		if err != nil {
@@ -84,9 +80,7 @@ func addDaoTools(server *sdkmcp.Server, cfg Config) {
 		Name:        "get_dao_config",
 		Title:       "Get DAO Config",
 		Description: "Return the public DAO registry config for one DAO code.",
-		Annotations: &sdkmcp.ToolAnnotations{
-			ReadOnlyHint: true,
-		},
+		Annotations: readOnlyToolAnnotations(),
 	}, func(ctx context.Context, req *sdkmcp.CallToolRequest, input getDaoConfigInput) (*sdkmcp.CallToolResult, daoConfigOutput, error) {
 		daoCode, err := normalizeDaoCode(input.DaoCode)
 		if err != nil {

--- a/backend/internal/mcp/tools_dao.go
+++ b/backend/internal/mcp/tools_dao.go
@@ -2,10 +2,12 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
 
+	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 	dbmodels "github.com/ringecosystem/degov-square/database/models"
@@ -21,6 +23,7 @@ func addDaoTools(server *sdkmcp.Server, cfg Config) {
 		Title:       "List DAOs",
 		Description: "Return a bounded list of public DAO summaries.",
 		Annotations: readOnlyToolAnnotations(),
+		InputSchema: listDaosInputSchema(),
 	}, func(ctx context.Context, req *sdkmcp.CallToolRequest, input listDaosInput) (*sdkmcp.CallToolResult, listDaosOutput, error) {
 		serviceInput, err := toListDaosServiceInput(input)
 		if err != nil {
@@ -81,6 +84,7 @@ func addDaoTools(server *sdkmcp.Server, cfg Config) {
 		Title:       "Get DAO Config",
 		Description: "Return the public DAO registry config for one DAO code.",
 		Annotations: readOnlyToolAnnotations(),
+		InputSchema: getDaoConfigInputSchema(),
 	}, func(ctx context.Context, req *sdkmcp.CallToolRequest, input getDaoConfigInput) (*sdkmcp.CallToolResult, daoConfigOutput, error) {
 		daoCode, err := normalizeDaoCode(input.DaoCode)
 		if err != nil {
@@ -106,6 +110,62 @@ func addDaoTools(server *sdkmcp.Server, cfg Config) {
 			Content: content,
 		}, nil
 	})
+}
+
+func listDaosInputSchema() *jsonschema.Schema {
+	return &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"codes": {
+				Type:        "array",
+				Description: "Optional DAO codes to filter by, for example ring-dao.",
+				Items: &jsonschema.Schema{
+					Type:    "string",
+					Pattern: daoCodePattern.String(),
+				},
+				MaxItems: jsonschema.Ptr(20),
+			},
+			"state": {
+				Type:        "array",
+				Description: "Optional DAO states to filter by.",
+				Items: &jsonschema.Schema{
+					Type: "string",
+					Enum: []any{
+						string(dbmodels.DaoStateActive),
+						string(dbmodels.DaoStateDraft),
+						string(dbmodels.DaoStateInactive),
+					},
+				},
+				MaxItems: jsonschema.Ptr(3),
+			},
+			"limit": {
+				Type:        "integer",
+				Description: "Maximum number of DAOs to return. Values above 100 are capped.",
+				Minimum:     jsonschema.Ptr(1.0),
+				Maximum:     jsonschema.Ptr(float64(maxListDaosLimit)),
+			},
+		},
+	}
+}
+
+func getDaoConfigInputSchema() *jsonschema.Schema {
+	return &jsonschema.Schema{
+		Type:     "object",
+		Required: []string{"daoCode"},
+		Properties: map[string]*jsonschema.Schema{
+			"daoCode": {
+				Type:        "string",
+				Description: "DAO code, for example ring-dao.",
+				Pattern:     daoCodePattern.String(),
+			},
+			"format": {
+				Type:        "string",
+				Description: "Config format. Defaults to json.",
+				Enum:        []any{"json", "yaml"},
+				Default:     json.RawMessage(`"json"`),
+			},
+		},
+	}
 }
 
 func normalizeListDaosLimit(limit int) int {

--- a/backend/internal/mcp/tools_dao_test.go
+++ b/backend/internal/mcp/tools_dao_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -196,6 +197,53 @@ func TestDaoToolsRejectInvalidDaoCode(t *testing.T) {
 	}
 }
 
+func TestDaoToolInputSchemasAreConstrained(t *testing.T) {
+	t.Parallel()
+
+	session, closeSession := newTestMCPSession(t, Config{
+		Name:             "degov-square",
+		Version:          "test-version",
+		DaoService:       &fakeDaoService{},
+		DaoConfigService: &fakeDaoConfigService{},
+	})
+	defer closeSession()
+
+	result, err := session.ListTools(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("ListTools() error = %v", err)
+	}
+
+	listDaosSchema := toolInputSchema(t, result.Tools, "list_daos")
+	codes := schemaProperty(t, listDaosSchema, "codes")
+	if got := codes["type"]; got != "array" {
+		t.Fatalf("list_daos codes type = %v, want array", got)
+	}
+	codesItems := codes["items"].(map[string]any)
+	if got := codesItems["type"]; got != "string" {
+		t.Fatalf("list_daos codes item type = %v, want string", got)
+	}
+	if got := codesItems["pattern"]; got != daoCodePattern.String() {
+		t.Fatalf("list_daos codes pattern = %v, want %s", got, daoCodePattern.String())
+	}
+
+	state := schemaProperty(t, listDaosSchema, "state")
+	if got := state["type"]; got != "array" {
+		t.Fatalf("list_daos state type = %v, want array", got)
+	}
+	stateItems := state["items"].(map[string]any)
+	if got := stateItems["type"]; got != "string" {
+		t.Fatalf("list_daos state item type = %v, want string", got)
+	}
+	assertStringEnum(t, stateItems["enum"], []string{"ACTIVE", "DRAFT", "INACTIVE"})
+
+	getDaoConfigSchema := toolInputSchema(t, result.Tools, "get_dao_config")
+	format := schemaProperty(t, getDaoConfigSchema, "format")
+	if got := format["type"]; got != "string" {
+		t.Fatalf("get_dao_config format type = %v, want string", got)
+	}
+	assertStringEnum(t, format["enum"], []string{"json", "yaml"})
+}
+
 func TestDaoToolsReturnStructuredNotFoundError(t *testing.T) {
 	t.Parallel()
 
@@ -223,6 +271,58 @@ func TestDaoToolsReturnStructuredNotFoundError(t *testing.T) {
 	}
 	if !strings.Contains(rpcErr.Message, "not found") {
 		t.Fatalf("error message %q does not mention not found", rpcErr.Message)
+	}
+}
+
+func toolInputSchema(t *testing.T, tools []*sdkmcp.Tool, name string) map[string]any {
+	t.Helper()
+
+	for _, tool := range tools {
+		if tool.Name != name {
+			continue
+		}
+		data, err := json.Marshal(tool.InputSchema)
+		if err != nil {
+			t.Fatalf("Marshal %s input schema: %v", name, err)
+		}
+		var schema map[string]any
+		if err := json.Unmarshal(data, &schema); err != nil {
+			t.Fatalf("Unmarshal %s input schema: %v", name, err)
+		}
+		return schema
+	}
+	t.Fatalf("%s not found in tool listing", name)
+	return nil
+}
+
+func schemaProperty(t *testing.T, schema map[string]any, name string) map[string]any {
+	t.Helper()
+
+	properties, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("schema properties type = %T, want map[string]any", schema["properties"])
+	}
+	property, ok := properties[name].(map[string]any)
+	if !ok {
+		t.Fatalf("schema property %s type = %T, want map[string]any", name, properties[name])
+	}
+	return property
+}
+
+func assertStringEnum(t *testing.T, value any, want []string) {
+	t.Helper()
+
+	values, ok := value.([]any)
+	if !ok {
+		t.Fatalf("enum type = %T, want []any", value)
+	}
+	if len(values) != len(want) {
+		t.Fatalf("enum len = %d, want %d", len(values), len(want))
+	}
+	for i, value := range values {
+		if value != want[i] {
+			t.Fatalf("enum[%d] = %v, want %s", i, value, want[i])
+		}
 	}
 }
 

--- a/backend/internal/mcp/tools_dao_test.go
+++ b/backend/internal/mcp/tools_dao_test.go
@@ -227,14 +227,10 @@ func TestDaoToolInputSchemasAreConstrained(t *testing.T) {
 	}
 
 	state := schemaProperty(t, listDaosSchema, "state")
-	if got := state["type"]; got != "array" {
-		t.Fatalf("list_daos state type = %v, want array", got)
+	if got := state["type"]; got != "string" {
+		t.Fatalf("list_daos state type = %v, want string", got)
 	}
-	stateItems := state["items"].(map[string]any)
-	if got := stateItems["type"]; got != "string" {
-		t.Fatalf("list_daos state item type = %v, want string", got)
-	}
-	assertStringEnum(t, stateItems["enum"], []string{"ACTIVE", "DRAFT", "INACTIVE"})
+	assertStringEnum(t, state["enum"], []string{"ACTIVE", "DRAFT", "INACTIVE", "active", "draft", "inactive"})
 
 	getDaoConfigSchema := toolInputSchema(t, result.Tools, "get_dao_config")
 	format := schemaProperty(t, getDaoConfigSchema, "format")

--- a/backend/internal/mcp/tools_indexer.go
+++ b/backend/internal/mcp/tools_indexer.go
@@ -19,9 +19,7 @@ func addIndexerTools(server *sdkmcp.Server, cfg Config) {
 		Name:        "get_contributor",
 		Title:       "Get Contributor",
 		Description: "Return an indexer-backed governance contributor for a DAO.",
-		Annotations: &sdkmcp.ToolAnnotations{
-			ReadOnlyHint: true,
-		},
+		Annotations: readOnlyToolAnnotations(),
 	}, func(ctx context.Context, req *sdkmcp.CallToolRequest, input getContributorInput) (*sdkmcp.CallToolResult, getContributorOutput, error) {
 		return getContributorTool(ctx, cfg, input)
 	})
@@ -30,9 +28,7 @@ func addIndexerTools(server *sdkmcp.Server, cfg Config) {
 		Name:        "list_contributors",
 		Title:       "List Contributors",
 		Description: "Return bounded indexer-backed governance contributors for a DAO.",
-		Annotations: &sdkmcp.ToolAnnotations{
-			ReadOnlyHint: true,
-		},
+		Annotations: readOnlyToolAnnotations(),
 	}, func(ctx context.Context, req *sdkmcp.CallToolRequest, input listContributorsInput) (*sdkmcp.CallToolResult, listContributorsOutput, error) {
 		return listContributorsTool(ctx, cfg, input)
 	})
@@ -41,9 +37,7 @@ func addIndexerTools(server *sdkmcp.Server, cfg Config) {
 		Name:        "list_proposal_votes",
 		Title:       "List Proposal Votes",
 		Description: "Return bounded indexer-backed vote rows for a DAO proposal.",
-		Annotations: &sdkmcp.ToolAnnotations{
-			ReadOnlyHint: true,
-		},
+		Annotations: readOnlyToolAnnotations(),
 	}, func(ctx context.Context, req *sdkmcp.CallToolRequest, input listProposalVotesInput) (*sdkmcp.CallToolResult, listProposalVotesOutput, error) {
 		return listProposalVotesTool(ctx, cfg, input)
 	})

--- a/backend/internal/mcp/tools_indexer.go
+++ b/backend/internal/mcp/tools_indexer.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/jsonschema-go/jsonschema"
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 	gqlmodels "github.com/ringecosystem/degov-square/graph/models"
 	degovinternal "github.com/ringecosystem/degov-square/internal"
@@ -29,6 +30,7 @@ func addIndexerTools(server *sdkmcp.Server, cfg Config) {
 		Title:       "List Contributors",
 		Description: "Return bounded indexer-backed governance contributors for a DAO.",
 		Annotations: readOnlyToolAnnotations(),
+		InputSchema: listContributorsInputSchema(),
 	}, func(ctx context.Context, req *sdkmcp.CallToolRequest, input listContributorsInput) (*sdkmcp.CallToolResult, listContributorsOutput, error) {
 		return listContributorsTool(ctx, cfg, input)
 	})
@@ -41,6 +43,33 @@ func addIndexerTools(server *sdkmcp.Server, cfg Config) {
 	}, func(ctx context.Context, req *sdkmcp.CallToolRequest, input listProposalVotesInput) (*sdkmcp.CallToolResult, listProposalVotesOutput, error) {
 		return listProposalVotesTool(ctx, cfg, input)
 	})
+}
+
+func listContributorsInputSchema() *jsonschema.Schema {
+	return &jsonschema.Schema{
+		Type:     "object",
+		Required: []string{"daoCode"},
+		Properties: map[string]*jsonschema.Schema{
+			"daoCode": {
+				Type:        "string",
+				Description: "DAO code, for example ring-dao.",
+				Pattern:     daoCodePattern.String(),
+			},
+			"limit": {
+				Type:        "integer",
+				Description: "Maximum number of contributors to return.",
+			},
+			"offset": {
+				Type:        "integer",
+				Description: "Number of contributors to skip.",
+			},
+			"orderBy": {
+				Type:        "string",
+				Description: "Contributor sort order. Defaults to power_desc.",
+				Enum:        []any{"power_desc", "power_asc", "id_asc"},
+			},
+		},
+	}
 }
 
 func getContributorTool(ctx context.Context, cfg Config, input getContributorInput) (*sdkmcp.CallToolResult, getContributorOutput, error) {

--- a/backend/internal/mcp/tools_indexer_test.go
+++ b/backend/internal/mcp/tools_indexer_test.go
@@ -164,6 +164,34 @@ func TestIndexerToolAnnotationsAreReadOnly(t *testing.T) {
 	}
 }
 
+func TestToolAnnotationsSetRequiredHints(t *testing.T) {
+	session, closeSession := newTestMCPSession(t, Config{
+		Name:    "test-server",
+		Version: "test-version",
+	})
+	defer closeSession()
+
+	result, err := session.ListTools(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("ListTools() error = %v", err)
+	}
+
+	for _, tool := range result.Tools {
+		if tool.Annotations == nil {
+			t.Fatalf("%s annotations = nil", tool.Name)
+		}
+		if !tool.Annotations.ReadOnlyHint {
+			t.Fatalf("%s readOnlyHint = false, want true", tool.Name)
+		}
+		if tool.Annotations.OpenWorldHint == nil || *tool.Annotations.OpenWorldHint {
+			t.Fatalf("%s openWorldHint = %v, want false", tool.Name, tool.Annotations.OpenWorldHint)
+		}
+		if tool.Annotations.DestructiveHint == nil || *tool.Annotations.DestructiveHint {
+			t.Fatalf("%s destructiveHint = %v, want false", tool.Name, tool.Annotations.DestructiveHint)
+		}
+	}
+}
+
 func TestIndexerToolsRejectUnknownDAO(t *testing.T) {
 	server := newTestProposalServer(t)
 

--- a/backend/internal/mcp/tools_indexer_test.go
+++ b/backend/internal/mcp/tools_indexer_test.go
@@ -164,6 +164,24 @@ func TestIndexerToolAnnotationsAreReadOnly(t *testing.T) {
 	}
 }
 
+func TestIndexerToolInputSchemasAreConstrained(t *testing.T) {
+	server := newTestProposalServer(t)
+	session, closeSession := newProposalTestSession(t, server)
+	defer closeSession()
+
+	result, err := session.ListTools(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("ListTools() error = %v", err)
+	}
+
+	listContributorsSchema := toolInputSchema(t, result.Tools, "list_contributors")
+	orderBy := schemaProperty(t, listContributorsSchema, "orderBy")
+	if got := orderBy["type"]; got != "string" {
+		t.Fatalf("list_contributors orderBy type = %v, want string", got)
+	}
+	assertStringEnum(t, orderBy["enum"], []string{"power_desc", "power_asc", "id_asc"})
+}
+
 func TestToolAnnotationsSetRequiredHints(t *testing.T) {
 	session, closeSession := newTestMCPSession(t, Config{
 		Name:    "test-server",

--- a/backend/internal/mcp/tools_ping.go
+++ b/backend/internal/mcp/tools_ping.go
@@ -19,9 +19,7 @@ func addPingTool(server *sdkmcp.Server, cfg Config) {
 		Name:        "ping",
 		Title:       "Ping",
 		Description: "Return the MCP service health status.",
-		Annotations: &sdkmcp.ToolAnnotations{
-			ReadOnlyHint: true,
-		},
+		Annotations: readOnlyToolAnnotations(),
 	}, func(ctx context.Context, req *sdkmcp.CallToolRequest, input pingInput) (*sdkmcp.CallToolResult, pingOutput, error) {
 		return nil, pingOutput{
 			Status:  "ok",

--- a/backend/internal/mcp/tools_proposal.go
+++ b/backend/internal/mcp/tools_proposal.go
@@ -8,7 +8,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/jsonschema-go/jsonschema"
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	dbmodels "github.com/ringecosystem/degov-square/database/models"
 	gqlmodels "github.com/ringecosystem/degov-square/graph/models"
 	degovinternal "github.com/ringecosystem/degov-square/internal"
 	"github.com/ringecosystem/degov-square/services"
@@ -22,6 +24,7 @@ func addProposalTools(server *sdkmcp.Server, cfg Config) {
 		Title:       "List Proposals",
 		Description: "Return bounded governance proposal rows for a DAO.",
 		Annotations: readOnlyToolAnnotations(),
+		InputSchema: listProposalsInputSchema(),
 	}, listProposalsTool)
 
 	sdkmcp.AddTool(server, &sdkmcp.Tool{
@@ -39,6 +42,51 @@ func addProposalTools(server *sdkmcp.Server, cfg Config) {
 		Description: "Return the cached governance proposal state for a DAO.",
 		Annotations: readOnlyToolAnnotations(),
 	}, getProposalStateTool)
+}
+
+func listProposalsInputSchema() *jsonschema.Schema {
+	return &jsonschema.Schema{
+		Type:     "object",
+		Required: []string{"daoCode"},
+		Properties: map[string]*jsonschema.Schema{
+			"daoCode": {
+				Type:        "string",
+				Description: "DAO code, for example ring-dao.",
+			},
+			"state": {
+				Type:        "string",
+				Description: "Optional proposal state filter.",
+				Enum: []any{
+					string(dbmodels.ProposalStateUnknown),
+					string(dbmodels.ProposalStatePending),
+					string(dbmodels.ProposalStateActive),
+					string(dbmodels.ProposalStateCanceled),
+					string(dbmodels.ProposalStateDefeated),
+					string(dbmodels.ProposalStateSucceeded),
+					string(dbmodels.ProposalStateQueued),
+					string(dbmodels.ProposalStateExecuted),
+					string(dbmodels.ProposalStateExpired),
+					strings.ToLower(string(dbmodels.ProposalStateUnknown)),
+					strings.ToLower(string(dbmodels.ProposalStatePending)),
+					strings.ToLower(string(dbmodels.ProposalStateActive)),
+					strings.ToLower(string(dbmodels.ProposalStateCanceled)),
+					strings.ToLower(string(dbmodels.ProposalStateDefeated)),
+					strings.ToLower(string(dbmodels.ProposalStateSucceeded)),
+					strings.ToLower(string(dbmodels.ProposalStateQueued)),
+					strings.ToLower(string(dbmodels.ProposalStateExecuted)),
+					strings.ToLower(string(dbmodels.ProposalStateExpired)),
+				},
+			},
+			"limit": {
+				Type:        "integer",
+				Description: "Maximum number of proposals to return.",
+			},
+			"offset": {
+				Type:        "integer",
+				Description: "Number of proposals to skip.",
+			},
+		},
+	}
 }
 
 func listProposalsTool(ctx context.Context, req *sdkmcp.CallToolRequest, input listProposalsInput) (*sdkmcp.CallToolResult, listProposalsOutput, error) {

--- a/backend/internal/mcp/tools_proposal.go
+++ b/backend/internal/mcp/tools_proposal.go
@@ -21,18 +21,14 @@ func addProposalTools(server *sdkmcp.Server, cfg Config) {
 		Name:        "list_proposals",
 		Title:       "List Proposals",
 		Description: "Return bounded governance proposal rows for a DAO.",
-		Annotations: &sdkmcp.ToolAnnotations{
-			ReadOnlyHint: true,
-		},
+		Annotations: readOnlyToolAnnotations(),
 	}, listProposalsTool)
 
 	sdkmcp.AddTool(server, &sdkmcp.Tool{
 		Name:        "get_proposal",
 		Title:       "Get Proposal",
 		Description: "Return a governance proposal detail payload for a DAO.",
-		Annotations: &sdkmcp.ToolAnnotations{
-			ReadOnlyHint: true,
-		},
+		Annotations: readOnlyToolAnnotations(),
 	}, func(ctx context.Context, req *sdkmcp.CallToolRequest, input getProposalInput) (*sdkmcp.CallToolResult, getProposalOutput, error) {
 		return getProposalTool(ctx, cfg, input)
 	})
@@ -41,9 +37,7 @@ func addProposalTools(server *sdkmcp.Server, cfg Config) {
 		Name:        "get_proposal_state",
 		Title:       "Get Proposal State",
 		Description: "Return the cached governance proposal state for a DAO.",
-		Annotations: &sdkmcp.ToolAnnotations{
-			ReadOnlyHint: true,
-		},
+		Annotations: readOnlyToolAnnotations(),
 	}, getProposalStateTool)
 }
 

--- a/backend/internal/mcp/tools_proposal_test.go
+++ b/backend/internal/mcp/tools_proposal_test.go
@@ -360,6 +360,43 @@ func TestProposalToolsListIncludesGetProposalState(t *testing.T) {
 	t.Fatal("get_proposal_state not found in tool listing")
 }
 
+func TestProposalToolInputSchemasAreConstrained(t *testing.T) {
+	server := newTestProposalServer(t)
+	session, closeSession := newProposalTestSession(t, server)
+	defer closeSession()
+
+	result, err := session.ListTools(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("ListTools() error = %v", err)
+	}
+
+	listProposalsSchema := toolInputSchema(t, result.Tools, "list_proposals")
+	state := schemaProperty(t, listProposalsSchema, "state")
+	if got := state["type"]; got != "string" {
+		t.Fatalf("list_proposals state type = %v, want string", got)
+	}
+	assertStringEnum(t, state["enum"], []string{
+		"UNKNOWN",
+		"PENDING",
+		"ACTIVE",
+		"CANCELED",
+		"DEFEATED",
+		"SUCCEEDED",
+		"QUEUED",
+		"EXECUTED",
+		"EXPIRED",
+		"unknown",
+		"pending",
+		"active",
+		"canceled",
+		"defeated",
+		"succeeded",
+		"queued",
+		"executed",
+		"expired",
+	})
+}
+
 func TestProposalToolsListOmitsStandaloneENSTools(t *testing.T) {
 	server := newTestProposalServer(t)
 	session, closeSession := newProposalTestSession(t, server)
@@ -572,7 +609,7 @@ func TestProposalToolsReturnClearErrors(t *testing.T) {
 			name:      "invalid state",
 			tool:      "list_proposals",
 			arguments: map[string]any{"daoCode": "ring-dao", "state": "bad"},
-			wantError: "invalid_state",
+			wantError: "does not equal any of",
 		},
 		{
 			name:      "invalid dao code",

--- a/backend/internal/mcp/tools_summary.go
+++ b/backend/internal/mcp/tools_summary.go
@@ -19,9 +19,7 @@ func addProposalSummaryTool(server *sdkmcp.Server, cfg Config) {
 		Name:        "summarize_proposal",
 		Title:       "Summarize Proposal",
 		Description: "Return a cached proposal summary, or generate one only when MCP summary generation is enabled.",
-		Annotations: &sdkmcp.ToolAnnotations{
-			ReadOnlyHint: true,
-		},
+		Annotations: readOnlyToolAnnotations(),
 	}, func(ctx context.Context, req *sdkmcp.CallToolRequest, input summarizeProposalInput) (*sdkmcp.CallToolResult, summarizeProposalOutput, error) {
 		return summarizeProposalTool(ctx, cfg, input)
 	})

--- a/backend/internal/mcp/types_dao.go
+++ b/backend/internal/mcp/types_dao.go
@@ -21,7 +21,7 @@ type daoConfigService interface {
 
 type listDaosInput struct {
 	Codes []string `json:"codes,omitempty" jsonschema:"DAO codes to filter by."`
-	State []string `json:"state,omitempty" jsonschema:"DAO states to filter by."`
+	State string   `json:"state,omitempty" jsonschema:"DAO state to filter by."`
 	Limit int      `json:"limit,omitempty" jsonschema:"Maximum number of DAOs to return. Values above 100 are capped."`
 }
 


### PR DESCRIPTION
## Summary
- add the public `/.well-known/openai-apps-challenge` endpoint backed by `OPENAI_APPS_CHALLENGE_TOKEN`
- explicitly set `readOnlyHint`, `openWorldHint`, and `destructiveHint` on MCP tools
- keep this branch based on `419a3e727d1880de9534ae140457479684aad29d` so it does not include the datalens schema change from `7de6633`

## Tests
- `cd backend && go test ./...`

This PR is intentionally left open for review.