### PR TITLE
Expose Square directory content provenance

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",
+    "test:content-provenance": "node scripts/check-content-provenance.mjs",
     "test:private-route-indexing": "node scripts/check-private-route-indexing.mjs",
     "test:social-preview": "node scripts/check-social-preview.mjs",
     "start": "next start",

--- a/web/scripts/check-content-provenance.mjs
+++ b/web/scripts/check-content-provenance.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const webRoot = join(fileURLToPath(new URL('..', import.meta.url)));
+const pageSource = readFileSync(join(webRoot, 'src/app/page.tsx'), 'utf8');
+
+const assertContains = (source, expected, label) => {
+  assert.ok(source.includes(expected), `${label} must include ${expected}`);
+};
+
+assertContains(pageSource, "const canonicalUrl = 'https://square.degov.ai/';", 'Square canonical');
+assertContains(pageSource, '<h1', 'Square homepage');
+assertContains(pageSource, 'DeGov Square DAO Directory', 'Square H1 text');
+assertContains(pageSource, 'Square indexes public DAO governance sites', 'Directory description');
+assertContains(pageSource, 'DeGov public DAO registry', 'Directory provenance label');
+assertContains(
+  pageSource,
+  "const directorySourceUrl = 'https://github.com/ringecosystem/degov-registry';",
+  'Directory provenance URL'
+);
+assertContains(pageSource, 'Last server read:', 'Directory freshness text');
+assertContains(
+  pageSource,
+  'representativeDaos = initialDirectory.daos.filter((dao) => dao.website).slice(0, 6)',
+  'Representative DAO selection'
+);
+assertContains(pageSource, 'aria-label="Representative public DAOs"', 'Representative DAO links');
+assertContains(
+  pageSource,
+  'Representative DAO links are temporarily unavailable in server HTML',
+  'Directory unavailable fallback'
+);
+assertContains(pageSource, 'initialLoadFailed={initialDirectory.failed}', 'Client retry state');
+
+console.log('Verified Square content provenance contract.');

--- a/web/scripts/check-content-provenance.mjs
+++ b/web/scripts/check-content-provenance.mjs
@@ -21,9 +21,15 @@ assertContains(
   'Directory provenance URL'
 );
 assertContains(pageSource, 'Last server read:', 'Directory freshness text');
+assertContains(pageSource, 'function isHttpUrl(value: string)', 'Representative link URL guard');
 assertContains(
   pageSource,
-  'representativeDaos = initialDirectory.daos.filter((dao) => dao.website).slice(0, 6)',
+  "url.protocol === 'http:' || url.protocol === 'https:'",
+  'HTTP URL guard'
+);
+assertContains(
+  pageSource,
+  '.filter((dao) => isHttpUrl(dao.website))',
   'Representative DAO selection'
 );
 assertContains(pageSource, 'aria-label="Representative public DAOs"', 'Representative DAO links');

--- a/web/scripts/check-content-provenance.mjs
+++ b/web/scripts/check-content-provenance.mjs
@@ -21,17 +21,24 @@ assertContains(
   'Directory provenance URL'
 );
 assertContains(pageSource, 'Last server read:', 'Directory freshness text');
-assertContains(pageSource, 'function isHttpUrl(value: string)', 'Representative link URL guard');
+assertContains(pageSource, 'function getHttpUrl(value: string)', 'Representative link URL guard');
 assertContains(
   pageSource,
   "url.protocol === 'http:' || url.protocol === 'https:'",
   'HTTP URL guard'
 );
+assertContains(pageSource, 'return url.toString();', 'Representative URL normalization');
 assertContains(
   pageSource,
-  '.filter((dao) => isHttpUrl(dao.website))',
+  '.map((dao) => ({ ...dao, websiteUrl: getHttpUrl(dao.website) }))',
+  'Representative DAO URL normalization'
+);
+assertContains(
+  pageSource,
+  '.filter((dao): dao is typeof dao & { websiteUrl: string } => Boolean(dao.websiteUrl))',
   'Representative DAO selection'
 );
