### PR TITLE
fix(indexer): restore proposal and vote tracking

### DIFF
--- a/backend/database/models/dao.go
+++ b/backend/database/models/dao.go
@@ -65,8 +65,8 @@ type Dao struct {
 	MetricsCountMembers    int        `gorm:"column:metrics_count_members;not null;default:0" json:"metrics_count_members"`
 	MetricsSumPower        string     `gorm:"column:metrics_sum_power;type:varchar(255);not null;default:'0'" json:"metrics_sum_power"`
 	MetricsCountVote       int        `gorm:"column:metrics_count_vote;not null;default:0" json:"metrics_count_vote"`
-	LastTrackedBlockNumber int64      `gorm:"column:last_tracked_block_number;not null;default:0" json:"last_tracked_block_number"`                  // Last tracked proposal block number (blockNumber cursor)
-	LastTrackedProposalID  string     `gorm:"column:last_tracked_proposal_id;type:varchar(255);not null;default:''" json:"last_tracked_proposal_id"` // Last tracked indexer proposal id for blockNumber tie-breaker
+	LastTrackedBlockNumber int64      `gorm:"column:last_tracked_block_number;not null;default:0" json:"last_tracked_block_number"`          // Last tracked proposal block number (blockNumber cursor)
+	LastTrackedProposalID  string     `gorm:"column:last_tracked_proposal_id;type:text;not null;default:''" json:"last_tracked_proposal_id"` // Last tracked indexer proposal id for blockNumber tie-breaker
 	CTime                  time.Time  `gorm:"column:ctime;default:now()" json:"ctime"`
 	UTime                  *time.Time `gorm:"column:utime" json:"utime,omitempty"`
 }

--- a/backend/database/models/dao_test.go
+++ b/backend/database/models/dao_test.go
@@ -16,11 +16,38 @@ func TestLastTrackedProposalIDUsesTextColumn(t *testing.T) {
 		t.Fatalf("LastTrackedProposalID gorm tag = %q, want type:text", got)
 	}
 
-	migration, err := os.ReadFile("../../migrations/000007_proposal_cursor_text.up.sql")
+	upMigration, err := os.ReadFile("../../migrations/000007_proposal_cursor_text.up.sql")
 	if err != nil {
-		t.Fatalf("read cursor migration: %v", err)
+		t.Fatalf("read cursor up migration: %v", err)
 	}
-	if got := string(migration); !strings.Contains(got, "ALTER COLUMN last_tracked_proposal_id TYPE text") {
-		t.Fatalf("migration = %q, want last_tracked_proposal_id text conversion", got)
+	upSQL := string(upMigration)
+	if !strings.Contains(upSQL, "ALTER COLUMN last_tracked_proposal_id TYPE text") {
+		t.Fatalf("up migration = %q, want last_tracked_proposal_id text conversion", upSQL)
+	}
+	for _, destructive := range []string{"left(", "substring(", "substr(", "USING"} {
+		if strings.Contains(strings.ToLower(upSQL), strings.ToLower(destructive)) {
+			t.Fatalf("up migration = %q, must widen without data rewrite %q", upSQL, destructive)
+		}
+	}
+
+	downMigration, err := os.ReadFile("../../migrations/000007_proposal_cursor_text.down.sql")
+	if err != nil {
+		t.Fatalf("read cursor down migration: %v", err)
+	}
+	downSQL := string(downMigration)
+	for _, required := range []string{
+		"IF EXISTS",
+		"length(last_tracked_proposal_id) > 255",
+		"RAISE EXCEPTION",
+		"ALTER COLUMN last_tracked_proposal_id TYPE varchar(255)",
+	} {
+		if !strings.Contains(downSQL, required) {
+			t.Fatalf("down migration = %q, want explicit non-lossy rollback contract %q", downSQL, required)
+		}
+	}
+	for _, destructive := range []string{"left(", "substring(", "substr("} {
+		if strings.Contains(strings.ToLower(downSQL), destructive) {
+			t.Fatalf("down migration = %q, must refuse rather than truncate with %q", downSQL, destructive)
+		}
 	}
 }

