### PR TITLE
Add Square directory structured data

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -34,6 +34,11 @@ jobs:
         run: |
           pnpm run test:social-preview
 
+      - name: Check structured data
+        working-directory: web
+        run: |
+          pnpm run test:structured-data
+
       - name: Check Build
         working-directory: web
         run: |
@@ -47,7 +52,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25.0'
+          go-version: "1.25.0"
           cache-dependency-path: backend/go.sum
 
       - uses: taiki-e/install-action@just

--- a/web/package.json
+++ b/web/package.json
@@ -9,6 +9,7 @@
     "test:content-provenance": "node scripts/check-content-provenance.mjs",
     "test:private-route-indexing": "node scripts/check-private-route-indexing.mjs",
     "test:social-preview": "node scripts/check-social-preview.mjs",
+    "test:structured-data": "node --experimental-strip-types scripts/check-structured-data.mjs",
     "start": "next start",
     "lint": "next lint"
   },

--- a/web/scripts/check-content-provenance.mjs
+++ b/web/scripts/check-content-provenance.mjs
@@ -10,7 +10,7 @@ const assertContains = (source, expected, label) => {
   assert.ok(source.includes(expected), `${label} must include ${expected}`);
 };
 
-assertContains(pageSource, "const canonicalUrl = 'https://square.degov.ai/';", 'Square canonical');
+assertContains(pageSource, 'const canonicalUrl = SQUARE_CANONICAL_URL;', 'Square canonical');
 assertContains(pageSource, '<h1', 'Square homepage');
 assertContains(pageSource, 'DeGov Square DAO Directory', 'Square H1 text');
 assertContains(pageSource, 'Square indexes public DAO governance sites', 'Directory description');

--- a/web/scripts/check-social-preview.mjs
+++ b/web/scripts/check-social-preview.mjs
@@ -15,7 +15,7 @@ const assertContains = (source, expected, label) => {
   assert.ok(source.includes(expected), `${label} must include ${expected}`);
 };
 
-assertContains(pageSource, "const canonicalUrl = 'https://square.degov.ai/';", 'Square canonical');
+assertContains(pageSource, 'const canonicalUrl = SQUARE_CANONICAL_URL;', 'Square canonical');
 assertContains(pageSource, `const shareImageUrl = '${expectedImageUrl}';`, 'Square share image');
 assertContains(pageSource, 'width: 1200', 'Open Graph image width');
 assertContains(pageSource, 'height: 630', 'Open Graph image height');