+assertContains(pageSource, 'href={dao.websiteUrl}', 'Representative DAO safe href');
 assertContains(pageSource, 'aria-label="Representative public DAOs"', 'Representative DAO links');
 assertContains(
   pageSource,

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -12,13 +12,17 @@ const shareImageUrl = 'https://degov.ai/images/degov-social-card.png';
 const shareImageAlt = 'DeGov Square DAO Directory — discover public DAO governance.';
 const directorySourceUrl = 'https://github.com/ringecosystem/degov-registry';
 
-function isHttpUrl(value: string) {
+function getHttpUrl(value: string) {
   try {
     const url = new URL(value);
-    return url.protocol === 'http:' || url.protocol === 'https:';
+    if (url.protocol === 'http:' || url.protocol === 'https:') {
+      return url.toString();
+    }
   } catch {
-    return false;
+    return null;
   }
+
+  return null;
 }
 
 export const metadata: Metadata = {
@@ -61,7 +65,8 @@ export const dynamic = 'force-dynamic';
 export default async function Home() {
   const initialDirectory = await getPublicDaoDirectory();
   const representativeDaos = initialDirectory.daos
-    .filter((dao) => isHttpUrl(dao.website))
+    .map((dao) => ({ ...dao, websiteUrl: getHttpUrl(dao.website) }))
+    .filter((dao): dao is typeof dao & { websiteUrl: string } => Boolean(dao.websiteUrl))
     .slice(0, 6);
   const directoryReadAt = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
   const directoryCountText = initialDirectory.failed
@@ -104,7 +109,7 @@ export default async function Home() {
             {representativeDaos.map((dao) => (
               <Link
                 key={dao.id}
-                href={dao.website}
+                href={dao.websiteUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="border-border hover:bg-accent rounded-[4px] border px-[10px] py-[6px] text-[14px] transition-colors"

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { HomeClient } from './_components/home-client';
 import { getPublicDaoDirectory } from '@/lib/public-dao-directory';
 
+import Link from 'next/link';
 import type { Metadata } from 'next';
 
 const title = 'DeGov Square DAO Directory';
@@ -9,6 +10,7 @@ const description =
 const canonicalUrl = 'https://square.degov.ai/';
 const shareImageUrl = 'https://degov.ai/images/degov-social-card.png';
 const shareImageAlt = 'DeGov Square DAO Directory — discover public DAO governance.';
+const directorySourceUrl = 'https://github.com/ringecosystem/degov-registry';
 
 export const metadata: Metadata = {
   title,
@@ -49,11 +51,68 @@ export const dynamic = 'force-dynamic';
 
 export default async function Home() {
   const initialDirectory = await getPublicDaoDirectory();
+  const representativeDaos = initialDirectory.daos.filter((dao) => dao.website).slice(0, 6);
+  const directoryReadAt = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
+  const directoryCountText = initialDirectory.failed
+    ? 'temporarily unavailable in server HTML'
+    : `${initialDirectory.daos.length} public DAOs`;
 
   return (
-    <HomeClient
-      initialDaoData={initialDirectory.daos}
-      initialLoadFailed={initialDirectory.failed}
-    />
+    <main>
+      <section className="container flex flex-col gap-[12px] pt-[8px] pb-[24px] md:pb-[32px]">
+        <div className="flex flex-col gap-[8px]">
+          <h1 className="text-[28px] leading-[1.15] font-semibold md:text-[40px]">
+            DeGov Square DAO Directory
+          </h1>
+          <p className="text-muted-foreground max-w-[760px] text-[15px] leading-[1.6] md:text-[16px]">
+            Square indexes public DAO governance sites, supported networks, and proposal activity
+            from DeGov registry-backed directory data.
+          </p>
+        </div>
+        <div className="text-muted-foreground flex flex-col gap-[8px] text-[14px] leading-[1.6] md:flex-row md:flex-wrap md:gap-x-[24px]">
+          <p>
+            Directory count:{' '}
+            <strong className="text-foreground font-medium">{directoryCountText}</strong>.
+          </p>
+          <p>
+            Source:{' '}
+            <Link
+              href={directorySourceUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-foreground underline underline-offset-4"
+            >
+              DeGov public DAO registry
+            </Link>
+            .
+          </p>
+          <p>Last server read: {directoryReadAt}.</p>
+        </div>
+        {representativeDaos.length > 0 ? (
+          <nav aria-label="Representative public DAOs" className="flex flex-wrap gap-[8px]">
+            {representativeDaos.map((dao) => (
+              <Link
+                key={dao.id}
+                href={dao.website}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="border-border hover:bg-accent rounded-[4px] border px-[10px] py-[6px] text-[14px] transition-colors"
+              >
+                {dao.name}
+              </Link>
+            ))}
+          </nav>
+        ) : (
+          <p className="text-muted-foreground text-[14px] leading-[1.6]">
+            Representative DAO links are temporarily unavailable in server HTML; the browser
+            directory retries against the public API.
+          </p>
+        )}
+      </section>
+      <HomeClient
+        initialDaoData={initialDirectory.daos}
+        initialLoadFailed={initialDirectory.failed}
+      />
+    </main>
   );
 }

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -12,6 +12,15 @@ const shareImageUrl = 'https://degov.ai/images/degov-social-card.png';
 const shareImageAlt = 'DeGov Square DAO Directory — discover public DAO governance.';
 const directorySourceUrl = 'https://github.com/ringecosystem/degov-registry';
 
+function isHttpUrl(value: string) {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
 export const metadata: Metadata = {
   title,
   description,
@@ -51,7 +60,9 @@ export const dynamic = 'force-dynamic';
 
 export default async function Home() {
   const initialDirectory = await getPublicDaoDirectory();
-  const representativeDaos = initialDirectory.daos.filter((dao) => dao.website).slice(0, 6);
+  const representativeDaos = initialDirectory.daos
+    .filter((dao) => isHttpUrl(dao.website))
+    .slice(0, 6);
   const directoryReadAt = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
   const directoryCountText = initialDirectory.failed
     ? 'temporarily unavailable in server HTML'


### PR DESCRIPTION
## Summary
- add server-rendered Square directory H1, description, provenance, freshness, and representative DAO links
- keep the existing interactive directory while exposing an honest unavailable fallback for server HTML
- add a local content provenance verifier for the homepage contract

## Verification
- pnpm run test:content-provenance
- pnpm run test:social-preview
- pnpm run test:private-route-indexing
- pnpm exec prettier --check src/app/page.tsx scripts/check-content-provenance.mjs package.json
- git diff --check
- pnpm run build
- local raw HTML readback from http://localhost:3216/ confirmed H1, canonical, provenance, freshness, and representative DAO nav

Refs ringecosystem/degov-square#306
Refs ringecosystem/degov#1027
Refs ringecosystem/degov#714