--- a/backend/database/models/dao_test.go
+++ b/backend/database/models/dao_test.go
@@ -1,0 +1,26 @@
+package dbmodels
+
+import (
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestLastTrackedProposalIDUsesTextColumn(t *testing.T) {
+	field, ok := reflect.TypeOf(Dao{}).FieldByName("LastTrackedProposalID")
+	if !ok {
+		t.Fatal("Dao.LastTrackedProposalID field not found")
+	}
+	if got := field.Tag.Get("gorm"); !strings.Contains(got, "type:text") {
+		t.Fatalf("LastTrackedProposalID gorm tag = %q, want type:text", got)
+	}
+
+	migration, err := os.ReadFile("../../migrations/000007_proposal_cursor_text.up.sql")
+	if err != nil {
+		t.Fatalf("read cursor migration: %v", err)
+	}
+	if got := string(migration); !strings.Contains(got, "ALTER COLUMN last_tracked_proposal_id TYPE text") {
+		t.Fatalf("migration = %q, want last_tracked_proposal_id text conversion", got)
+	}
+}

--- a/backend/database/models/dao_test.go
+++ b/backend/database/models/dao_test.go
@@ -39,6 +39,7 @@ func TestLastTrackedProposalIDUsesTextColumn(t *testing.T) {
 		"IF EXISTS",
 		"length(last_tracked_proposal_id) > 255",
 		"RAISE EXCEPTION",
+		"END;\n$$;",
 		"ALTER COLUMN last_tracked_proposal_id TYPE varchar(255)",
 	} {
 		if !strings.Contains(downSQL, required) {

--- a/backend/internal/indexer.go
+++ b/backend/internal/indexer.go
@@ -498,32 +498,48 @@ func (d *DegovIndexer) QueryContributor(ctx context.Context, scope ProposalScope
 }
 
 func (d *DegovIndexer) QueryVote(scope ProposalScope, proposalId string, id string) (*VoteCast, error) {
+	query := `
+		query QueryVote($where: ProposalWhereInput!, $voterWhere: VoteCastGroupWhereInput!) {
+			proposals(orderBy: [id_ASC], limit: 2, where: $where) {
+				voters(where: $voterWhere, orderBy: [id_ASC], limit: 2) {
+					reason
+					support
+					voter
+					weight
+					transactionHash
+					id
+					blockNumber
+					blockTimestamp
+				}
+			}
+		}
+	`
+
+	req := graphql.NewRequest(query)
+	req.Var("where", scope.withScope(map[string]any{
+		"proposalId_eq": proposalId,
+	}))
+	req.Var("voterWhere", map[string]any{"id_eq": id})
+
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	const limit = 50
-	seenIDs := make(map[string]struct{})
-	for offset := 0; ; offset += limit {
-		votes, err := d.QueryVotes(ctx, scope, offset, limit, proposalId)
-		if err != nil {
-			return nil, fmt.Errorf("failed to query vote page at offset %d: %w", offset, err)
+	var response ProposalVotersResponse
+	if err := d.client.Run(ctx, req, &response); err != nil {
+		return nil, fmt.Errorf("failed to execute QueryVote: %w", err)
+	}
+	if len(response.Proposals) > 1 {
+		return nil, fmt.Errorf("multiple proposals found for proposalId %s", proposalId)
+	}
+	if len(response.Proposals) == 1 {
+		votes := response.Proposals[0].Voters
+		if len(votes) > 1 {
+			return nil, fmt.Errorf("multiple votes found with id %s", id)
 		}
-		newIDs := 0
-		for _, vote := range votes {
-			if vote.ID == id {
-				return &vote, nil
-			}
-			if _, exists := seenIDs[vote.ID]; exists {
-				continue
-			}
-			seenIDs[vote.ID] = struct{}{}
-			newIDs++
-		}
-		if len(votes) < limit {
-			break
-		}
-		if newIDs == 0 {
-			return nil, fmt.Errorf("vote pagination made no progress at offset %d", offset)
+		if len(votes) == 1 {
+			vote := votes[0]
+			vote.ProposalID = proposalId
+			return &vote, nil
 		}
 	}
 

--- a/backend/internal/indexer.go
+++ b/backend/internal/indexer.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -102,6 +103,12 @@ type VoteCastsResponse struct {
 	VoteCasts []VoteCast `json:"voteCasts"`
 }
 
+type ProposalVotersResponse struct {
+	Proposals []struct {
+		Voters []VoteCast `json:"voters"`
+	} `json:"proposals"`
+}
+
 type Contributor struct {
 	ID                      string  `json:"id"`
 	Power                   string  `json:"power"`
@@ -140,6 +147,7 @@ func (s ProposalScope) withScope(where map[string]any) map[string]any {
 type DegovIndexer struct {
 	client   *graphql.Client
 	endpoint string
+	now      func() time.Time
 }
 
 // NewDegovIndexer creates a new DegovIndexer instance with the given endpoint
@@ -148,6 +156,7 @@ func NewDegovIndexer(endpoint string) *DegovIndexer {
 	return &DegovIndexer{
 		client:   client,
 		endpoint: endpoint,
+		now:      time.Now,
 	}
 }
 
@@ -309,41 +318,44 @@ func (d *DegovIndexer) InspectProposalWithContext(ctx context.Context, scope Pro
 // QueryProposalsByBlockNumber queries proposals after the given blockNumber/id cursor.
 func (d *DegovIndexer) QueryProposalsByBlockNumber(scope ProposalScope, afterBlockNumber int64, afterProposalID string) ([]Proposal, error) {
 	const limit = 30
-	proposals := make([]Proposal, 0, limit)
-
-	if afterBlockNumber > 0 {
-		sameBlockFilter := map[string]any{
-			"blockNumber_eq": strconv.FormatInt(afterBlockNumber, 10),
-		}
-		if strings.TrimSpace(afterProposalID) != "" {
-			sameBlockFilter["id_gt"] = afterProposalID
-		}
-
-		sameBlockProposals, err := d.queryProposalsByBlockNumber(scope, sameBlockFilter, limit)
-		if err != nil {
-			return nil, err
-		}
-
-		proposals = append(proposals, sameBlockProposals...)
-		if len(proposals) >= limit {
-			return proposals, nil
-		}
-	}
-
-	nextBlockProposals, err := d.queryProposalsByBlockNumber(scope, map[string]any{
-		"blockNumber_gt": strconv.FormatInt(afterBlockNumber, 10),
-	}, limit-len(proposals))
+	allProposals, err := d.queryProposalsByBlockNumber(scope, limit)
 	if err != nil {
 		return nil, err
 	}
 
-	return append(proposals, nextBlockProposals...), nil
+	type proposalWithBlockNumber struct {
+		proposal    Proposal
+		blockNumber int64
+	}
+	proposals := make([]proposalWithBlockNumber, 0, len(allProposals))
+	for _, proposal := range allProposals {
+		blockNumber, err := strconv.ParseInt(proposal.BlockNumber, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid blockNumber %q for proposal %q: %w", proposal.BlockNumber, proposal.ID, err)
+		}
+		if blockNumber > afterBlockNumber || (blockNumber == afterBlockNumber && proposal.ID > afterProposalID) {
+			proposals = append(proposals, proposalWithBlockNumber{proposal: proposal, blockNumber: blockNumber})
+		}
+	}
+
+	sort.Slice(proposals, func(i, j int) bool {
+		if proposals[i].blockNumber != proposals[j].blockNumber {
+			return proposals[i].blockNumber < proposals[j].blockNumber
+		}
+		return proposals[i].proposal.ID < proposals[j].proposal.ID
+	})
+
+	result := make([]Proposal, len(proposals))
+	for i := range proposals {
+		result[i] = proposals[i].proposal
+	}
+	return result, nil
 }
 
-func (d *DegovIndexer) queryProposalsByBlockNumber(scope ProposalScope, whereFilter map[string]any, limit int) ([]Proposal, error) {
+func (d *DegovIndexer) queryProposalsByBlockNumber(scope ProposalScope, limit int) ([]Proposal, error) {
 	query := `
-		query QueryProposalsByBlockNumber($limit: Int!, $where: ProposalWhereInput) {
-			proposals(orderBy: [blockNumber_ASC_NULLS_FIRST, id_ASC], limit: $limit, where: $where) {
+		query QueryProposalsByBlockNumber($limit: Int!, $offset: Int!, $where: ProposalWhereInput) {
+			proposals(orderBy: [blockTimestamp_DESC_NULLS_LAST, id_ASC], limit: $limit, offset: $offset, where: $where) {
 				id
 				chainId
 				daoCode
@@ -379,19 +391,42 @@ func (d *DegovIndexer) queryProposalsByBlockNumber(scope ProposalScope, whereFil
 		}
 	`
 
-	req := graphql.NewRequest(query)
-	req.Var("limit", limit)
-	req.Var("where", scope.withScope(whereFilter))
-
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	var response ProposalsResponse
-	if err := d.client.Run(ctx, req, &response); err != nil {
-		return nil, fmt.Errorf("failed to execute QueryProposalsByBlockNumber: %w", err)
+	var proposals []Proposal
+	seenIDs := make(map[string]struct{})
+	seenPages := make(map[string]struct{})
+	for offset := 0; ; offset += limit {
+		req := graphql.NewRequest(query)
+		req.Var("limit", limit)
+		req.Var("offset", offset)
+		req.Var("where", scope.withScope(nil))
+
+		var response ProposalsResponse
+		if err := d.client.Run(ctx, req, &response); err != nil {
+			return nil, fmt.Errorf("failed to execute QueryProposalsByBlockNumber: %w", err)
+		}
+
+		pageKey := ""
+		for _, proposal := range response.Proposals {
+			pageKey += "\x00" + proposal.ID
+			if _, exists := seenIDs[proposal.ID]; exists {
+				continue
+			}
+			seenIDs[proposal.ID] = struct{}{}
+			proposals = append(proposals, proposal)
+		}
+		if len(response.Proposals) < limit {
+			break
+		}
+		if _, exists := seenPages[pageKey]; exists {
+			break
+		}
+		seenPages[pageKey] = struct{}{}
 	}
 
-	return response.Proposals, nil
+	return proposals, nil
 }
 
 func (d *DegovIndexer) QueryVotesOffset(ctx context.Context, scope ProposalScope, offset int, proposalId string) ([]VoteCast, error) {
@@ -400,17 +435,18 @@ func (d *DegovIndexer) QueryVotesOffset(ctx context.Context, scope ProposalScope
 
 func (d *DegovIndexer) QueryVotes(ctx context.Context, scope ProposalScope, offset int, limit int, proposalId string) ([]VoteCast, error) {
 	query := `
-		query QueryVotesOffset($limit: Int!, $offset: Int!, $where: VoteCastWhereInput!) {
-			voteCasts(orderBy: blockNumber_ASC_NULLS_FIRST, limit: $limit, offset: $offset, where: $where) {
-				proposalId
-				reason
-				support
-				voter
-				weight
-				transactionHash
-				id
-				blockNumber
-				blockTimestamp
+		query QueryVotesOffset($limit: Int!, $offset: Int!, $where: ProposalWhereInput!) {
+			proposals(where: $where) {
+				voters(orderBy: [blockTimestamp_ASC_NULLS_LAST, id_ASC], limit: $limit, offset: $offset) {
+					reason
+					support
+					voter
+					weight
+					transactionHash
+					id
+					blockNumber
+					blockTimestamp
+				}
 			}
 		}
 	`
@@ -421,12 +457,19 @@ func (d *DegovIndexer) QueryVotes(ctx context.Context, scope ProposalScope, offs
 		"proposalId_eq": proposalId,
 	}))
 
-	var response VoteCastsResponse
+	var response ProposalVotersResponse
 	if err := d.client.Run(ctx, req, &response); err != nil {
 		return nil, fmt.Errorf("failed to execute QueryVotesOffset: %w", err)
 	}
 
-	return response.VoteCasts, nil
+	var votes []VoteCast
+	for _, proposal := range response.Proposals {
+		for _, vote := range proposal.Voters {
+			vote.ProposalID = proposalId
+			votes = append(votes, vote)
+		}
+	}
+	return votes, nil
 }
 
 func (d *DegovIndexer) QueryContributors(ctx context.Context, scope ProposalScope, offset int, limit int, orderBy string) ([]Contributor, error) {
@@ -566,7 +609,7 @@ func (d *DegovIndexer) QueryExpiringProposals(scope ProposalScope) ([]Proposal, 
 	  proposals(
 	    limit: $limit
 	    offset: $offset
-	    orderBy: blockTimestamp_ASC_NULLS_FIRST
+	    orderBy: [blockTimestamp_DESC_NULLS_LAST, id_ASC]
 	    where: $where
 	  ) {
 	    id
@@ -603,39 +646,54 @@ func (d *DegovIndexer) QueryExpiringProposals(scope ProposalScope) ([]Proposal, 
 	`
 
 	const limit = 50
-	var offset = 0
-	var allProposals []Proposal
+	var proposals []Proposal
 
-	now := time.Now()
+	now := d.now()
 	startTimestamp := now.UnixMilli()
-	endTimestamp := now.Add(2 * 24 * 60 * time.Minute).UnixMilli()
+	endTimestamp := now.Add(48 * time.Hour).UnixMilli()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	for {
+	seenIDs := make(map[string]struct{})
+	seenPages := make(map[string]struct{})
+	for offset := 0; ; offset += limit {
 		req := graphql.NewRequest(query)
 
 		req.Var("limit", limit)
 		req.Var("offset", offset)
-		req.Var("where", scope.withScope(map[string]any{
-			"voteEndTimestamp_gte": startTimestamp,
-			"voteEndTimestamp_lt":  endTimestamp,
-		}))
+		req.Var("where", scope.withScope(nil))
 
 		var response ProposalsResponse
 
 		if err := d.client.Run(ctx, req, &response); err != nil {
 			return nil, fmt.Errorf("graphql query failed on offset %d: %w", offset, err)
 		}
-		if len(response.Proposals) == 0 {
+		pageKey := ""
+		for _, proposal := range response.Proposals {
+			pageKey += "\x00" + proposal.ID
+			if _, exists := seenIDs[proposal.ID]; exists {
+				continue
+			}
+			seenIDs[proposal.ID] = struct{}{}
+			voteEndTimestamp, err := strconv.ParseInt(proposal.VoteEndTimestamp, 10, 64)
+			if err != nil {
+				continue
+			}
+			if voteEndTimestamp >= startTimestamp && voteEndTimestamp < endTimestamp {
+				proposals = append(proposals, proposal)
+			}
+		}
+		if len(response.Proposals) < limit {
 			break
 		}
-		allProposals = append(allProposals, response.Proposals...)
-		offset += len(response.Proposals)
+		if _, exists := seenPages[pageKey]; exists {
+			break
+		}
+		seenPages[pageKey] = struct{}{}
 	}
 
-	return allProposals, nil
+	return proposals, nil
 }
 
 // Delegate represents a delegation record

--- a/backend/internal/indexer.go
+++ b/backend/internal/indexer.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"context"
 	"fmt"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -318,44 +317,9 @@ func (d *DegovIndexer) InspectProposalWithContext(ctx context.Context, scope Pro
 // QueryProposalsByBlockNumber queries proposals after the given blockNumber/id cursor.
 func (d *DegovIndexer) QueryProposalsByBlockNumber(scope ProposalScope, afterBlockNumber int64, afterProposalID string) ([]Proposal, error) {
 	const limit = 30
-	allProposals, err := d.queryProposalsByBlockNumber(scope, limit)
-	if err != nil {
-		return nil, err
-	}
-
-	type proposalWithBlockNumber struct {
-		proposal    Proposal
-		blockNumber int64
-	}
-	proposals := make([]proposalWithBlockNumber, 0, len(allProposals))
-	for _, proposal := range allProposals {
-		blockNumber, err := strconv.ParseInt(proposal.BlockNumber, 10, 64)
-		if err != nil {
-			return nil, fmt.Errorf("invalid blockNumber %q for proposal %q: %w", proposal.BlockNumber, proposal.ID, err)
-		}
-		if blockNumber > afterBlockNumber || (blockNumber == afterBlockNumber && proposal.ID > afterProposalID) {
-			proposals = append(proposals, proposalWithBlockNumber{proposal: proposal, blockNumber: blockNumber})
-		}
-	}
-
-	sort.Slice(proposals, func(i, j int) bool {
-		if proposals[i].blockNumber != proposals[j].blockNumber {
-			return proposals[i].blockNumber < proposals[j].blockNumber
-		}
-		return proposals[i].proposal.ID < proposals[j].proposal.ID
-	})
-
-	result := make([]Proposal, len(proposals))
-	for i := range proposals {
-		result[i] = proposals[i].proposal
-	}
-	return result, nil
-}
-
-func (d *DegovIndexer) queryProposalsByBlockNumber(scope ProposalScope, limit int) ([]Proposal, error) {
 	query := `
-		query QueryProposalsByBlockNumber($limit: Int!, $offset: Int!, $where: ProposalWhereInput) {
-			proposals(orderBy: [blockTimestamp_DESC_NULLS_LAST, id_ASC], limit: $limit, offset: $offset, where: $where) {
+		query QueryProposalsByBlockNumber($limit: Int!, $where: ProposalWhereInput) {
+			proposals(orderBy: [blockNumber_ASC_NULLS_FIRST, id_ASC], limit: $limit, where: $where) {
 				id
 				chainId
 				daoCode
@@ -394,39 +358,38 @@ func (d *DegovIndexer) queryProposalsByBlockNumber(scope ProposalScope, limit in
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	var proposals []Proposal
-	seenIDs := make(map[string]struct{})
-	seenPages := make(map[string]struct{})
-	for offset := 0; ; offset += limit {
-		req := graphql.NewRequest(query)
-		req.Var("limit", limit)
-		req.Var("offset", offset)
-		req.Var("where", scope.withScope(nil))
+	req := graphql.NewRequest(query)
+	req.Var("limit", limit)
+	req.Var("where", scope.withScope(map[string]any{
+		"OR": []map[string]any{
+			{"blockNumber_gt": strconv.FormatInt(afterBlockNumber, 10)},
+			{"blockNumber_eq": strconv.FormatInt(afterBlockNumber, 10), "id_gt": afterProposalID},
+		},
+	}))
 
-		var response ProposalsResponse
-		if err := d.client.Run(ctx, req, &response); err != nil {
-			return nil, fmt.Errorf("failed to execute QueryProposalsByBlockNumber: %w", err)
-		}
-
-		pageKey := ""
-		for _, proposal := range response.Proposals {
-			pageKey += "\x00" + proposal.ID
-			if _, exists := seenIDs[proposal.ID]; exists {
-				continue
-			}
-			seenIDs[proposal.ID] = struct{}{}
-			proposals = append(proposals, proposal)
-		}
-		if len(response.Proposals) < limit {
-			break
-		}
-		if _, exists := seenPages[pageKey]; exists {
-			break
-		}
-		seenPages[pageKey] = struct{}{}
+	var response ProposalsResponse
+	if err := d.client.Run(ctx, req, &response); err != nil {
+		return nil, fmt.Errorf("failed to execute QueryProposalsByBlockNumber: %w", err)
+	}
+	if len(response.Proposals) > limit {
+		return nil, fmt.Errorf("QueryProposalsByBlockNumber returned %d proposals, limit is %d", len(response.Proposals), limit)
 	}
 
-	return proposals, nil
+	previousBlockNumber := afterBlockNumber
+	previousProposalID := afterProposalID
+	for _, proposal := range response.Proposals {
+		blockNumber, err := strconv.ParseInt(proposal.BlockNumber, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid blockNumber %q for proposal %q: %w", proposal.BlockNumber, proposal.ID, err)
+		}
+		if blockNumber < previousBlockNumber || (blockNumber == previousBlockNumber && proposal.ID <= previousProposalID) {
+			return nil, fmt.Errorf("proposal cursor regressed at blockNumber %d id %q", blockNumber, proposal.ID)
+		}
+		previousBlockNumber = blockNumber
+		previousProposalID = proposal.ID
+	}
+
+	return response.Proposals, nil
 }
 
 func (d *DegovIndexer) QueryVotesOffset(ctx context.Context, scope ProposalScope, offset int, proposalId string) ([]VoteCast, error) {
@@ -436,7 +399,7 @@ func (d *DegovIndexer) QueryVotesOffset(ctx context.Context, scope ProposalScope
 func (d *DegovIndexer) QueryVotes(ctx context.Context, scope ProposalScope, offset int, limit int, proposalId string) ([]VoteCast, error) {
 	query := `
 		query QueryVotesOffset($limit: Int!, $offset: Int!, $where: ProposalWhereInput!) {
-			proposals(where: $where) {
+			proposals(orderBy: [id_ASC], limit: 2, where: $where) {
 				voters(orderBy: [blockTimestamp_ASC_NULLS_LAST, id_ASC], limit: $limit, offset: $offset) {
 					reason
 					support
@@ -461,13 +424,16 @@ func (d *DegovIndexer) QueryVotes(ctx context.Context, scope ProposalScope, offs
 	if err := d.client.Run(ctx, req, &response); err != nil {
 		return nil, fmt.Errorf("failed to execute QueryVotesOffset: %w", err)
 	}
+	if len(response.Proposals) > 1 {
+		return nil, fmt.Errorf("multiple proposals found for proposalId %s", proposalId)
+	}
+	if len(response.Proposals) == 0 {
+		return nil, nil
+	}
 
-	var votes []VoteCast
-	for _, proposal := range response.Proposals {
-		for _, vote := range proposal.Voters {
-			vote.ProposalID = proposalId
-			votes = append(votes, vote)
-		}
+	votes := response.Proposals[0].Voters
+	for i := range votes {
+		votes[i].ProposalID = proposalId
 	}
 	return votes, nil
 }
@@ -531,36 +497,34 @@ func (d *DegovIndexer) QueryContributor(ctx context.Context, scope ProposalScope
 	return nil, fmt.Errorf("no contributor found with address %s", address)
 }
 
-func (d *DegovIndexer) QueryVote(id string) (*VoteCast, error) {
-	query := `
-	query QueryVote($id: String!) {
-		voteCasts(where: {id_eq: $id}) {
-			proposalId
-			reason
-			support
-			voter
-			weight
-			transactionHash
-			id
-			blockNumber
-			blockTimestamp
-		}
-	}
-	`
-
-	req := graphql.NewRequest(query)
-	req.Var("id", id)
-
+func (d *DegovIndexer) QueryVote(scope ProposalScope, proposalId string, id string) (*VoteCast, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	var response VoteCastsResponse
-	if err := d.client.Run(ctx, req, &response); err != nil {
-		return nil, fmt.Errorf("failed to execute QueryVotesOffset: %w", err)
-	}
-	voteCasts := response.VoteCasts
-	if len(voteCasts) > 0 {
-		return &voteCasts[0], nil
+	const limit = 50
+	seenIDs := make(map[string]struct{})
+	for offset := 0; ; offset += limit {
+		votes, err := d.QueryVotes(ctx, scope, offset, limit, proposalId)
+		if err != nil {
+			return nil, fmt.Errorf("failed to query vote page at offset %d: %w", offset, err)
+		}
+		newIDs := 0
+		for _, vote := range votes {
+			if vote.ID == id {
+				return &vote, nil
+			}
+			if _, exists := seenIDs[vote.ID]; exists {
+				continue
+			}
+			seenIDs[vote.ID] = struct{}{}
+			newIDs++
+		}
+		if len(votes) < limit {
+			break
+		}
+		if newIDs == 0 {
+			return nil, fmt.Errorf("vote pagination made no progress at offset %d", offset)
+		}
 	}
 
 	return nil, fmt.Errorf("no vote found with id %s", id)
@@ -568,17 +532,18 @@ func (d *DegovIndexer) QueryVote(id string) (*VoteCast, error) {
 
 func (d *DegovIndexer) QueryVoteByVoter(scope ProposalScope, proposalId string, voter string) (*VoteCast, error) {
 	query := `
-		query QueryVoteByVoter($where: VoteCastWhereInput!) {
-			voteCasts(where: $where) {
-				proposalId
-				reason
-				support
-				voter
-				weight
-				transactionHash
-				id
-				blockNumber
-				blockTimestamp
+		query QueryVoteByVoter($where: ProposalWhereInput!, $voterWhere: VoteCastGroupWhereInput!) {
+			proposals(orderBy: [id_ASC], limit: 2, where: $where) {
+				voters(where: $voterWhere, orderBy: [blockTimestamp_ASC_NULLS_LAST, id_ASC], limit: 1) {
+					reason
+					support
+					voter
+					weight
+					transactionHash
+					id
+					blockNumber
+					blockTimestamp
+				}
 			}
 		}
 	`
@@ -586,18 +551,23 @@ func (d *DegovIndexer) QueryVoteByVoter(scope ProposalScope, proposalId string, 
 	req := graphql.NewRequest(query)
 	req.Var("where", scope.withScope(map[string]any{
 		"proposalId_eq": proposalId,
-		"voter_eq":      voter,
 	}))
+	req.Var("voterWhere", map[string]any{"voter_eq": voter})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	var response VoteCastsResponse
+	var response ProposalVotersResponse
 	if err := d.client.Run(ctx, req, &response); err != nil {
 		return nil, fmt.Errorf("failed to execute QueryVoteByVoter: %w", err)
 	}
-	if len(response.VoteCasts) > 0 {
-		return &response.VoteCasts[0], nil
+	if len(response.Proposals) > 1 {
+		return nil, fmt.Errorf("multiple proposals found for proposalId %s", proposalId)
+	}
+	if len(response.Proposals) == 1 && len(response.Proposals[0].Voters) > 0 {
+		vote := response.Proposals[0].Voters[0]
+		vote.ProposalID = proposalId
+		return &vote, nil
 	}
 
 	return nil, fmt.Errorf("no vote found for proposalId %s and voter %s", proposalId, voter)
@@ -609,7 +579,7 @@ func (d *DegovIndexer) QueryExpiringProposals(scope ProposalScope) ([]Proposal, 
 	  proposals(
 	    limit: $limit
 	    offset: $offset
-	    orderBy: [blockTimestamp_DESC_NULLS_LAST, id_ASC]
+	    orderBy: [blockTimestamp_ASC_NULLS_FIRST, id_ASC]
 	    where: $where
 	  ) {
 	    id
@@ -656,41 +626,36 @@ func (d *DegovIndexer) QueryExpiringProposals(scope ProposalScope) ([]Proposal, 
 	defer cancel()
 
 	seenIDs := make(map[string]struct{})
-	seenPages := make(map[string]struct{})
 	for offset := 0; ; offset += limit {
 		req := graphql.NewRequest(query)
 
 		req.Var("limit", limit)
 		req.Var("offset", offset)
-		req.Var("where", scope.withScope(nil))
+		req.Var("where", scope.withScope(map[string]any{
+			"voteEndTimestamp_gte": strconv.FormatInt(startTimestamp, 10),
+			"voteEndTimestamp_lt":  strconv.FormatInt(endTimestamp, 10),
+		}))
 
 		var response ProposalsResponse
 
 		if err := d.client.Run(ctx, req, &response); err != nil {
 			return nil, fmt.Errorf("graphql query failed on offset %d: %w", offset, err)
 		}
-		pageKey := ""
+		newIDs := 0
 		for _, proposal := range response.Proposals {
-			pageKey += "\x00" + proposal.ID
 			if _, exists := seenIDs[proposal.ID]; exists {
 				continue
 			}
 			seenIDs[proposal.ID] = struct{}{}
-			voteEndTimestamp, err := strconv.ParseInt(proposal.VoteEndTimestamp, 10, 64)
-			if err != nil {
-				continue
-			}
-			if voteEndTimestamp >= startTimestamp && voteEndTimestamp < endTimestamp {
-				proposals = append(proposals, proposal)
-			}
+			newIDs++
+			proposals = append(proposals, proposal)
 		}
 		if len(response.Proposals) < limit {
 			break
 		}
-		if _, exists := seenPages[pageKey]; exists {
-			break
+		if newIDs == 0 {
+			return nil, fmt.Errorf("expiring proposal pagination made no progress at offset %d", offset)
 		}
-		seenPages[pageKey] = struct{}{}
 	}
 
 	return proposals, nil

--- a/backend/internal/indexer_test.go
+++ b/backend/internal/indexer_test.go
@@ -12,67 +12,55 @@ import (
 	"time"
 )
 
-func TestQueryProposalsByBlockNumberPaginatesAndFiltersCursorDeterministically(t *testing.T) {
+func TestQueryProposalsByBlockNumberRequestsOneServerCursorBatch(t *testing.T) {
 	type graphqlRequest struct {
 		Query     string         `json:"query"`
 		Variables map[string]any `json:"variables"`
 	}
 
 	longID := strings.Repeat("x", 369)
-	page := make([]Proposal, 30)
-	for i := range page {
-		page[i] = Proposal{ID: fmt.Sprintf("old-%02d", i), BlockNumber: "99"}
-	}
-	page[5] = Proposal{ID: "later-block", BlockNumber: "102"}
-
 	requestCount := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
 		var req graphqlRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			t.Fatalf("decode request: %v", err)
 		}
-		for _, unsupported := range []string{
-			"blockNumber_ASC_NULLS_FIRST",
-			"blockNumber_eq",
-			"blockNumber_gt",
-			"id_gt",
-		} {
-			if strings.Contains(req.Query, unsupported) {
-				t.Fatalf("query contains unsupported schema value %q: %s", unsupported, req.Query)
-			}
+		if strings.Contains(req.Query, "offset:") {
+			t.Fatalf("query = %s, want no all-history offset scan", req.Query)
 		}
-		if !strings.Contains(req.Query, "orderBy: [blockTimestamp_DESC_NULLS_LAST, id_ASC]") {
-			t.Fatalf("query = %s, want supported stable order", req.Query)
+		if !strings.Contains(req.Query, "orderBy: [blockNumber_ASC_NULLS_FIRST, id_ASC]") {
+			t.Fatalf("query = %s, want provider cursor order", req.Query)
 		}
 		where, ok := req.Variables["where"].(map[string]any)
 		if !ok {
 			t.Fatalf("where = %#v, want map", req.Variables["where"])
 		}
-		if len(where) != 3 {
-			t.Fatalf("where = %#v, want only scope fields", where)
-		}
 		if got, want := req.Variables["limit"], float64(30); got != want {
 			t.Fatalf("limit = %#v, want %#v", got, want)
 		}
-		if got, want := req.Variables["offset"], float64(requestCount*30); got != want {
-			t.Fatalf("offset = %#v, want %#v", got, want)
+		cursor, ok := where["OR"].([]any)
+		if !ok || len(cursor) != 2 {
+			t.Fatalf("OR = %#v, want two cursor branches", where["OR"])
+		}
+		nextBlock := cursor[0].(map[string]any)
+		if got, want := nextBlock["blockNumber_gt"], "100"; got != want {
+			t.Fatalf("blockNumber_gt = %#v, want string %#v", got, want)
+		}
+		sameBlock := cursor[1].(map[string]any)
+		if got, want := sameBlock["blockNumber_eq"], "100"; got != want {
+			t.Fatalf("blockNumber_eq = %#v, want string %#v", got, want)
+		}
+		if got, want := sameBlock["id_gt"], "m"; got != want {
+			t.Fatalf("id_gt = %#v, want %#v", got, want)
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		switch requestCount {
-		case 0:
-			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"proposals": page}})
-		case 1:
-			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"proposals": []Proposal{
-				{ID: longID, BlockNumber: "101"},
-				{ID: "z", BlockNumber: "100"},
-				{ID: "a", BlockNumber: "100"},
-				{ID: "later-block", BlockNumber: "102"},
-			}}})
-		default:
-			t.Fatalf("unexpected request %d", requestCount)
-		}
-		requestCount++
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"proposals": []Proposal{
+			{ID: "z", BlockNumber: "100"},
+			{ID: longID, BlockNumber: "101"},
+			{ID: "later-block", BlockNumber: "102"},
+		}}})
 	}))
 	defer server.Close()
 
@@ -85,7 +73,7 @@ func TestQueryProposalsByBlockNumberPaginatesAndFiltersCursorDeterministically(t
 	if err != nil {
 		t.Fatalf("QueryProposalsByBlockNumber() error = %v", err)
 	}
-	if got, want := requestCount, 2; got != want {
+	if got, want := requestCount, 1; got != want {
 		t.Fatalf("request count = %d, want %d", got, want)
 	}
 	if got, want := len(proposals), 3; got != want {
@@ -96,7 +84,33 @@ func TestQueryProposalsByBlockNumberPaginatesAndFiltersCursorDeterministically(t
 	}
 }
 
-func TestQueryExpiringProposalsPaginatesAndFiltersFortyEightHourWindow(t *testing.T) {
+func TestQueryProposalsByBlockNumberRejectsInvalidServerOrder(t *testing.T) {
+	tests := []struct {
+		name      string
+		proposals []Proposal
+	}{
+		{name: "malformed block", proposals: []Proposal{{ID: "z", BlockNumber: "bad"}}},
+		{name: "cursor regression", proposals: []Proposal{{ID: "z", BlockNumber: "99"}}},
+		{name: "same block id regression", proposals: []Proposal{{ID: "z", BlockNumber: "101"}, {ID: "a", BlockNumber: "101"}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"proposals": tt.proposals}})
+			}))
+			defer server.Close()
+
+			_, err := NewDegovIndexer(server.URL).QueryProposalsByBlockNumber(ProposalScope{DaoCode: "ring-dao"}, 100, "m")
+			if err == nil {
+				t.Fatal("QueryProposalsByBlockNumber() error = nil, want invalid order error")
+			}
+		})
+	}
+}
+
+func TestQueryExpiringProposalsUsesServerWindowAndPaginates(t *testing.T) {
 	type graphqlRequest struct {
 		Query     string         `json:"query"`
 		Variables map[string]any `json:"variables"`
@@ -105,9 +119,8 @@ func TestQueryExpiringProposalsPaginatesAndFiltersFortyEightHourWindow(t *testin
 	now := time.Date(2026, time.July, 20, 12, 0, 0, 0, time.UTC)
 	page := make([]Proposal, 50)
 	for i := range page {
-		page[i] = Proposal{ID: fmt.Sprintf("expired-%02d", i), VoteEndTimestamp: fmt.Sprint(now.Add(-time.Hour).UnixMilli())}
+		page[i] = Proposal{ID: fmt.Sprintf("proposal-%02d", i), VoteEndTimestamp: fmt.Sprint(now.Add(time.Hour).UnixMilli())}
 	}
-	page[0] = Proposal{ID: "window-start", VoteEndTimestamp: fmt.Sprint(now.UnixMilli())}
 
 	requestCount := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -115,21 +128,18 @@ func TestQueryExpiringProposalsPaginatesAndFiltersFortyEightHourWindow(t *testin
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			t.Fatalf("decode request: %v", err)
 		}
-		for _, unsupported := range []string{
-			"blockTimestamp_ASC_NULLS_FIRST",
-			"voteEndTimestamp_gte",
-			"voteEndTimestamp_lt",
-		} {
-			if strings.Contains(req.Query, unsupported) {
-				t.Fatalf("query contains unsupported schema value %q: %s", unsupported, req.Query)
-			}
-		}
-		if !strings.Contains(req.Query, "orderBy: [blockTimestamp_DESC_NULLS_LAST, id_ASC]") {
-			t.Fatalf("query = %s, want supported stable order", req.Query)
+		if !strings.Contains(req.Query, "orderBy: [blockTimestamp_ASC_NULLS_FIRST, id_ASC]") {
+			t.Fatalf("query = %s, want provider expiry order", req.Query)
 		}
 		where, ok := req.Variables["where"].(map[string]any)
-		if !ok || len(where) != 3 {
-			t.Fatalf("where = %#v, want only scope fields", req.Variables["where"])
+		if !ok {
+			t.Fatalf("where = %#v, want map", req.Variables["where"])
+		}
+		if got, want := where["voteEndTimestamp_gte"], fmt.Sprint(now.UnixMilli()); got != want {
+			t.Fatalf("voteEndTimestamp_gte = %#v, want string %#v", got, want)
+		}
+		if got, want := where["voteEndTimestamp_lt"], fmt.Sprint(now.Add(48*time.Hour).UnixMilli()); got != want {
+			t.Fatalf("voteEndTimestamp_lt = %#v, want string %#v", got, want)
 		}
 		if got, want := req.Variables["limit"], float64(50); got != want {
 			t.Fatalf("limit = %#v, want %#v", got, want)
@@ -144,11 +154,8 @@ func TestQueryExpiringProposalsPaginatesAndFiltersFortyEightHourWindow(t *testin
 			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"proposals": page}})
 		case 1:
 			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"proposals": []Proposal{
-				{ID: "window-start", VoteEndTimestamp: fmt.Sprint(now.UnixMilli())},
-				{ID: "window-end-minus-one", VoteEndTimestamp: fmt.Sprint(now.Add(48*time.Hour).UnixMilli() - 1)},
-				{ID: "window-end", VoteEndTimestamp: fmt.Sprint(now.Add(48 * time.Hour).UnixMilli())},
-				{ID: "before-window", VoteEndTimestamp: fmt.Sprint(now.UnixMilli() - 1)},
-				{ID: "missing-time"},
+				page[49],
+				{ID: "proposal-50", VoteEndTimestamp: fmt.Sprint(now.Add(2 * time.Hour).UnixMilli())},
 			}}})
 		default:
 			t.Fatalf("unexpected request %d", requestCount)
@@ -170,8 +177,50 @@ func TestQueryExpiringProposalsPaginatesAndFiltersFortyEightHourWindow(t *testin
 	if got, want := requestCount, 2; got != want {
 		t.Fatalf("request count = %d, want %d", got, want)
 	}
-	if got, want := []string{proposals[0].ID, proposals[1].ID}, []string{"window-start", "window-end-minus-one"}; fmt.Sprint(got) != fmt.Sprint(want) {
-		t.Fatalf("proposal ids = %#v, want %#v", got, want)
+	if got, want := len(proposals), 51; got != want {
+		t.Fatalf("len(proposals) = %d, want %d", got, want)
+	}
+	if got, want := proposals[50].ID, "proposal-50"; got != want {
+		t.Fatalf("last proposal id = %q, want %q", got, want)
+	}
+}
+
+func TestQueryExpiringProposalsRejectsFullPageWithoutProgress(t *testing.T) {
+	firstPage := make([]Proposal, 50)
+	for i := range firstPage {
+		firstPage[i] = Proposal{ID: fmt.Sprintf("proposal-%02d", i)}
+	}
+
+	tests := []struct {
+		name       string
+		secondPage []Proposal
+	}{
+		{name: "repeated page", secondPage: append([]Proposal(nil), firstPage...)},
+		{name: "same ids reordered", secondPage: append(append([]Proposal(nil), firstPage[1:]...), firstPage[0])},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requestCount := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				page := firstPage
+				if requestCount > 0 {
+					page = tt.secondPage
+				}
+				requestCount++
+				_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"proposals": page}})
+			}))
+			defer server.Close()
+
+			_, err := NewDegovIndexer(server.URL).QueryExpiringProposals(ProposalScope{DaoCode: "ring-dao"})
+			if err == nil {
+				t.Fatal("QueryExpiringProposals() error = nil, want pagination progress error")
+			}
+			if got, want := requestCount, 2; got != want {
+				t.Fatalf("request count = %d, want %d", got, want)
+			}
+		})
 	}
 }
 
@@ -194,8 +243,8 @@ func TestQueryVotesUsesNestedProposalVotersWithPagination(t *testing.T) {
 		if strings.Contains(req.Query, "voteCasts") || strings.Contains(req.Query, "VoteCastWhereInput") {
 			t.Fatalf("query uses removed top-level voteCasts schema: %s", req.Query)
 		}
-		if !strings.Contains(req.Query, "proposals(where: $where)") {
-			t.Fatalf("query = %s, want scoped proposals query", req.Query)
+		if !strings.Contains(req.Query, "proposals(orderBy: [id_ASC], limit: 2, where: $where)") {
+			t.Fatalf("query = %s, want deterministic bounded parent query", req.Query)
 		}
 		if !strings.Contains(req.Query, "voters(orderBy: [blockTimestamp_ASC_NULLS_LAST, id_ASC], limit: $limit, offset: $offset)") {
 			t.Fatalf("query = %s, want nested voters with stable pagination", req.Query)
@@ -244,6 +293,190 @@ func TestQueryVotesUsesNestedProposalVotersWithPagination(t *testing.T) {
 	}
 	if got, want := votes[0].ProposalID, "proposal-1"; got != want {
 		t.Fatalf("vote proposal id = %q, want %q", got, want)
+	}
+}
+
+func TestQueryVotesValidatesProposalParentCardinality(t *testing.T) {
+	tests := []struct {
+		name          string
+		response      string
+		wantError     bool
+		wantVoteCount int
+	}{
+		{name: "zero parents", response: `{"data":{"proposals":[]}}`, wantVoteCount: 0},
+		{name: "multiple parents", response: `{"data":{"proposals":[{"voters":[]},{"voters":[]}]}}`, wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tt.response))
+			}))
+			defer server.Close()
+
+			votes, err := NewDegovIndexer(server.URL).QueryVotes(context.Background(), ProposalScope{DaoCode: "ring-dao"}, 0, 30, "proposal-1")
+			if tt.wantError {
+				if err == nil {
+					t.Fatal("QueryVotes() error = nil, want multiple parent error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("QueryVotes() error = %v", err)
+			}
+			if got := len(votes); got != tt.wantVoteCount {
+				t.Fatalf("len(votes) = %d, want %d", got, tt.wantVoteCount)
+			}
+		})
+	}
+}
+
+func TestQueryVotePagesNestedVotersUntilFound(t *testing.T) {
+	type graphqlRequest struct {
+		Variables map[string]any `json:"variables"`
+	}
+
+	firstPage := make([]VoteCast, 50)
+	for i := range firstPage {
+		firstPage[i] = VoteCast{ID: fmt.Sprintf("vote-%02d", i)}
+	}
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req graphqlRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if got, want := req.Variables["limit"], float64(50); got != want {
+			t.Fatalf("limit = %#v, want %#v", got, want)
+		}
+		if got, want := req.Variables["offset"], float64(requestCount*50); got != want {
+			t.Fatalf("offset = %#v, want %#v", got, want)
+		}
+		votes := firstPage
+		if requestCount == 1 {
+			votes = []VoteCast{{ID: "target-vote", Voter: "0x1"}}
+		}
+		requestCount++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"proposals": []map[string]any{{"voters": votes}}}})
+	}))
+	defer server.Close()
+
+	vote, err := NewDegovIndexer(server.URL).QueryVote(ProposalScope{DaoCode: "ring-dao"}, "proposal-1", "target-vote")
+	if err != nil {
+		t.Fatalf("QueryVote() error = %v", err)
+	}
+	if got, want := requestCount, 2; got != want {
+		t.Fatalf("request count = %d, want %d", got, want)
+	}
+	if got, want := vote.ID, "target-vote"; got != want {
+		t.Fatalf("vote id = %q, want %q", got, want)
+	}
+	if got, want := vote.ProposalID, "proposal-1"; got != want {
+		t.Fatalf("proposal id = %q, want %q", got, want)
+	}
+}
+
+func TestQueryVoteReturnsNotFoundAfterShortPage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"proposals":[{"voters":[{"id":"another-vote"}]}]}}`))
+	}))
+	defer server.Close()
+
+	_, err := NewDegovIndexer(server.URL).QueryVote(ProposalScope{DaoCode: "ring-dao"}, "proposal-1", "missing-vote")
+	if err == nil || !strings.Contains(err.Error(), "no vote found") {
+		t.Fatalf("QueryVote() error = %v, want not found", err)
+	}
+}
+
+func TestQueryVoteRejectsRepeatedFullVoterPage(t *testing.T) {
+	votes := make([]VoteCast, 50)
+	for i := range votes {
+		votes[i] = VoteCast{ID: fmt.Sprintf("vote-%02d", i)}
+	}
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"proposals": []map[string]any{{"voters": votes}}}})
+	}))
+	defer server.Close()
+
+	_, err := NewDegovIndexer(server.URL).QueryVote(ProposalScope{DaoCode: "ring-dao"}, "proposal-1", "missing-vote")
+	if err == nil || !strings.Contains(err.Error(), "no progress") {
+		t.Fatalf("QueryVote() error = %v, want pagination progress error", err)
+	}
+	if got, want := requestCount, 2; got != want {
+		t.Fatalf("request count = %d, want %d", got, want)
+	}
+}
+
+func TestQueryVoteByVoterUsesNestedScopedFilter(t *testing.T) {
+	type graphqlRequest struct {
+		Query     string         `json:"query"`
+		Variables map[string]any `json:"variables"`
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req graphqlRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if strings.Contains(req.Query, "voteCasts") || strings.Contains(req.Query, "VoteCastWhereInput") {
+			t.Fatalf("query uses removed vote shape: %s", req.Query)
+		}
+		if !strings.Contains(req.Query, "proposals(orderBy: [id_ASC], limit: 2, where: $where)") {
+			t.Fatalf("query = %s, want deterministic parent query", req.Query)
+		}
+		if !strings.Contains(req.Query, "voters(where: $voterWhere, orderBy: [blockTimestamp_ASC_NULLS_LAST, id_ASC], limit: 1)") {
+			t.Fatalf("query = %s, want filtered nested voter", req.Query)
+		}
+		where := req.Variables["where"].(map[string]any)
+		if got, want := where["proposalId_eq"], "proposal-1"; got != want {
+			t.Fatalf("proposalId_eq = %#v, want %#v", got, want)
+		}
+		voterWhere := req.Variables["voterWhere"].(map[string]any)
+		if got, want := voterWhere["voter_eq"], "0xVoter"; got != want {
+			t.Fatalf("voter_eq = %#v, want %#v", got, want)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"proposals":[{"voters":[{"id":"vote-1","voter":"0xVoter"}]}]}}`))
+	}))
+	defer server.Close()
+
+	vote, err := NewDegovIndexer(server.URL).QueryVoteByVoter(ProposalScope{DaoCode: "ring-dao"}, "proposal-1", "0xVoter")
+	if err != nil {
+		t.Fatalf("QueryVoteByVoter() error = %v", err)
+	}
+	if got, want := vote.ProposalID, "proposal-1"; got != want {
+		t.Fatalf("proposal id = %q, want %q", got, want)
+	}
+}
+
+func TestQueryVoteByVoterValidatesProposalParentCardinality(t *testing.T) {
+	tests := []struct {
+		name     string
+		response string
+	}{
+		{name: "zero parents", response: `{"data":{"proposals":[]}}`},
+		{name: "multiple parents", response: `{"data":{"proposals":[{"voters":[]},{"voters":[]}]}}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tt.response))
+			}))
+			defer server.Close()
+
+			_, err := NewDegovIndexer(server.URL).QueryVoteByVoter(ProposalScope{DaoCode: "ring-dao"}, "proposal-1", "0xVoter")
+			if err == nil {
+				t.Fatal("QueryVoteByVoter() error = nil, want parent cardinality error")
+			}
+		})
 	}
 }
 

--- a/backend/internal/indexer_test.go
+++ b/backend/internal/indexer_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -81,6 +82,100 @@ func TestQueryProposalsByBlockNumberRequestsOneServerCursorBatch(t *testing.T) {
 	}
 	if got, want := []string{proposals[0].ID, proposals[1].ID, proposals[2].ID}, []string{"z", longID, "later-block"}; fmt.Sprint(got) != fmt.Sprint(want) {
 		t.Fatalf("proposal ids = %#v, want %#v", got, want)
+	}
+}
+
+func TestQueryProposalsByBlockNumberContinuesBeyondFullBatch(t *testing.T) {
+	type graphqlRequest struct {
+		Variables map[string]any `json:"variables"`
+	}
+
+	longID := strings.Repeat("z", 369)
+	firstBatch := []Proposal{{ID: "same-block-z", BlockNumber: "100"}}
+	for i := 0; i < 28; i++ {
+		firstBatch = append(firstBatch, Proposal{ID: fmt.Sprintf("id-%02d", i), BlockNumber: "101"})
+	}
+	firstBatch = append(firstBatch, Proposal{ID: longID, BlockNumber: "101"})
+	secondBatch := []Proposal{
+		{ID: longID + "z", BlockNumber: "101"},
+		{ID: "later-block", BlockNumber: "102"},
+	}
+
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req graphqlRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		where := req.Variables["where"].(map[string]any)
+		cursor := where["OR"].([]any)
+		nextBlock := cursor[0].(map[string]any)
+		sameBlock := cursor[1].(map[string]any)
+
+		response := firstBatch
+		if requestCount == 0 {
+			if got, want := nextBlock["blockNumber_gt"], "100"; got != want {
+				t.Fatalf("first blockNumber_gt = %#v, want %#v", got, want)
+			}
+			if got, want := sameBlock["blockNumber_eq"], "100"; got != want {
+				t.Fatalf("first blockNumber_eq = %#v, want %#v", got, want)
+			}
+			if got, want := sameBlock["id_gt"], "same-block-m"; got != want {
+				t.Fatalf("first id_gt = %#v, want %#v", got, want)
+			}
+		} else {
+			response = secondBatch
+			if got, want := nextBlock["blockNumber_gt"], "101"; got != want {
+				t.Fatalf("second blockNumber_gt = %#v, want string %#v", got, want)
+			}
+			if got, want := sameBlock["blockNumber_eq"], "101"; got != want {
+				t.Fatalf("second blockNumber_eq = %#v, want string %#v", got, want)
+			}
+			if got, want := sameBlock["id_gt"], longID; got != want {
+				t.Fatalf("second id_gt length = %d, want preserved length %d", len(fmt.Sprint(got)), len(want))
+			}
+		}
+		requestCount++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"proposals": response}})
+	}))
+	defer server.Close()
+
+	indexer := NewDegovIndexer(server.URL)
+	first, err := indexer.QueryProposalsByBlockNumber(ProposalScope{DaoCode: "ring-dao"}, 100, "same-block-m")
+	if err != nil {
+		t.Fatalf("first QueryProposalsByBlockNumber() error = %v", err)
+	}
+	if got, want := len(first), 30; got != want {
+		t.Fatalf("first batch length = %d, want %d", got, want)
+	}
+	last := first[len(first)-1]
+	lastBlockNumber, err := strconv.ParseInt(last.BlockNumber, 10, 64)
+	if err != nil {
+		t.Fatalf("parse last block number: %v", err)
+	}
+	second, err := indexer.QueryProposalsByBlockNumber(ProposalScope{DaoCode: "ring-dao"}, lastBlockNumber, last.ID)
+	if err != nil {
+		t.Fatalf("second QueryProposalsByBlockNumber() error = %v", err)
+	}
+	if got, want := requestCount, 2; got != want {
+		t.Fatalf("request count = %d, want %d", got, want)
+	}
+
+	combined := append(append([]Proposal(nil), first...), second...)
+	want := append(append([]Proposal(nil), firstBatch...), secondBatch...)
+	if got := len(combined); got != len(want) {
+		t.Fatalf("combined length = %d, want %d", got, len(want))
+	}
+	seen := make(map[string]struct{}, len(combined))
+	for i := range combined {
+		if combined[i].ID != want[i].ID || combined[i].BlockNumber != want[i].BlockNumber {
+			t.Fatalf("combined[%d] = (%q, %q), want (%q, %q)", i, combined[i].BlockNumber, combined[i].ID, want[i].BlockNumber, want[i].ID)
+		}
+		if _, exists := seen[combined[i].ID]; exists {
+			t.Fatalf("duplicate proposal id %q", combined[i].ID)
+		}
+		seen[combined[i].ID] = struct{}{}
 	}
 }
 