--- a/web/scripts/check-structured-data.mjs
+++ b/web/scripts/check-structured-data.mjs
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  buildSquareDirectoryStructuredData,
+  DEGOV_PUBLISHER_ID,
+  SQUARE_CANONICAL_URL,
+  SQUARE_COLLECTION_ID,
+  SQUARE_ITEM_LIST_ID,
+  SQUARE_WEBSITE_ID
+} from '../src/lib/square-structured-data.ts';
+
+const webRoot = join(fileURLToPath(new URL('..', import.meta.url)));
+
+const read = (path) => readFileSync(join(webRoot, path), 'utf8');
+
+const visibleDaos = [
+  { name: 'Lisk DAO', websiteUrl: 'https://lisk.degov.ai/' },
+  { name: 'Kusama Fellowship', websiteUrl: 'https://collectives.kusama.network/' }
+];
+
+const hiddenDao = { name: 'Hidden DAO', websiteUrl: 'https://hidden.example/' };
+const structuredData = buildSquareDirectoryStructuredData(visibleDaos);
+assert.ok(structuredData, 'visible directory items must produce structured data');
+
+const parsed = JSON.parse(JSON.stringify(structuredData));
+const website = parsed.find((item) => item['@type'] === 'WebSite');
+const collectionPage = parsed.find((item) => item['@type'] === 'CollectionPage');
+assert.ok(website, 'Square directory structured data must include WebSite');
+assert.ok(collectionPage, 'Square directory structured data must include CollectionPage');
+
+assert.equal(website['@id'], SQUARE_WEBSITE_ID, 'WebSite @id');
+assert.equal(website.url, SQUARE_CANONICAL_URL, 'WebSite URL');
+assert.equal(website.publisher['@id'], DEGOV_PUBLISHER_ID, 'WebSite publisher identity');
+
+assert.equal(collectionPage['@id'], SQUARE_COLLECTION_ID, 'CollectionPage @id');
+assert.equal(collectionPage.url, SQUARE_CANONICAL_URL, 'CollectionPage URL');
+assert.equal(collectionPage.isPartOf['@id'], SQUARE_WEBSITE_ID, 'CollectionPage website link');
+assert.equal(
+  collectionPage.publisher['@id'],
+  DEGOV_PUBLISHER_ID,
+  'CollectionPage publisher identity'
+);
+assert.equal(collectionPage.mainEntity['@id'], SQUARE_ITEM_LIST_ID, 'ItemList @id');
+assert.equal(collectionPage.mainEntity['@type'], 'ItemList', 'mainEntity type');
+assert.equal(collectionPage.mainEntity.numberOfItems, visibleDaos.length, 'visible item count');
+
+const listItems = collectionPage.mainEntity.itemListElement;
+assert.deepEqual(
+  listItems.map((item) => item.name),
+  visibleDaos.map((dao) => dao.name),
+  'JSON-LD item names must match visible DAO labels'
+);
+assert.deepEqual(
+  listItems.map((item) => item.url),
+  visibleDaos.map((dao) => dao.websiteUrl),
+  'JSON-LD item URLs must match visible DAO links'
+);
+assert.deepEqual(
+  listItems.map((item) => item.position),
+  [1, 2],
+  'JSON-LD item positions must follow visible order'
+);
+assert.ok(
+  !JSON.stringify(parsed).includes(hiddenDao.name),
+  'JSON-LD must not include hidden or client-only DAO items'
+);
+assert.equal(
+  buildSquareDirectoryStructuredData([]),
+  null,
+  'directory structured data must be omitted without visible items'
+);
+
+const pageSource = read('src/app/page.tsx');
+assert.ok(
+  pageSource.includes(
+    'const directoryStructuredData = buildSquareDirectoryStructuredData(representativeDaos);'
+  ),
+  'page must derive JSON-LD from the same representative DAO items shown in initial HTML'
+);
+assert.ok(
+  pageSource.includes('id="square-directory-structured-data"'),
+  'page must emit an identifiable Square directory JSON-LD block'
+);
+assert.ok(
+  pageSource.includes('href={dao.websiteUrl}'),
+  'visible representative DAO links must use the same normalized websiteUrl field'
+);
+
+for (const privateRoute of [
+  'src/app/add/layout.tsx',
+  'src/app/oauth/layout.tsx',
+  'src/app/notification/layout.tsx',
+  'src/app/setting/layout.tsx',
+  'src/app/not-found.tsx'
+]) {
+  const source = read(privateRoute);
+  assert.ok(
+    !source.includes('application/ld+json') &&
+      !source.includes('square-directory-structured-data') &&
+      !source.includes('CollectionPage') &&
+      !source.includes('ItemList'),
+    `${privateRoute} must not emit convincing public Square directory structured data`
+  );
+}
+
+console.log('Verified Square directory structured-data contract.');

