### PR TITLE
Make Square directory search-ready

### DIFF
--- a/web/src/app/_components/home-client.tsx
+++ b/web/src/app/_components/home-client.tsx
@@ -1,0 +1,335 @@
+'use client';
+import Image from 'next/image';
+import Link from 'next/link';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+
+import type { ColumnType } from '@/components/custom-table';
+import { CustomTable } from '@/components/custom-table';
+import { LikeButton } from '@/components/like-button';
+import { SortableCell } from '@/components/sortable-cell';
+import { Button } from '@/components/ui/button';
+import TagGroup from '@/components/ui/tag-group';
+import { useGraphqlDaoData } from '@/hooks/useGraphqlDaoData';
+import { useMiniApp } from '@/provider/miniapp';
+import type { DaoInfo } from '@/utils/config';
+import { formatNetworkName, formatTimeAgo } from '@/utils/helper';
+
+import { DaoList } from './daoList';
+import { MobileSearchDialog } from './MobileSearchDialog';
+
+type SortState = 'asc' | 'desc';
+
+interface HomeClientProps {
+  initialDaoData: DaoInfo[];
+  initialLoadFailed: boolean;
+}
+
+export function HomeClient({ initialDaoData, initialLoadFailed }: HomeClientProps) {
+  const { daoData, isLoading } = useGraphqlDaoData();
+  const { isMiniApp, markReady } = useMiniApp();
+  const readySentRef = useRef(false);
+  const displayDaoData = daoData.length > 0 ? daoData : initialDaoData;
+  const displayIsLoading = isLoading && initialDaoData.length === 0;
+
+  const [sortState, setSortState] = useState<SortState | undefined>(undefined);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [openSearchDialog, setOpenSearchDialog] = useState(false);
+  const [selectedNetwork, setSelectedNetwork] = useState<string>('');
+
+  const filteredAndSortedData = useMemo(() => {
+    let filtered = displayDaoData;
+
+    if (selectedNetwork) {
+      filtered = filtered.filter(
+        (dao) => dao.network.toLowerCase() === selectedNetwork.toLowerCase()
+      );
+    }
+
+    if (searchQuery.trim()) {
+      const query = searchQuery.toLowerCase().trim();
+      filtered = filtered.filter(
+        (dao) =>
+          dao.name.toLowerCase().includes(query) ||
+          dao.network.toLowerCase().includes(query) ||
+          dao.code.toLowerCase().includes(query)
+      );
+    }
+
+    if (sortState) {
+      filtered = [...filtered].sort((a, b) => {
+        const aProposals = a.proposals || 0;
+        const bProposals = b.proposals || 0;
+        return sortState === 'asc' ? aProposals - bProposals : bProposals - aProposals;
+      });
+      return filtered;
+    }
+
+    const sortByLastProposal = (a: DaoInfo, b: DaoInfo) => {
+      const aTime = a.lastProposal?.proposalCreatedAt;
+      const bTime = b.lastProposal?.proposalCreatedAt;
+
+      if (aTime && bTime) {
+        return new Date(bTime).getTime() - new Date(aTime).getTime();
+      }
+
+      if (aTime && !bTime) return -1;
+      if (!aTime && bTime) return 1;
+
+      return 0;
+    };
+
+    const favorites = filtered.filter((dao) => dao.favorite).sort(sortByLastProposal);
+    const others = filtered.filter((dao) => !dao.favorite).sort(sortByLastProposal);
+
+    return [...favorites, ...others];
+  }, [displayDaoData, searchQuery, selectedNetwork, sortState]);
+
+  const columns: ColumnType<DaoInfo>[] = [
+    {
+      title: 'Name',
+      key: 'name',
+      className: 'w-[34.48%] text-left',
+      render(value) {
+        return (
+          <div className="flex items-center gap-[10px]">
+            <Link
+              href={value?.website}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-[10px] hover:underline"
+            >
+              <Image
+                src={value?.daoIcon}
+                alt="dao"
+                width={34}
+                height={34}
+                className="rounded-full"
+              />
+              <span className="text-[16px]">{value?.name}</span>
+            </Link>
+            <TagGroup dao={value} />
+          </div>
+        );
+      }
+    },
+    {
+      title: 'Network',
+      key: 'network',
+      className: 'w-[18.97%] text-left',
+      render(value) {
+        return (
+          <div
+            className="flex cursor-pointer items-center justify-start gap-[10px] transition-opacity hover:opacity-80"
+            onClick={() => {
+              setSelectedNetwork(value?.network || '');
+              setSearchQuery('');
+            }}
+          >
+            <Image
+              src={value?.networkIcon}
+              alt="network"
+              width={24}
+              height={24}
+              className="rounded-full"
+            />
+            <span className="text-[16px]">{formatNetworkName(value?.network)}</span>
+          </div>
+        );
+      }
+    },
+    {
+      title: 'Last Proposal',
+      key: 'lastProposal',
+      className: 'w-[18.97%] text-left',
+      render(value) {
+        const proposalLink = value?.lastProposal?.proposalLink;
+        const proposalTime = value?.lastProposal?.proposalCreatedAt;
+
+        if (!proposalLink) {
+          return <span className="text-[16px]">No proposals yet</span>;
+        }
+
+        return (
+          <Link
+            href={proposalLink}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-[6px] text-[16px] hover:underline"
+            title="View latest proposal"
+          >
+            <span className="text-[16px]">{formatTimeAgo(proposalTime || '')}</span>
+          </Link>
+        );
+      }
+    },
+    {
+      title: <SortableCell onClick={setSortState} sortState={sortState} />,
+      key: 'proposals',
+      className: 'w-[18.97%] text-center',
+      render(value) {
+        return <span className="text-[16px]">{value?.proposals}</span>;
+      }
+    },
+    {
+      title: 'Action',
+      key: 'action',
+      className: 'w-[8.62%] text-right',
+      render(value) {
+        return (
+          <div className="flex items-center justify-end gap-[10px]">
+            {/* <Link
+              href={`/setting/${value?.id}`}
+              className="cursor-pointer transition-opacity hover:opacity-80"
+            >
+              <Image src="/setting.svg" alt="setting" width={20} height={20} />
+            </Link> */}
+            <LikeButton dao={value} isLiked={value.favorite} className="flex-shrink-0" />
+          </div>
+        );
+      }
+    }
+  ];
+
+  const handleSearch = useCallback((query: string) => {
+    setSearchQuery(query);
+    setSelectedNetwork('');
+    setOpenSearchDialog(false);
+  }, []);
+
+  const handleDesktopSearch = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchQuery(e.target.value);
+    setSelectedNetwork('');
+  }, []);
+
+  const clearSearch = useCallback(() => {
+    setSearchQuery('');
+    setSelectedNetwork('');
+  }, []);
+
+  const openMobileSearch = useCallback(() => {
+    setOpenSearchDialog(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isMiniApp || isLoading || readySentRef.current) return;
+    readySentRef.current = true;
+    void markReady();
+  }, [isMiniApp, isLoading, markReady]);
+
+  useEffect(() => {
+    return () => {
+      setSortState(undefined);
+    };
+  }, []);
+
+  return (
+    <div className="container flex flex-col gap-[20px]">
+      <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-[4px]">
+          <span className="text-[18px] font-semibold">
+            All DAOs({filteredAndSortedData.length}
+            {(searchQuery || selectedNetwork) &&
+              displayDaoData.length !== filteredAndSortedData.length && (
+                <span className="text-muted-foreground">/{displayDaoData.length}</span>
+              )}
+            )
+          </span>
+          <span className="text-muted-foreground text-[14px]">
+            Discover public DAO governance sites, networks, and proposal activity.
+          </span>
+          {initialLoadFailed && filteredAndSortedData.length === 0 ? (
+            <span className="text-muted-foreground text-[14px]">
+              DAO directory data is temporarily unavailable. The interactive directory will retry in
+              the browser.
+            </span>
+          ) : null}
+        </div>
+        <div className="flex items-center gap-[20px]">
+          <div className="bg-card flex h-[36px] w-[109px] items-center gap-[13px] rounded-[19px] border px-[17px] py-[9px] md:h-auto md:w-[388px] md:gap-[10px]">
+            <Image src="/search.svg" alt="search" width={16} height={16} />
+            <input
+              className="placeholder:text-muted-foreground hidden h-[17px] w-full outline-none placeholder:text-[14px] md:block"
+              placeholder="Search by DAO name or Chain name"
+              value={selectedNetwork ? formatNetworkName(selectedNetwork) : searchQuery}
+              onChange={handleDesktopSearch}
+            />
+            <button
+              className="text-muted-foreground block text-[14px] md:hidden"
+              onClick={openMobileSearch}
+            >
+              Search
+            </button>
+            {(searchQuery || selectedNetwork) && (
+              <button
+                onClick={clearSearch}
+                className="text-muted-foreground hover:text-foreground hidden items-center justify-center md:flex"
+                title="Clear search"
+              >
+                <Image src="/close.svg" alt="clear" width={12} height={12} />
+              </button>
+            )}
+          </div>
+          <div className="hidden gap-[20px] md:flex">
+            <Button variant="outline" className="hidden rounded-[100px]" asChild>
+              <Link href="/add/existing">Add Existing DAO</Link>
+            </Button>
+            <Button
+              variant="outline"
+              className="!border-foreground rounded-[100px] p-[10px]"
+              asChild
+            >
+              <Link
+                href="https://docs.degov.ai/integration/deploy"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Self Host
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {
+        <>
+          <CustomTable
+            columns={columns}
+            dataSource={filteredAndSortedData}
+            className="hidden md:block"
+            rowKey="id"
+            isLoading={displayIsLoading}
+            emptyText="No DAOs found"
+          />
+          <DaoList
+            daoInfo={filteredAndSortedData}
+            isLoading={displayIsLoading}
+            onNetworkClick={(network) => {
+              setSelectedNetwork(network);
+              setSearchQuery('');
+            }}
+          />
+        </>
+      }
+
+      <div className="flex flex-col py-[20px] md:hidden">
+        <Button variant="outline" className="!border-foreground rounded-[100px] p-[10px]" asChild>
+          <Link
+            href="https://docs.degov.ai/integration/deploy"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Self Host
+          </Link>
+        </Button>
+      </div>
+      <MobileSearchDialog
+        open={openSearchDialog}
+        onOpenChange={setOpenSearchDialog}
+        onConfirm={handleSearch}
+        initialQuery={searchQuery}
+        selectedNetwork={selectedNetwork}
+        formatNetworkName={formatNetworkName}
+      />
+    </div>
+  );
+}