--- a/backend/internal/indexer_test.go
+++ b/backend/internal/indexer_test.go
@@ -3,12 +3,249 @@ package internal
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 )
+
+func TestQueryProposalsByBlockNumberPaginatesAndFiltersCursorDeterministically(t *testing.T) {
+	type graphqlRequest struct {
+		Query     string         `json:"query"`
+		Variables map[string]any `json:"variables"`
+	}
+
+	longID := strings.Repeat("x", 369)
+	page := make([]Proposal, 30)
+	for i := range page {
+		page[i] = Proposal{ID: fmt.Sprintf("old-%02d", i), BlockNumber: "99"}
+	}
+	page[5] = Proposal{ID: "later-block", BlockNumber: "102"}
+
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req graphqlRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		for _, unsupported := range []string{
+			"blockNumber_ASC_NULLS_FIRST",
+			"blockNumber_eq",
+			"blockNumber_gt",
+			"id_gt",
+		} {
+			if strings.Contains(req.Query, unsupported) {
+				t.Fatalf("query contains unsupported schema value %q: %s", unsupported, req.Query)
+			}
+		}
+		if !strings.Contains(req.Query, "orderBy: [blockTimestamp_DESC_NULLS_LAST, id_ASC]") {
+			t.Fatalf("query = %s, want supported stable order", req.Query)
+		}
+		where, ok := req.Variables["where"].(map[string]any)
+		if !ok {
+			t.Fatalf("where = %#v, want map", req.Variables["where"])
+		}
+		if len(where) != 3 {
+			t.Fatalf("where = %#v, want only scope fields", where)
+		}
+		if got, want := req.Variables["limit"], float64(30); got != want {
+			t.Fatalf("limit = %#v, want %#v", got, want)
+		}
+		if got, want := req.Variables["offset"], float64(requestCount*30); got != want {
+			t.Fatalf("offset = %#v, want %#v", got, want)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		switch requestCount {
+		case 0:
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"proposals": page}})
+		case 1:
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"proposals": []Proposal{
+				{ID: longID, BlockNumber: "101"},
+				{ID: "z", BlockNumber: "100"},
+				{ID: "a", BlockNumber: "100"},
+				{ID: "later-block", BlockNumber: "102"},
+			}}})
+		default:
+			t.Fatalf("unexpected request %d", requestCount)
+		}
+		requestCount++
+	}))
+	defer server.Close()
+
+	indexer := NewDegovIndexer(server.URL)
+	proposals, err := indexer.QueryProposalsByBlockNumber(ProposalScope{
+		ChainID:         46,
+		DaoCode:         "ring-dao",
+		GovernorAddress: "0xAbC123",
+	}, 100, "m")
+	if err != nil {
+		t.Fatalf("QueryProposalsByBlockNumber() error = %v", err)
+	}
+	if got, want := requestCount, 2; got != want {
+		t.Fatalf("request count = %d, want %d", got, want)
+	}
+	if got, want := len(proposals), 3; got != want {
+		t.Fatalf("len(proposals) = %d, want %d: %#v", got, want, proposals)
+	}
+	if got, want := []string{proposals[0].ID, proposals[1].ID, proposals[2].ID}, []string{"z", longID, "later-block"}; fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("proposal ids = %#v, want %#v", got, want)
+	}
+}
+
+func TestQueryExpiringProposalsPaginatesAndFiltersFortyEightHourWindow(t *testing.T) {
+	type graphqlRequest struct {
+		Query     string         `json:"query"`
+		Variables map[string]any `json:"variables"`
+	}
+
+	now := time.Date(2026, time.July, 20, 12, 0, 0, 0, time.UTC)
+	page := make([]Proposal, 50)
+	for i := range page {
+		page[i] = Proposal{ID: fmt.Sprintf("expired-%02d", i), VoteEndTimestamp: fmt.Sprint(now.Add(-time.Hour).UnixMilli())}
+	}
+	page[0] = Proposal{ID: "window-start", VoteEndTimestamp: fmt.Sprint(now.UnixMilli())}
+
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req graphqlRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		for _, unsupported := range []string{
+			"blockTimestamp_ASC_NULLS_FIRST",
+			"voteEndTimestamp_gte",
+			"voteEndTimestamp_lt",
+		} {
+			if strings.Contains(req.Query, unsupported) {
+				t.Fatalf("query contains unsupported schema value %q: %s", unsupported, req.Query)
+			}
+		}
+		if !strings.Contains(req.Query, "orderBy: [blockTimestamp_DESC_NULLS_LAST, id_ASC]") {
+			t.Fatalf("query = %s, want supported stable order", req.Query)
+		}
+		where, ok := req.Variables["where"].(map[string]any)
+		if !ok || len(where) != 3 {
+			t.Fatalf("where = %#v, want only scope fields", req.Variables["where"])
+		}
+		if got, want := req.Variables["limit"], float64(50); got != want {
+			t.Fatalf("limit = %#v, want %#v", got, want)
+		}
+		if got, want := req.Variables["offset"], float64(requestCount*50); got != want {
+			t.Fatalf("offset = %#v, want %#v", got, want)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		switch requestCount {
+		case 0:
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"proposals": page}})
+		case 1:
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"proposals": []Proposal{
+				{ID: "window-start", VoteEndTimestamp: fmt.Sprint(now.UnixMilli())},
+				{ID: "window-end-minus-one", VoteEndTimestamp: fmt.Sprint(now.Add(48*time.Hour).UnixMilli() - 1)},
+				{ID: "window-end", VoteEndTimestamp: fmt.Sprint(now.Add(48 * time.Hour).UnixMilli())},
+				{ID: "before-window", VoteEndTimestamp: fmt.Sprint(now.UnixMilli() - 1)},
+				{ID: "missing-time"},
+			}}})
+		default:
+			t.Fatalf("unexpected request %d", requestCount)
+		}
+		requestCount++
+	}))
+	defer server.Close()
+
+	indexer := NewDegovIndexer(server.URL)
+	indexer.now = func() time.Time { return now }
+	proposals, err := indexer.QueryExpiringProposals(ProposalScope{
+		ChainID:         46,
+		DaoCode:         "ring-dao",
+		GovernorAddress: "0xAbC123",
+	})
+	if err != nil {
+		t.Fatalf("QueryExpiringProposals() error = %v", err)
+	}
+	if got, want := requestCount, 2; got != want {
+		t.Fatalf("request count = %d, want %d", got, want)
+	}
+	if got, want := []string{proposals[0].ID, proposals[1].ID}, []string{"window-start", "window-end-minus-one"}; fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("proposal ids = %#v, want %#v", got, want)
+	}
+}
+
+func TestQueryVotesUsesNestedProposalVotersWithPagination(t *testing.T) {
+	type graphqlRequest struct {
+		Query     string         `json:"query"`
+		Variables map[string]any `json:"variables"`
+	}
+
+	scope := ProposalScope{
+		ChainID:         46,
+		DaoCode:         "ring-dao",
+		GovernorAddress: "0xAbC123",
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req graphqlRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if strings.Contains(req.Query, "voteCasts") || strings.Contains(req.Query, "VoteCastWhereInput") {
+			t.Fatalf("query uses removed top-level voteCasts schema: %s", req.Query)
+		}
+		if !strings.Contains(req.Query, "proposals(where: $where)") {
+			t.Fatalf("query = %s, want scoped proposals query", req.Query)
+		}
+		if !strings.Contains(req.Query, "voters(orderBy: [blockTimestamp_ASC_NULLS_LAST, id_ASC], limit: $limit, offset: $offset)") {
+			t.Fatalf("query = %s, want nested voters with stable pagination", req.Query)
+		}
+		if strings.Contains(req.Query, "\n\t\t\t\t\tproposalId\n") {
+			t.Fatalf("query requests proposalId unavailable on nested voters: %s", req.Query)
+		}
+		if got, want := req.Variables["limit"], float64(7); got != want {
+			t.Fatalf("limit = %#v, want %#v", got, want)
+		}
+		if got, want := req.Variables["offset"], float64(14); got != want {
+			t.Fatalf("offset = %#v, want %#v", got, want)
+		}
+		where, ok := req.Variables["where"].(map[string]any)
+		if !ok {
+			t.Fatalf("where = %#v, want map", req.Variables["where"])
+		}
+		if got, want := where["proposalId_eq"], "proposal-1"; got != want {
+			t.Fatalf("proposalId_eq = %#v, want %#v", got, want)
+		}
+		if got, want := where["chainId_eq"], float64(scope.ChainID); got != want {
+			t.Fatalf("chainId_eq = %#v, want %#v", got, want)
+		}
+		if got, want := where["daoCode_eq"], scope.DaoCode; got != want {
+			t.Fatalf("daoCode_eq = %#v, want %#v", got, want)
+		}
+		if got, want := where["governorAddress_eq"], "0xabc123"; got != want {
+			t.Fatalf("governorAddress_eq = %#v, want %#v", got, want)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"proposals":[{"voters":[{"reason":"because","support":1,"voter":"0x1","weight":"10","transactionHash":"0xtx","id":"vote-1","blockNumber":"12","blockTimestamp":"1000"}]}]}}`))
+	}))
+	defer server.Close()
+
+	indexer := NewDegovIndexer(server.URL)
+	votes, err := indexer.QueryVotes(context.Background(), scope, 14, 7, "proposal-1")
+	if err != nil {
+		t.Fatalf("QueryVotes() error = %v", err)
+	}
+	if got, want := len(votes), 1; got != want {
+		t.Fatalf("len(votes) = %d, want %d", got, want)
+	}
+	if got, want := votes[0].ID, "vote-1"; got != want {
+		t.Fatalf("vote id = %q, want %q", got, want)
+	}
+	if got, want := votes[0].ProposalID, "proposal-1"; got != want {
+		t.Fatalf("vote proposal id = %q, want %q", got, want)
+	}
+}
 
 func TestQueryGlobalDataMetricsFallsBackToProposalsPageWhenGlobalProposalCountUnavailable(t *testing.T) {
 	t.Parallel()

--- a/backend/internal/indexer_test.go
+++ b/backend/internal/indexer_test.go
@@ -427,34 +427,44 @@ func TestQueryVotesValidatesProposalParentCardinality(t *testing.T) {
 	}
 }
 
-func TestQueryVotePagesNestedVotersUntilFound(t *testing.T) {
+func TestQueryVoteUsesDirectNestedIDFilter(t *testing.T) {
 	type graphqlRequest struct {
+		Query     string         `json:"query"`
 		Variables map[string]any `json:"variables"`
 	}
 
-	firstPage := make([]VoteCast, 50)
-	for i := range firstPage {
-		firstPage[i] = VoteCast{ID: fmt.Sprintf("vote-%02d", i)}
-	}
 	requestCount := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
 		var req graphqlRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			t.Fatalf("decode request: %v", err)
 		}
-		if got, want := req.Variables["limit"], float64(50); got != want {
-			t.Fatalf("limit = %#v, want %#v", got, want)
+		if strings.Contains(req.Query, "voteCasts") || strings.Contains(req.Query, "VoteCastWhereInput") {
+			t.Fatalf("query uses removed top-level vote shape: %s", req.Query)
 		}
-		if got, want := req.Variables["offset"], float64(requestCount*50); got != want {
-			t.Fatalf("offset = %#v, want %#v", got, want)
+		if !strings.Contains(req.Query, "query QueryVote($where: ProposalWhereInput!, $voterWhere: VoteCastGroupWhereInput!)") {
+			t.Fatalf("query = %s, want approved voter where input", req.Query)
 		}
-		votes := firstPage
-		if requestCount == 1 {
-			votes = []VoteCast{{ID: "target-vote", Voter: "0x1"}}
+		if !strings.Contains(req.Query, "proposals(orderBy: [id_ASC], limit: 2, where: $where)") {
+			t.Fatalf("query = %s, want deterministic parent lookup", req.Query)
 		}
-		requestCount++
+		if !strings.Contains(req.Query, "voters(where: $voterWhere, orderBy: [id_ASC], limit: 2)") {
+			t.Fatalf("query = %s, want direct bounded vote lookup", req.Query)
+		}
+		if _, exists := req.Variables["offset"]; exists {
+			t.Fatalf("unexpected offset scan variable: %#v", req.Variables)
+		}
+		where := req.Variables["where"].(map[string]any)
+		if got, want := where["proposalId_eq"], "proposal-1"; got != want {
+			t.Fatalf("proposalId_eq = %#v, want %#v", got, want)
+		}
+		voterWhere := req.Variables["voterWhere"].(map[string]any)
+		if got, want := voterWhere["id_eq"], "target-vote"; got != want {
+			t.Fatalf("id_eq = %#v, want %#v", got, want)
+		}
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"proposals": []map[string]any{{"voters": votes}}}})
+		_, _ = w.Write([]byte(`{"data":{"proposals":[{"voters":[{"id":"target-vote","voter":"0x1"}]}]}}`))
 	}))
 	defer server.Close()
 
@@ -462,7 +472,7 @@ func TestQueryVotePagesNestedVotersUntilFound(t *testing.T) {
 	if err != nil {
 		t.Fatalf("QueryVote() error = %v", err)
 	}
-	if got, want := requestCount, 2; got != want {
+	if got, want := requestCount, 1; got != want {
 		t.Fatalf("request count = %d, want %d", got, want)
 	}
 	if got, want := vote.ID, "target-vote"; got != want {
@@ -473,38 +483,36 @@ func TestQueryVotePagesNestedVotersUntilFound(t *testing.T) {
 	}
 }
 
-func TestQueryVoteReturnsNotFoundAfterShortPage(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"data":{"proposals":[{"voters":[{"id":"another-vote"}]}]}}`))
-	}))
-	defer server.Close()
-
-	_, err := NewDegovIndexer(server.URL).QueryVote(ProposalScope{DaoCode: "ring-dao"}, "proposal-1", "missing-vote")
-	if err == nil || !strings.Contains(err.Error(), "no vote found") {
-		t.Fatalf("QueryVote() error = %v, want not found", err)
+func TestQueryVoteValidatesDirectLookupCardinality(t *testing.T) {
+	tests := []struct {
+		name      string
+		response  string
+		wantError string
+	}{
+		{name: "zero parents", response: `{"data":{"proposals":[]}}`, wantError: "no vote found"},
+		{name: "zero votes", response: `{"data":{"proposals":[{"voters":[]}]}}`, wantError: "no vote found"},
+		{name: "multiple parents", response: `{"data":{"proposals":[{"voters":[]},{"voters":[]}]}}`, wantError: "multiple proposals"},
+		{name: "duplicate exact votes", response: `{"data":{"proposals":[{"voters":[{"id":"target-vote"},{"id":"target-vote"}]}]}}`, wantError: "multiple votes"},
 	}
-}
 
-func TestQueryVoteRejectsRepeatedFullVoterPage(t *testing.T) {
-	votes := make([]VoteCast, 50)
-	for i := range votes {
-		votes[i] = VoteCast{ID: fmt.Sprintf("vote-%02d", i)}
-	}
-	requestCount := 0
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestCount++
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"proposals": []map[string]any{{"voters": votes}}}})
-	}))
-	defer server.Close()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requestCount := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requestCount++
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tt.response))
+			}))
+			defer server.Close()
 