--- a/web/scripts/check-structured-data.mjs
+++ b/web/scripts/check-structured-data.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 import {
   buildSquareDirectoryStructuredData,
   DEGOV_PUBLISHER_ID,
+  serializeJsonLd,
   SQUARE_CANONICAL_URL,
   SQUARE_COLLECTION_ID,
   SQUARE_ITEM_LIST_ID,
@@ -25,7 +26,9 @@ const hiddenDao = { name: 'Hidden DAO', websiteUrl: 'https://hidden.example/' };
 const structuredData = buildSquareDirectoryStructuredData(visibleDaos);
 assert.ok(structuredData, 'visible directory items must produce structured data');
 
-const parsed = JSON.parse(JSON.stringify(structuredData));
+const serialized = serializeJsonLd(structuredData);
+assert.ok(!serialized.includes('<'), 'serialized JSON-LD must escape literal < characters');
+const parsed = JSON.parse(serialized);
 const website = parsed.find((item) => item['@type'] === 'WebSite');
 const collectionPage = parsed.find((item) => item['@type'] === 'CollectionPage');
 assert.ok(website, 'Square directory structured data must include WebSite');
@@ -72,6 +75,14 @@ assert.equal(
   null,
   'directory structured data must be omitted without visible items'
 );
+assert.ok(
+  serializeJsonLd(
+    buildSquareDirectoryStructuredData([
+      { name: 'Bad </script><script>alert(1)</script>', websiteUrl: 'https://example.com/' }
+    ])
+  ).includes('\\u003c/script>'),
+  'JSON-LD serialization must harden script-closing DAO names'
+);
 
 const pageSource = read('src/app/page.tsx');
 assert.ok(
@@ -79,6 +90,12 @@ assert.ok(
     'const directoryStructuredData = buildSquareDirectoryStructuredData(representativeDaos);'
   ),
   'page must derive JSON-LD from the same representative DAO items shown in initial HTML'
+);
+assert.ok(
+  pageSource.includes(
+    'dangerouslySetInnerHTML={{ __html: serializeJsonLd(directoryStructuredData) }}'
+  ),
+  'page must inject escaped JSON-LD rather than raw JSON.stringify output'
 );
 assert.ok(
   pageSource.includes('id="square-directory-structured-data"'),

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,5 +1,9 @@
 import { HomeClient } from './_components/home-client';
 import { getPublicDaoDirectory } from '@/lib/public-dao-directory';
+import {
+  buildSquareDirectoryStructuredData,
+  SQUARE_CANONICAL_URL
+} from '@/lib/square-structured-data';
 
 import Link from 'next/link';
 import type { Metadata } from 'next';
@@ -7,7 +11,7 @@ import type { Metadata } from 'next';
 const title = 'DeGov Square DAO Directory';
 const description =
   'Discover public DAO governance sites, proposal activity, supported networks, and DeGov-managed governance communities.';
-const canonicalUrl = 'https://square.degov.ai/';
+const canonicalUrl = SQUARE_CANONICAL_URL;
 const shareImageUrl = 'https://degov.ai/images/degov-social-card.png';
 const shareImageAlt = 'DeGov Square DAO Directory — discover public DAO governance.';
 const directorySourceUrl = 'https://github.com/ringecosystem/degov-registry';
@@ -72,6 +76,7 @@ export default async function Home() {
   const directoryCountText = initialDirectory.failed
     ? 'temporarily unavailable in server HTML'
     : `${initialDirectory.daos.length} public DAOs`;
+  const directoryStructuredData = buildSquareDirectoryStructuredData(representativeDaos);
 
   return (
     <main>
@@ -125,6 +130,14 @@ export default async function Home() {
           </p>
         )}
       </section>
+      {directoryStructuredData ? (
+        <script
+          id="square-directory-structured-data"
+          type="application/ld+json"
+          suppressHydrationWarning
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(directoryStructuredData) }}
+        />
+      ) : null}
       <HomeClient
         initialDaoData={initialDirectory.daos}
         initialLoadFailed={initialDirectory.failed}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -2,6 +2,7 @@ import { HomeClient } from './_components/home-client';
 import { getPublicDaoDirectory } from '@/lib/public-dao-directory';
 import {
   buildSquareDirectoryStructuredData,
+  serializeJsonLd,
   SQUARE_CANONICAL_URL
 } from '@/lib/square-structured-data';
 
@@ -135,7 +136,7 @@ export default async function Home() {
           id="square-directory-structured-data"
           type="application/ld+json"
           suppressHydrationWarning
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(directoryStructuredData) }}
+          dangerouslySetInnerHTML={{ __html: serializeJsonLd(directoryStructuredData) }}
         />
       ) : null}
       <HomeClient