--- a/web/src/app/add/layout.tsx
+++ b/web/src/app/add/layout.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  robots: {
+    index: false,
+    follow: false
+  }
+};
+
+export default function AddLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/src/app/analytics.tsx
+++ b/web/src/app/analytics.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import Script from 'next/script';
+import { usePathname } from 'next/navigation';
+
+import { APP_URL, GOOGLE_ANALYTICS_TAG } from '@/config/base';
+
+const excludedPrefixes = ['/add', '/oauth', '/notification', '/setting'];
+
+export function Analytics() {
+  const pathname = usePathname() || '/';
+  const excluded = excludedPrefixes.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`));
+
+  if (!GOOGLE_ANALYTICS_TAG || excluded) {
+    return null;
+  }
+
+  const pageLocation = new URL(pathname, APP_URL).toString();
+
+  return (
+    <>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${GOOGLE_ANALYTICS_TAG}`}
+        strategy="afterInteractive"
+      />
+      <Script id="google-analytics" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', '${GOOGLE_ANALYTICS_TAG}', {
+            page_path: '${pathname}',
+            page_location: '${pageLocation}'
+          });
+        `}
+      </Script>
+    </>
+  );
+}

--- a/web/src/app/analytics.tsx
+++ b/web/src/app/analytics.tsx
@@ -16,6 +16,9 @@ export function Analytics() {
   }
 
   const pageLocation = new URL(pathname, APP_URL).toString();
+  const analyticsTagLiteral = JSON.stringify(GOOGLE_ANALYTICS_TAG);
+  const pathnameLiteral = JSON.stringify(pathname);
+  const pageLocationLiteral = JSON.stringify(pageLocation);
 
   return (
     <>
@@ -28,9 +31,9 @@ export function Analytics() {
           window.dataLayer = window.dataLayer || [];
           function gtag(){dataLayer.push(arguments);}
           gtag('js', new Date());
-          gtag('config', '${GOOGLE_ANALYTICS_TAG}', {
-            page_path: '${pathname}',
-            page_location: '${pageLocation}'
+          gtag('config', ${analyticsTagLiteral}, {
+            page_path: ${pathnameLiteral},
+            page_location: ${pageLocationLiteral}
           });
         `}
       </Script>

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,5 +1,4 @@
 import { Geist, Geist_Mono } from 'next/font/google';