-	_, err := NewDegovIndexer(server.URL).QueryVote(ProposalScope{DaoCode: "ring-dao"}, "proposal-1", "missing-vote")
-	if err == nil || !strings.Contains(err.Error(), "no progress") {
-		t.Fatalf("QueryVote() error = %v, want pagination progress error", err)
-	}
-	if got, want := requestCount, 2; got != want {
-		t.Fatalf("request count = %d, want %d", got, want)
+			_, err := NewDegovIndexer(server.URL).QueryVote(ProposalScope{DaoCode: "ring-dao"}, "proposal-1", "target-vote")
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("QueryVote() error = %v, want %q", err, tt.wantError)
+			}
+			if got, want := requestCount, 1; got != want {
+				t.Fatalf("request count = %d, want %d", got, want)
+			}
+		})
 	}
 }
 

--- a/backend/internal/mcp/tools_indexer_test.go
+++ b/backend/internal/mcp/tools_indexer_test.go
@@ -76,7 +76,7 @@ func TestGetContributorToolIncludesENSNameWhenAvailable(t *testing.T) {
 }
 
 func TestListProposalVotesToolReturnsVoterIdentities(t *testing.T) {
-	indexer := newMCPIndexerServer(t, `{"data":{"voteCasts":[{"id":"vote-1","proposalId":"0xproposal","voter":"0x0000000000000000000000000000000000000001","support":1,"weight":"100","reason":"","transactionHash":"0xtx","blockNumber":"1","blockTimestamp":"2"}]}}`)
+	indexer := newMCPIndexerServer(t, `{"data":{"proposals":[{"voters":[{"id":"vote-1","voter":"0x0000000000000000000000000000000000000001","support":1,"weight":"100","reason":"","transactionHash":"0xtx","blockNumber":"1","blockTimestamp":"2"}]}]}}`)
 	defer indexer.Close()
 
 	server := newTestProposalServer(t)

--- a/backend/migrations/000007_proposal_cursor_text.down.sql
+++ b/backend/migrations/000007_proposal_cursor_text.down.sql
@@ -7,7 +7,7 @@ BEGIN
     ) THEN
         RAISE EXCEPTION 'cannot narrow last_tracked_proposal_id to varchar(255): values longer than 255 characters exist';
     END IF;
