### PR TITLE
chore(release): bump version to 0.8.1

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Bump the DeGov Square package version to 0.8.1 for the production release containing the proposal and vote tracking repair from #294.

## Validation

- #294 Backend, Web, and Deploy checks passed
- version-only diff
- `git diff --check`