### PR TITLE
Add Square social preview metadata

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,6 +29,11 @@ jobs:
         run: |
           pnpm run test:private-route-indexing
 
+      - name: Check social preview
+        working-directory: web
+        run: |
+          pnpm run test:social-preview
+
       - name: Check Build
         working-directory: web
         run: |

--- a/web/package.json
+++ b/web/package.json
@@ -7,6 +7,7 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "test:private-route-indexing": "node scripts/check-private-route-indexing.mjs",
+    "test:social-preview": "node scripts/check-social-preview.mjs",
     "start": "next start",
     "lint": "next lint"
   },

--- a/web/scripts/check-social-preview.mjs
+++ b/web/scripts/check-social-preview.mjs
@@ -32,6 +32,7 @@ assert.ok(
 assert.ok(!pageSource.includes("card: 'summary'"), 'Twitter card must not use small summary card');
 
 const response = await fetch(expectedImageUrl, {
+  signal: AbortSignal.timeout(20_000),
   headers: {
     'user-agent': 'degov-square-social-preview-check'
   }
@@ -44,6 +45,7 @@ assert.ok(
 assert.ok(response.headers.get('cache-control'), 'social image must declare cache behavior');
 
 const body = Buffer.from(await response.arrayBuffer());
+assert.ok(body.length >= 24, 'social image must include a PNG IHDR header');
 assert.ok(
   body.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])),
   'social image must be a PNG'

--- a/web/scripts/check-social-preview.mjs
+++ b/web/scripts/check-social-preview.mjs
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const webRoot = join(fileURLToPath(new URL('..', import.meta.url)));
+const pageSource = readFileSync(join(webRoot, 'src/app/page.tsx'), 'utf8');
+
+const expectedImageUrl = 'https://degov.ai/images/degov-social-card.png';
+const expectedImageWidth = 1200;
+const expectedImageHeight = 630;
+const expectedImageType = 'image/png';
+
+const assertContains = (source, expected, label) => {
+  assert.ok(source.includes(expected), `${label} must include ${expected}`);
+};
+
+assertContains(pageSource, "const canonicalUrl = 'https://square.degov.ai/';", 'Square canonical');
+assertContains(pageSource, `const shareImageUrl = '${expectedImageUrl}';`, 'Square share image');
+assertContains(pageSource, 'width: 1200', 'Open Graph image width');
+assertContains(pageSource, 'height: 630', 'Open Graph image height');
+assertContains(pageSource, "type: 'image/png'", 'Open Graph image type');
+assertContains(pageSource, 'alt: shareImageAlt', 'Open Graph image alt');
+assertContains(pageSource, "card: 'summary_large_image'", 'Twitter large card');
+assertContains(pageSource, 'url: shareImageUrl', 'Twitter image object URL');
+assertContains(pageSource, 'url: canonicalUrl', 'Open Graph URL');
+assertContains(pageSource, 'canonical: canonicalUrl', 'canonical metadata');
+assert.ok(
+  !pageSource.includes('raw.githubusercontent.com'),
+  'social image must not use registry raw square icon fallback'
+);
+assert.ok(!pageSource.includes("card: 'summary'"), 'Twitter card must not use small summary card');
+
+const response = await fetch(expectedImageUrl, {
+  headers: {
+    'user-agent': 'degov-square-social-preview-check'
+  }
+});
+assert.equal(response.status, 200, 'social image must return HTTP 200');
+assert.ok(
+  response.headers.get('content-type')?.startsWith(expectedImageType),
+  'social image must return image/png'
+);
+assert.ok(response.headers.get('cache-control'), 'social image must declare cache behavior');
+
+const body = Buffer.from(await response.arrayBuffer());
+assert.ok(
+  body.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])),
+  'social image must be a PNG'
+);
+assert.equal(body.readUInt32BE(16), expectedImageWidth, 'social image width');
+assert.equal(body.readUInt32BE(20), expectedImageHeight, 'social image height');
+
+console.log('Verified Square social preview metadata.');

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -7,8 +7,8 @@ const title = 'DeGov Square DAO Directory';
 const description =
   'Discover public DAO governance sites, proposal activity, supported networks, and DeGov-managed governance communities.';
 const canonicalUrl = 'https://square.degov.ai/';
-const shareImageUrl =
-  'https://raw.githubusercontent.com/ringecosystem/degov-registry/refs/heads/main/assets/common/degov-1024.png';
+const shareImageUrl = 'https://degov.ai/images/degov-social-card.png';
+const shareImageAlt = 'DeGov Square DAO Directory — discover public DAO governance.';
 
 export const metadata: Metadata = {
   title,
@@ -25,17 +25,23 @@ export const metadata: Metadata = {
     images: [
       {
         url: shareImageUrl,
-        width: 1024,
-        height: 1024,
-        alt: 'DeGov Square'
+        width: 1200,
+        height: 630,
+        alt: shareImageAlt,
+        type: 'image/png'
       }
     ]
   },
   twitter: {
-    card: 'summary',
+    card: 'summary_large_image',
     title,
     description,
-    images: [shareImageUrl]
+    images: [
+      {
+        url: shareImageUrl,
+        alt: shareImageAlt
+      }
+    ]
   }
 };
 


### PR DESCRIPTION
## Summary

- switch the Square directory social preview to a verified 1200x630 DeGov card
- emit large-card Open Graph and X/Twitter image metadata with dimensions/type/alt text
- add a CI check for Square social preview metadata and image fetch/dimensions

## Verification

- pnpm install
- pnpm run test:private-route-indexing
- pnpm run test:social-preview
- pnpm build
- git diff --check
- backend: just generate && just deps && just build
- local production readback for `/` confirmed canonical, OG, and Twitter tags

Part of ringecosystem/degov#1029 and ringecosystem/degov#714.