-END
+END;
 $$;
 
 ALTER TABLE dgv_dao ALTER COLUMN last_tracked_proposal_id TYPE varchar(255);

--- a/backend/migrations/000007_proposal_cursor_text.down.sql
+++ b/backend/migrations/000007_proposal_cursor_text.down.sql
@@ -1,1 +1,13 @@
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM dgv_dao
+        WHERE length(last_tracked_proposal_id) > 255
+    ) THEN
+        RAISE EXCEPTION 'cannot narrow last_tracked_proposal_id to varchar(255): values longer than 255 characters exist';
+    END IF;
+END
+$$;
+
 ALTER TABLE dgv_dao ALTER COLUMN last_tracked_proposal_id TYPE varchar(255);

--- a/backend/migrations/000007_proposal_cursor_text.down.sql
+++ b/backend/migrations/000007_proposal_cursor_text.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE dgv_dao ALTER COLUMN last_tracked_proposal_id TYPE varchar(255);

--- a/backend/migrations/000007_proposal_cursor_text.up.sql
+++ b/backend/migrations/000007_proposal_cursor_text.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE dgv_dao ALTER COLUMN last_tracked_proposal_id TYPE text;

--- a/backend/services/dao_test.go
+++ b/backend/services/dao_test.go
@@ -7,7 +7,47 @@ import (
 
 	dbmodels "github.com/ringecosystem/degov-square/database/models"
 	gqlmodels "github.com/ringecosystem/degov-square/graph/models"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
 )