-import Script from 'next/script';
 import './globals.css';
 import { ToastContainer } from 'react-toastify';
 
@@ -12,14 +11,15 @@ import {
   APP_URL,
   APP_ICON_URL,
   APP_SPLASH_IMAGE_URL,
-  APP_SPLASH_BACKGROUND_COLOR,
-  GOOGLE_ANALYTICS_TAG
+  APP_SPLASH_BACKGROUND_COLOR
 } from '@/config/base';
 import { ConfirmProvider } from '@/provider/confirm';
 import { DAppProvider } from '@/provider/dapp';
 import { MiniAppProvider } from '@/provider/miniapp';
 import { QueryProvider } from '@/provider/query';
 import { NextThemeProvider } from '@/provider/theme';
+
+import { Analytics } from './analytics';
 
 import type { Metadata } from 'next';
 
@@ -87,22 +87,7 @@ export default function RootLayout({
           </QueryProvider>
         </NextThemeProvider>
 
-        {GOOGLE_ANALYTICS_TAG && (
-          <Script
-            src={`https://www.googletagmanager.com/gtag/js?id=${GOOGLE_ANALYTICS_TAG}`}
-            strategy="afterInteractive"
-          />
-        )}
-        {GOOGLE_ANALYTICS_TAG && (
-          <Script id="google-analytics" strategy="afterInteractive">
-            {`
-              window.dataLayer = window.dataLayer || [];
-              function gtag(){dataLayer.push(arguments);}
-              gtag('js', new Date());
-              gtag('config', '${GOOGLE_ANALYTICS_TAG}');
-            `}
-          </Script>
-        )}
+        <Analytics />
       </body>
     </html>
   );

--- a/web/src/app/notification/layout.tsx
+++ b/web/src/app/notification/layout.tsx
@@ -1,100 +1,14 @@
-'use client';
+import { NotificationLayoutClient } from './notification-layout-client';
 
-import Image from 'next/image';
-import Link from 'next/link';
-import { usePathname } from 'next/navigation';
-import { Suspense } from 'react';
+import type { Metadata } from 'next';
 
-import { useUrlAuthSync } from '@/hooks/useUrlAuthSync';
-import { cn } from '@/lib/utils';
-
-import { AuthGuard } from './_components';
-import { useIsMobileAndSubSection } from './_hooks/isMobileAndSubSection';
-
-const NAVS = [
-  { label: 'Subscription', value: 'subscription' },
-  { label: 'Subscribed DAOs', value: 'subscribed-daos' },
-  { label: 'Subscribed Proposals', value: 'subscribed-proposals' }
-];
-
-function NavLink({
-  nav,
-  isActive,
-  href
-}: {
-  nav: (typeof NAVS)[0];
-  isActive: boolean;
-  href: string;
-}) {
-  return (
-    <Link
-      key={nav.value}
-      href={href}
-      className={cn(
-        'border-border hover:border-foreground bg-card text-foreground rounded-[14px] border px-[20px] py-[15px] text-left text-[14px] transition-colors',
-        isActive ? 'border-foreground' : ''
-      )}
-    >
-      {nav.label}
-    </Link>
-  );
-}
-
-const getHref = (nav: (typeof NAVS)[0]) => {
-  return `/notification/${nav.value}`;
+export const metadata: Metadata = {
+  robots: {
+    index: false,
+    follow: false
+  }
 };
 
-function NotificationLayoutContent({ children }: { children: React.ReactNode }) {
-  const isMobileAndSubSection = useIsMobileAndSubSection();
-  const pathname = usePathname();
-
-  // Initialize URL auth sync at layout level
-  useUrlAuthSync();
-
-  const isActive = (nav: (typeof NAVS)[0]) => {
-    return `/notification/${nav.value}` === pathname;
-  };
-
-  return (
-    <div className="container space-y-[20px]">
-      {!isMobileAndSubSection && (
-        <Link href="/" className="flex items-center gap-[5px] lg:gap-[10px]">
-          <Image
-            src="/back.svg"
-            alt="back"
-            width={32}
-            height={32}
-            className="size-[32px] flex-shrink-0"
-          />
-          <h1 className="text-[18px] font-semibold">Notifications Settings</h1>
-        </Link>
-      )}
-
-      <div className="flex w-full flex-col gap-[30px] lg:flex-row">
-        {!isMobileAndSubSection && (
-          <aside className="w-full flex-shrink-0 lg:w-[300px]">
-            <div className="flex flex-col gap-[20px] lg:gap-[10px]">
-              {NAVS.map((nav) => (
-                <NavLink key={nav.value} nav={nav} isActive={isActive(nav)} href={getHref(nav)} />
-              ))}
-            </div>
-          </aside>
-        )}
-
-        <main className="flex flex-1 flex-col">
-          <div className="lg:bg-card space-y-[15px] lg:space-y-[20px] lg:rounded-[14px] lg:p-[20px]">
-            <AuthGuard>{children}</AuthGuard>
-          </div>
-        </main>
-      </div>
-    </div>
-  );
-}
-
 export default function NotificationLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <Suspense fallback={<div>Loading...</div>}>
-      <NotificationLayoutContent>{children}</NotificationLayoutContent>
-    </Suspense>
-  );
+  return <NotificationLayoutClient>{children}</NotificationLayoutClient>;
 }