--- a/web/src/lib/square-structured-data.ts
+++ b/web/src/lib/square-structured-data.ts
@@ -1,0 +1,54 @@
+export const SQUARE_CANONICAL_URL = 'https://square.degov.ai/';
+export const DEGOV_PUBLISHER_ID = 'https://degov.ai/#organization';
+export const SQUARE_WEBSITE_ID = `${SQUARE_CANONICAL_URL}#website`;
+export const SQUARE_COLLECTION_ID = `${SQUARE_CANONICAL_URL}#dao-directory`;
+export const SQUARE_ITEM_LIST_ID = `${SQUARE_CANONICAL_URL}#dao-directory-items`;
+
+export type SquareDirectoryStructuredDataItem = {
+  name: string;
+  websiteUrl: string;
+};
+
+export function buildSquareDirectoryStructuredData(items: SquareDirectoryStructuredDataItem[]) {
+  if (items.length === 0) return null;
+
+  return [
+    {
+      '@context': 'https://schema.org',
+      '@id': SQUARE_WEBSITE_ID,
+      '@type': 'WebSite',
+      name: 'DeGov Square',
+      url: SQUARE_CANONICAL_URL,
+      publisher: {
+        '@id': DEGOV_PUBLISHER_ID
+      }
+    },
+    {
+      '@context': 'https://schema.org',
+      '@id': SQUARE_COLLECTION_ID,
+      '@type': 'CollectionPage',
+      name: 'DeGov Square DAO Directory',
+      description:
+        'Discover public DAO governance sites, proposal activity, supported networks, and DeGov-managed governance communities.',
+      url: SQUARE_CANONICAL_URL,
+      isPartOf: {
+        '@id': SQUARE_WEBSITE_ID
+      },
+      publisher: {
+        '@id': DEGOV_PUBLISHER_ID
+      },
+      mainEntity: {
+        '@id': SQUARE_ITEM_LIST_ID,
+        '@type': 'ItemList',
+        name: 'Representative public DAOs',
+        numberOfItems: items.length,
+        itemListElement: items.map((item, index) => ({
+          '@type': 'ListItem',
+          position: index + 1,
+          name: item.name,
+          url: item.websiteUrl
+        }))
+      }
+    }
+  ];
+}

--- a/web/src/lib/square-structured-data.ts
+++ b/web/src/lib/square-structured-data.ts
@@ -52,3 +52,7 @@ export function buildSquareDirectoryStructuredData(items: SquareDirectoryStructu
     }
   ];
 }
+
+export function serializeJsonLd(value: unknown) {
+  return JSON.stringify(value).replace(/</g, '\\u003c');
+}


### PR DESCRIPTION
## Summary

- emit Square homepage `WebSite` and `CollectionPage`/`ItemList` JSON-LD from the same representative DAO links shown in initial HTML
- omit directory structured data when no visible representative DAO items are available
- add a structured-data verifier and wire it into the PR web check

## Tracking

- Implements the repository code slice for ringecosystem/degov-square#308
- Supports ringecosystem/degov#1028 and ringecosystem/degov#714

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm run test:structured-data`
- `pnpm run test:content-provenance`
- `pnpm run test:private-route-indexing`
- `pnpm run test:social-preview`
- `pnpm build`
- `pnpm exec prettier --check ../.github/workflows/check.yml package.json scripts/check-content-provenance.mjs scripts/check-social-preview.mjs scripts/check-structured-data.mjs src/app/page.tsx src/lib/square-structured-data.ts`
- `git diff --check`

Note: `pnpm lint` currently fails on the repository's existing `next lint` circular-structure issue and is not part of the current GitHub Check Web workflow.