+
+func TestProposalCursorPreservesLongIndexerID(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite db: %v", err)
+	}
+	if err := db.Exec(`
+		CREATE TABLE dgv_dao (
+			code TEXT PRIMARY KEY,
+			last_tracked_block_number INTEGER NOT NULL DEFAULT 0,
+			last_tracked_proposal_id TEXT NOT NULL DEFAULT ''
+		)
+	`).Error; err != nil {
+		t.Fatalf("create dao table: %v", err)
+	}
+	if err := db.Exec("INSERT INTO dgv_dao (code) VALUES (?)", "ring-dao").Error; err != nil {
+		t.Fatalf("seed dao: %v", err)
+	}
+
+	service := &DaoService{db: db}
+	proposalID := strings.Repeat("proposal-id-", 34)
+	if len(proposalID) <= 255 {
+		t.Fatalf("test proposal id length = %d, want > 255", len(proposalID))
+	}
+	if err := service.UpdateDaoLastTrackedProposalCursor("ring-dao", 123, proposalID); err != nil {
+		t.Fatalf("UpdateDaoLastTrackedProposalCursor() error = %v", err)
+	}
+	blockNumber, storedProposalID, err := service.GetLastTrackedProposalCursor("ring-dao")
+	if err != nil {
+		t.Fatalf("GetLastTrackedProposalCursor() error = %v", err)
+	}
+	if got, want := blockNumber, int64(123); got != want {
+		t.Fatalf("block number = %d, want %d", got, want)
+	}
+	if got, want := storedProposalID, proposalID; got != want {
+		t.Fatalf("proposal id length = %d, want preserved length %d", len(got), len(want))
+	}
+}
 
 func TestConvertToGqlDaoMapsTagsAndDomains(t *testing.T) {
 	t.Parallel()

--- a/backend/services/template.go
+++ b/backend/services/template.go
@@ -218,7 +218,7 @@ func (s *TemplateService) GenerateTemplateByNotificationRecord(record *dbmodels.
 	}
 
 	if record.Type == dbmodels.SubscribeFeatureVoteEmitted {
-		voteIndexer, err := degovIndexer.QueryVote(*record.VoteID)
+		voteIndexer, err := degovIndexer.QueryVote(scope, proposal.ProposalID, *record.VoteID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get vote info: %w", err)
 		}


### PR DESCRIPTION
## Summary

- replace stale Datalens query shapes with bounded provider cursor contracts for proposal and vote-end tracking
- preserve deterministic `(blockNumber, id)` cursor continuation across full pages, same-block rows, and 369-character proposal IDs
- migrate `last_tracked_proposal_id` from `varchar(255)` to `text` with a guarded rollback
- query proposal voters through the current nested schema, including bounded exact vote lookup and explicit cardinality/pagination errors

## Root cause

Production Square v0.8.0 sends removed proposal order/filter enums and the removed top-level `voteCasts` query. Tracking jobs fail GraphQL validation before ingesting rows, leaving Kton frozen at block `9253596`. The stored proposal cursor was also too short for current Datalens IDs.

## Validation

- `cd backend && just generate && just deps && just build && just test`
- focused cursor continuation tests covering >30 rows, same-block rows, and 369-character IDs
- nested vote lookup and duplicate/multi-parent error tests
- provider schema deployed and smoke-tested in production before opening this consumer PR
- `git diff --check origin/main...HEAD`

Fixes the consumer side of ringecosystem/degov#1011.