--- a/web/src/app/notification/notification-layout-client.tsx
+++ b/web/src/app/notification/notification-layout-client.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { Suspense } from 'react';
+
+import { useUrlAuthSync } from '@/hooks/useUrlAuthSync';
+import { cn } from '@/lib/utils';
+
+import { AuthGuard } from './_components';
+import { useIsMobileAndSubSection } from './_hooks/isMobileAndSubSection';
+
+const NAVS = [
+  { label: 'Subscription', value: 'subscription' },
+  { label: 'Subscribed DAOs', value: 'subscribed-daos' },
+  { label: 'Subscribed Proposals', value: 'subscribed-proposals' }
+];
+
+function NavLink({
+  nav,
+  isActive,
+  href
+}: {
+  nav: (typeof NAVS)[0];
+  isActive: boolean;
+  href: string;
+}) {
+  return (
+    <Link
+      key={nav.value}
+      href={href}
+      className={cn(
+        'border-border hover:border-foreground bg-card text-foreground rounded-[14px] border px-[20px] py-[15px] text-left text-[14px] transition-colors',
+        isActive ? 'border-foreground' : ''
+      )}
+    >
+      {nav.label}
+    </Link>
+  );
+}
+
+const getHref = (nav: (typeof NAVS)[0]) => {
+  return `/notification/${nav.value}`;
+};
+
+function NotificationLayoutContent({ children }: { children: React.ReactNode }) {
+  const isMobileAndSubSection = useIsMobileAndSubSection();
+  const pathname = usePathname();
+
+  // Initialize URL auth sync at layout level
+  useUrlAuthSync();
+
+  const isActive = (nav: (typeof NAVS)[0]) => {
+    return `/notification/${nav.value}` === pathname;
+  };
+
+  return (
+    <div className="container space-y-[20px]">
+      {!isMobileAndSubSection && (
+        <Link href="/" className="flex items-center gap-[5px] lg:gap-[10px]">
+          <Image
+            src="/back.svg"
+            alt="back"
+            width={32}
+            height={32}
+            className="size-[32px] flex-shrink-0"
+          />
+          <h1 className="text-[18px] font-semibold">Notifications Settings</h1>
+        </Link>
+      )}
+
+      <div className="flex w-full flex-col gap-[30px] lg:flex-row">
+        {!isMobileAndSubSection && (
+          <aside className="w-full flex-shrink-0 lg:w-[300px]">
+            <div className="flex flex-col gap-[20px] lg:gap-[10px]">
+              {NAVS.map((nav) => (
+                <NavLink key={nav.value} nav={nav} isActive={isActive(nav)} href={getHref(nav)} />
+              ))}
+            </div>
+          </aside>
+        )}
+
+        <main className="flex flex-1 flex-col">
+          <div className="lg:bg-card space-y-[15px] lg:space-y-[20px] lg:rounded-[14px] lg:p-[20px]">
+            <AuthGuard>{children}</AuthGuard>
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}
+
+export function NotificationLayoutClient({ children }: { children: React.ReactNode }) {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <NotificationLayoutContent>{children}</NotificationLayoutContent>
+    </Suspense>
+  );
+}

--- a/web/src/app/oauth/layout.tsx
+++ b/web/src/app/oauth/layout.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  robots: {
+    index: false,
+    follow: false
+  }
+};
+
+export default function OAuthLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,319 +1,53 @@
-'use client';
-import Image from 'next/image';
-import Link from 'next/link';
-import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { HomeClient } from './_components/home-client';
+import { getPublicDaoDirectory } from '@/lib/public-dao-directory';
 
-import type { ColumnType } from '@/components/custom-table';
-import { CustomTable } from '@/components/custom-table';
-import { LikeButton } from '@/components/like-button';
-import { SortableCell } from '@/components/sortable-cell';
-import { Button } from '@/components/ui/button';
-import TagGroup from '@/components/ui/tag-group';
-import { useGraphqlDaoData } from '@/hooks/useGraphqlDaoData';
-import { useMiniApp } from '@/provider/miniapp';
-import type { DaoInfo } from '@/utils/config';
-import { formatNetworkName, formatTimeAgo } from '@/utils/helper';
+import type { Metadata } from 'next';
 
-import { DaoList } from './_components/daoList';
-import { MobileSearchDialog } from './_components/MobileSearchDialog';
+const title = 'DeGov Square DAO Directory';
+const description =
+  'Discover public DAO governance sites, proposal activity, supported networks, and DeGov-managed governance communities.';
+const canonicalUrl = 'https://square.degov.ai/';
+const shareImageUrl =
+  'https://raw.githubusercontent.com/ringecosystem/degov-registry/refs/heads/main/assets/common/degov-1024.png';
 
-type SortState = 'asc' | 'desc';
-
-export default function Home() {
-  const { daoData, isLoading } = useGraphqlDaoData();
-  const { isMiniApp, markReady } = useMiniApp();
-  const readySentRef = useRef(false);
-
-  const [sortState, setSortState] = useState<SortState | undefined>(undefined);
-  const [searchQuery, setSearchQuery] = useState('');
-  const [openSearchDialog, setOpenSearchDialog] = useState(false);
-  const [selectedNetwork, setSelectedNetwork] = useState<string>('');
-
-  const filteredAndSortedData = useMemo(() => {
-    let filtered = daoData;
-
-    if (selectedNetwork) {
-      filtered = filtered.filter(
-        (dao) => dao.network.toLowerCase() === selectedNetwork.toLowerCase()
-      );
-    }
-
-    if (searchQuery.trim()) {
-      const query = searchQuery.toLowerCase().trim();
-      filtered = filtered.filter(
-        (dao) =>
-          dao.name.toLowerCase().includes(query) ||
-          dao.network.toLowerCase().includes(query) ||
-          dao.code.toLowerCase().includes(query)
-      );
-    }
-
-    if (sortState) {
-      filtered = [...filtered].sort((a, b) => {
-        const aProposals = a.proposals || 0;
-        const bProposals = b.proposals || 0;
-        return sortState === 'asc' ? aProposals - bProposals : bProposals - aProposals;
-      });
-      return filtered;
-    }
-
-    const sortByLastProposal = (a: DaoInfo, b: DaoInfo) => {
-      const aTime = a.lastProposal?.proposalCreatedAt;
-      const bTime = b.lastProposal?.proposalCreatedAt;
-
-      if (aTime && bTime) {
-        return new Date(bTime).getTime() - new Date(aTime).getTime();
+export const metadata: Metadata = {
+  title,
+  description,
+  alternates: {
+    canonical: canonicalUrl
+  },
+  openGraph: {
+    type: 'website',
+    siteName: 'DeGov Square',
+    title,
+    description,
+    url: canonicalUrl,
+    images: [
+      {
+        url: shareImageUrl,
+        width: 1024,
+        height: 1024,
+        alt: 'DeGov Square'
       }
+    ]
+  },
+  twitter: {
+    card: 'summary',
+    title,
+    description,
+    images: [shareImageUrl]
+  }
+};
 
-      if (aTime && !bTime) return -1;
-      if (!aTime && bTime) return 1;
+export const dynamic = 'force-dynamic';
 
-      return 0;
-    };
-
-    const favorites = filtered.filter((dao) => dao.favorite).sort(sortByLastProposal);
-    const others = filtered.filter((dao) => !dao.favorite).sort(sortByLastProposal);
-
-    return [...favorites, ...others];
-  }, [daoData, searchQuery, selectedNetwork, sortState]);
-
-  const columns: ColumnType<DaoInfo>[] = [
-    {
-      title: 'Name',
-      key: 'name',
-      className: 'w-[34.48%] text-left',
-      render(value) {
-        return (
-          <div className="flex items-center gap-[10px]">
-            <Link
-              href={value?.website}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center gap-[10px] hover:underline"
-            >
-              <Image
-                src={value?.daoIcon}
-                alt="dao"
-                width={34}
-                height={34}
-                className="rounded-full"
-              />
-              <span className="text-[16px]">{value?.name}</span>
-            </Link>
-            <TagGroup dao={value} />
-          </div>
-        );
-      }
-    },
-    {
-      title: 'Network',
-      key: 'network',
-      className: 'w-[18.97%] text-left',
-      render(value) {
-        return (
-          <div
-            className="flex cursor-pointer items-center justify-start gap-[10px] transition-opacity hover:opacity-80"
-            onClick={() => {
-              setSelectedNetwork(value?.network || '');
-              setSearchQuery('');
-            }}
-          >
-            <Image
-              src={value?.networkIcon}
-              alt="network"
-              width={24}
-              height={24}
-              className="rounded-full"
-            />
-            <span className="text-[16px]">{formatNetworkName(value?.network)}</span>
-          </div>
-        );
-      }
-    },
-    {
-      title: 'Last Proposal',
-      key: 'lastProposal',
-      className: 'w-[18.97%] text-left',
-      render(value) {
-        const proposalLink = value?.lastProposal?.proposalLink;
-        const proposalTime = value?.lastProposal?.proposalCreatedAt;
-
-        if (!proposalLink) {
-          return <span className="text-[16px]">No proposals yet</span>;
-        }
-
-        return (
-          <Link
-            href={proposalLink}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-[6px] text-[16px] hover:underline"
-            title="View latest proposal"
-          >
-            <span className="text-[16px]">{formatTimeAgo(proposalTime || '')}</span>
-          </Link>
-        );
-      }
-    },
-    {
-      title: <SortableCell onClick={setSortState} sortState={sortState} />,
-      key: 'proposals',
-      className: 'w-[18.97%] text-center',
-      render(value) {
-        return <span className="text-[16px]">{value?.proposals}</span>;
-      }
-    },
-    {
-      title: 'Action',
-      key: 'action',
-      className: 'w-[8.62%] text-right',
-      render(value) {
-        return (
-          <div className="flex items-center justify-end gap-[10px]">
-            {/* <Link
-              href={`/setting/${value?.id}`}
-              className="cursor-pointer transition-opacity hover:opacity-80"
-            >
-              <Image src="/setting.svg" alt="setting" width={20} height={20} />
-            </Link> */}
-            <LikeButton dao={value} isLiked={value.favorite} className="flex-shrink-0" />
-          </div>
-        );
-      }
-    }
-  ];
-
-  const handleSearch = useCallback((query: string) => {
-    setSearchQuery(query);
-    setSelectedNetwork('');
-    setOpenSearchDialog(false);
-  }, []);
-
-  const handleDesktopSearch = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    setSearchQuery(e.target.value);
-    setSelectedNetwork('');
-  }, []);
-
-  const clearSearch = useCallback(() => {
-    setSearchQuery('');
-    setSelectedNetwork('');
-  }, []);
-
-  const openMobileSearch = useCallback(() => {
-    setOpenSearchDialog(true);
-  }, []);
-
-  useEffect(() => {
-    if (!isMiniApp || isLoading || readySentRef.current) return;
-    readySentRef.current = true;
-    void markReady();
-  }, [isMiniApp, isLoading, markReady]);
-
-  useEffect(() => {
-    return () => {
-      setSortState(undefined);
-    };
-  }, []);
+export default async function Home() {
+  const initialDirectory = await getPublicDaoDirectory();
 
   return (
-    <div className="container flex flex-col gap-[20px]">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-[10px]">
-          <span className="text-[18px] font-semibold">
-            All DAOs({filteredAndSortedData.length}
-            {(searchQuery || selectedNetwork) &&
-              daoData.length !== filteredAndSortedData.length && (
-                <span className="text-muted-foreground">/{daoData.length}</span>
-              )}
-            )
-          </span>
-        </div>
-        <div className="flex items-center gap-[20px]">
-          <div className="bg-card flex h-[36px] w-[109px] items-center gap-[13px] rounded-[19px] border px-[17px] py-[9px] md:h-auto md:w-[388px] md:gap-[10px]">
-            <Image src="/search.svg" alt="search" width={16} height={16} />
-            <input
-              className="placeholder:text-muted-foreground hidden h-[17px] w-full outline-none placeholder:text-[14px] md:block"
-              placeholder="Search by DAO name or Chain name"
-              value={selectedNetwork ? formatNetworkName(selectedNetwork) : searchQuery}
-              onChange={handleDesktopSearch}
-            />
-            <button
-              className="text-muted-foreground block text-[14px] md:hidden"
-              onClick={openMobileSearch}
-            >
-              Search
-            </button>
-            {(searchQuery || selectedNetwork) && (
-              <button
-                onClick={clearSearch}
-                className="text-muted-foreground hover:text-foreground hidden items-center justify-center md:flex"
-                title="Clear search"
-              >
-                <Image src="/close.svg" alt="clear" width={12} height={12} />
-              </button>
-            )}
-          </div>
-          <div className="hidden gap-[20px] md:flex">
-            <Button variant="outline" className="hidden rounded-[100px]" asChild>
-              <Link href="/add/existing">Add Existing DAO</Link>
-            </Button>
-            <Button
-              variant="outline"
-              className="!border-foreground rounded-[100px] p-[10px]"
-              asChild
-            >
-              <Link
-                href="https://docs.degov.ai/integration/deploy"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Self Host
-              </Link>
-            </Button>
-          </div>
-        </div>
-      </div>
-
-      {
-        <>
-          <CustomTable
-            columns={columns}
-            dataSource={filteredAndSortedData}
-            className="hidden md:block"
-            rowKey="id"
-            isLoading={isLoading}
-            emptyText="No DAOs found"
-          />
-          <DaoList
-            daoInfo={filteredAndSortedData}
-            isLoading={isLoading}
-            onNetworkClick={(network) => {
-              setSelectedNetwork(network);
-              setSearchQuery('');
-            }}
-          />
-        </>
-      }
-
-      <div className="flex flex-col py-[20px] md:hidden">
-        <Button variant="outline" className="!border-foreground rounded-[100px] p-[10px]" asChild>
-          <Link
-            href="https://docs.degov.ai/integration/deploy"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Self Host
-          </Link>
-        </Button>
-      </div>
-      <MobileSearchDialog
-        open={openSearchDialog}
-        onOpenChange={setOpenSearchDialog}
-        onConfirm={handleSearch}
-        initialQuery={searchQuery}
-        selectedNetwork={selectedNetwork}
-        formatNetworkName={formatNetworkName}
-      />
-    </div>
+    <HomeClient
+      initialDaoData={initialDirectory.daos}
+      initialLoadFailed={initialDirectory.failed}
+    />
   );
 }

--- a/web/src/app/robots.ts
+++ b/web/src/app/robots.ts
@@ -1,0 +1,12 @@
+import type { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: ['/add', '/oauth', '/notification', '/setting']
+    },
+    sitemap: ['https://square.degov.ai/sitemap.xml']
+  };
+}

--- a/web/src/app/setting/layout.tsx
+++ b/web/src/app/setting/layout.tsx
@@ -1,88 +1,14 @@
-'use client';
-import Image from 'next/image';
-import Link from 'next/link';
-import { useSelectedLayoutSegment, usePathname } from 'next/navigation';
+import { SettingLayoutClient } from './setting-layout-client';
 
-import { cn } from '@/lib/utils';
+import type { Metadata } from 'next';
 
-import { useIsMobileAndSubSection } from './_hooks/isMobileAndSubSection';
-
-const NAVS = [
-  { label: 'Basic', value: 'basic' },
-  { label: 'Treasury', value: 'treasury' },
-  { label: 'Safes', value: 'safes' },
-  { label: 'Advanced', value: 'advanced' }
-];
-
-function NavLink({
-  nav,
-  isActive,
-  href
-}: {
-  nav: (typeof NAVS)[0];
-  isActive: boolean;
-  href: string;
-}) {
-  return (
-    <Link
-      key={nav.value}
-      href={href}
-      className={cn(
-        'border-border hover:border-foreground bg-card text-foreground rounded-[14px] border px-[20px] py-[15px] text-left text-[14px] transition-colors',
-        isActive ? 'border-foreground' : ''
-      )}
-    >
-      {nav.label}
-    </Link>
-  );
-}
-
-const isActive = (id: string | null, nav: (typeof NAVS)[0], pathname: string) => {
-  return `/setting/${id}/${nav.value}` === pathname;
-};
-
-const getHref = (id: string | null, nav: (typeof NAVS)[0]) => {
-  return `/setting/${id}/${nav.value}`;
+export const metadata: Metadata = {
+  robots: {
+    index: false,
+    follow: false
+  }
 };
 
 export default function SettingLayout({ children }: { children: React.ReactNode }) {
-  const id = useSelectedLayoutSegment();
-  const pathname = usePathname();
-  const isMobileAndSubSection = useIsMobileAndSubSection();
-
-  return (
-    <div className="container space-y-[20px]">
-      {!isMobileAndSubSection && (
-        <Link href="/" className="flex items-center gap-[5px] md:gap-[10px]">
-          <Image
-            src="/back.svg"
-            alt="back"
-            width={32}
-            height={32}
-            className="size-[32px] flex-shrink-0"
-          />
-          <h1 className="text-[18px] font-semibold">DAO Settings</h1>
-        </Link>
-      )}
-
-      <div className="flex w-full flex-col gap-[30px] md:flex-row">
-        {!isMobileAndSubSection && (
-          <aside className="w-full flex-shrink-0 md:w-[300px]">
-            <div className="flex flex-col gap-[20px] md:gap-[10px]">
-              {NAVS.map((nav) => (
-                <NavLink
-                  key={nav.value}
-                  nav={nav}
-                  isActive={isActive(id as string, nav, pathname)}
-                  href={getHref(id as string, nav)}
-                />
-              ))}
-            </div>
-          </aside>
-        )}
-
-        <main className="flex-1">{children}</main>
-      </div>
-    </div>
-  );
+  return <SettingLayoutClient>{children}</SettingLayoutClient>;
 }

--- a/web/src/app/setting/setting-layout-client.tsx
+++ b/web/src/app/setting/setting-layout-client.tsx
@@ -1,0 +1,88 @@
+'use client';
+import Image from 'next/image';
+import Link from 'next/link';
+import { useSelectedLayoutSegment, usePathname } from 'next/navigation';
+
+import { cn } from '@/lib/utils';
+
+import { useIsMobileAndSubSection } from './_hooks/isMobileAndSubSection';
+
+const NAVS = [
+  { label: 'Basic', value: 'basic' },
+  { label: 'Treasury', value: 'treasury' },
+  { label: 'Safes', value: 'safes' },
+  { label: 'Advanced', value: 'advanced' }
+];
+
+function NavLink({
+  nav,
+  isActive,
+  href
+}: {
+  nav: (typeof NAVS)[0];
+  isActive: boolean;
+  href: string;
+}) {
+  return (
+    <Link
+      key={nav.value}
+      href={href}
+      className={cn(
+        'border-border hover:border-foreground bg-card text-foreground rounded-[14px] border px-[20px] py-[15px] text-left text-[14px] transition-colors',
+        isActive ? 'border-foreground' : ''
+      )}
+    >
+      {nav.label}
+    </Link>
+  );
+}
+
+const isActive = (id: string | null, nav: (typeof NAVS)[0], pathname: string) => {
+  return `/setting/${id}/${nav.value}` === pathname;
+};
+
+const getHref = (id: string | null, nav: (typeof NAVS)[0]) => {
+  return `/setting/${id}/${nav.value}`;
+};
+
+export function SettingLayoutClient({ children }: { children: React.ReactNode }) {
+  const id = useSelectedLayoutSegment();
+  const pathname = usePathname();
+  const isMobileAndSubSection = useIsMobileAndSubSection();
+
+  return (
+    <div className="container space-y-[20px]">
+      {!isMobileAndSubSection && (
+        <Link href="/" className="flex items-center gap-[5px] md:gap-[10px]">
+          <Image
+            src="/back.svg"
+            alt="back"
+            width={32}
+            height={32}
+            className="size-[32px] flex-shrink-0"
+          />
+          <h1 className="text-[18px] font-semibold">DAO Settings</h1>
+        </Link>
+      )}
+
+      <div className="flex w-full flex-col gap-[30px] md:flex-row">
+        {!isMobileAndSubSection && (
+          <aside className="w-full flex-shrink-0 md:w-[300px]">
+            <div className="flex flex-col gap-[20px] md:gap-[10px]">
+              {NAVS.map((nav) => (
+                <NavLink
+                  key={nav.value}
+                  nav={nav}
+                  isActive={isActive(id as string, nav, pathname)}
+                  href={getHref(id as string, nav)}
+                />
+              ))}
+            </div>
+          </aside>
+        )}
+
+        <main className="flex-1">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -1,0 +1,11 @@
+import type { MetadataRoute } from 'next';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: 'https://square.degov.ai/',
+      changeFrequency: 'daily',
+      priority: 1
+    }
+  ];
+}

--- a/web/src/hooks/useGraphqlDaoData.ts
+++ b/web/src/hooks/useGraphqlDaoData.ts
@@ -1,28 +1,8 @@
 import { useMemo } from 'react';
 
 import { useQueryDaosPublic, useQueryDaos } from '@/lib/graphql';
-import type { Dao } from '@/lib/graphql/types';
+import { transformDaoData } from '@/lib/dao-directory';
 import { useAuthStore } from '@/stores/auth';
-import type { DaoInfo } from '@/utils/config';
-
-function transformDaoData(dao: Dao, index: number): DaoInfo {
-  return {
-    id: dao.id,
-    name: dao.name,
-    code: dao.code,
-    daoIcon: dao.logo,
-    network: dao.chainName || `Chain ${dao.chainId}`,
-    networkIcon: dao.chainLogo,
-    proposals: dao.metricsCountProposals,
-    favorite: dao.liked,
-    settable: true,
-    website: dao.endpoint || '',
-    indexer: '',
-    chainId: dao.chainId.toString(),
-    chips: dao.chips,
-    lastProposal: dao.lastProposal
-  };
-}
 
 export function useGraphqlDaoData() {
   const { isAuthenticated } = useAuthStore();
@@ -39,7 +19,7 @@ export function useGraphqlDaoData() {
 
     return graphqlData.daos
       ?.filter((dao) => !dao.tags?.includes('demo'))
-      .map((dao, index) => transformDaoData(dao, index));
+      .map((dao) => transformDaoData(dao));
   }, [graphqlData]);
 
   return {

--- a/web/src/lib/dao-directory.ts
+++ b/web/src/lib/dao-directory.ts
@@ -1,0 +1,21 @@
+import type { Dao } from '@/lib/graphql/types';
+import type { DaoInfo } from '@/utils/config';
+
+export function transformDaoData(dao: Dao): DaoInfo {
+  return {
+    id: dao.id,
+    name: dao.name,
+    code: dao.code,
+    daoIcon: dao.logo,
+    network: dao.chainName || `Chain ${dao.chainId}`,
+    networkIcon: dao.chainLogo,
+    proposals: dao.metricsCountProposals,
+    favorite: dao.liked,
+    settable: true,
+    website: dao.endpoint || '',
+    indexer: '',
+    chainId: dao.chainId.toString(),
+    chips: dao.chips,
+    lastProposal: dao.lastProposal
+  };
+}

--- a/web/src/lib/public-dao-directory.ts
+++ b/web/src/lib/public-dao-directory.ts
@@ -1,6 +1,6 @@
 import { createPublicClient } from '@/lib/graphql/client';
 import { QUERY_DAOS } from '@/lib/graphql/queries';
-import type { DaosResponse } from '@/lib/graphql/types';
+import type { Dao } from '@/lib/graphql/types';
 
 import { transformDaoData } from './dao-directory';
 
@@ -11,10 +11,14 @@ export type PublicDaoDirectoryResult = {
   failed: boolean;
 };
 
+type PublicDaosResponse = {
+  daos: Dao[];
+};
+
 export async function getPublicDaoDirectory(): Promise<PublicDaoDirectoryResult> {
   try {
     const client = createPublicClient();
-    const data = await client.request<DaosResponse>(QUERY_DAOS);
+    const data = await client.request<PublicDaosResponse>(QUERY_DAOS);
 
     return {
       daos: (data.daos ?? [])

--- a/web/src/lib/public-dao-directory.ts
+++ b/web/src/lib/public-dao-directory.ts
@@ -1,0 +1,32 @@
+import { createPublicClient } from '@/lib/graphql/client';
+import { QUERY_DAOS } from '@/lib/graphql/queries';
+import type { DaosResponse } from '@/lib/graphql/types';
+
+import { transformDaoData } from './dao-directory';
+
+import type { DaoInfo } from '@/utils/config';
+
+export type PublicDaoDirectoryResult = {
+  daos: DaoInfo[];
+  failed: boolean;
+};
+
+export async function getPublicDaoDirectory(): Promise<PublicDaoDirectoryResult> {
+  try {
+    const client = createPublicClient();
+    const data = await client.request<DaosResponse>(QUERY_DAOS);
+
+    return {
+      daos: (data.daos ?? [])
+        .filter((dao) => !dao.tags?.includes('demo'))
+        .map((dao) => transformDaoData(dao)),
+      failed: false
+    };
+  } catch (error) {
+    console.error('Failed to load public DAO directory for initial HTML:', error);
+    return {
+      daos: [],
+      failed: true
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- render initial Square DAO directory data on the server while preserving client interactivity
- add homepage metadata, canonical/social metadata, sitemap, and robots output
- add noindex coverage for non-public routes
- avoid analytics collection on non-public routes and strip query strings from page URLs

## Validation
- pnpm --dir web build
- git diff --check

Note: pnpm --dir web lint still fails on the existing Next lint circular ESLint config issue: Converting circular structure to JSON ... property react closes the circle. The build reports that lint issue during its lint phase but exits successfully.

Part of ringecosystem/degov#714 first implementation batch.