### PR TITLE
Add Square DAO discovery analytics event

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -34,6 +34,11 @@ jobs:
         run: |
           pnpm run test:social-preview
 
+      - name: Check DAO discovery analytics
+        working-directory: web
+        run: |
+          pnpm run test:dao-discovery-analytics
+
       - name: Check structured data
         working-directory: web
         run: |

--- a/web/package.json
+++ b/web/package.json
@@ -7,6 +7,7 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "test:content-provenance": "node scripts/check-content-provenance.mjs",
+    "test:dao-discovery-analytics": "node --experimental-strip-types scripts/check-dao-discovery-analytics.mjs",
     "test:private-route-indexing": "node scripts/check-private-route-indexing.mjs",
     "test:social-preview": "node scripts/check-social-preview.mjs",
     "test:structured-data": "node --experimental-strip-types scripts/check-structured-data.mjs",

--- a/web/scripts/check-dao-discovery-analytics.mjs
+++ b/web/scripts/check-dao-discovery-analytics.mjs
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  buildSquareDaoClickEventParams,
+  getChannelGroupFromReferrer,
+  getTargetHostClass,
+  SQUARE_DAO_CLICK_EVENT_NAME
+} from '../src/lib/analytics.ts';
+
+const webRoot = join(fileURLToPath(new URL('..', import.meta.url)));
+const read = (path) => readFileSync(join(webRoot, path), 'utf8');
+
+assert.equal(SQUARE_DAO_CLICK_EVENT_NAME, 'degov_square_dao_click');
+assert.deepEqual(
+  Object.keys(
+    buildSquareDaoClickEventParams({
+      daoCode: 'lisk-dao',
+      targetUrl: 'https://lisk.degov.ai/',
+      referrer: 'https://chatgpt.com/share/example',
+      currentHost: 'square.degov.ai'
+    })
+  ).sort(),
+  ['channel_group', 'dao_slug_or_public_id', 'source_surface', 'target_host_class']
+);
+assert.deepEqual(
+  buildSquareDaoClickEventParams({
+    daoCode: 'lisk-dao',
+    targetUrl: 'https://lisk.degov.ai/',
+    referrer: 'https://chatgpt.com/share/example',
+    currentHost: 'square.degov.ai'
+  }),
+  {
+    source_surface: 'square',
+    dao_slug_or_public_id: 'lisk-dao',
+    target_host_class: 'degov-dao-host',
+    channel_group: 'ai-search-assistant-referral'
+  }
+);
+
+assert.equal(getTargetHostClass('https://lisk.degov.ai/'), 'degov-dao-host');
+assert.equal(getTargetHostClass('https://collectives.kusama.network/'), 'external-dao-host');
+assert.equal(getTargetHostClass('not a url'), 'unknown');
+assert.equal(getChannelGroupFromReferrer('', 'square.degov.ai'), 'direct-unknown');
+assert.equal(
+  getChannelGroupFromReferrer('https://www.square.degov.ai/', 'square.degov.ai'),
+  'direct-unknown'
+);
+assert.equal(
+  getChannelGroupFromReferrer('https://www.google.com/search?q=degov', 'square.degov.ai'),
+  'organic-search'
+);
+assert.equal(
+  getChannelGroupFromReferrer('https://x.com/ai_degov', 'square.degov.ai'),
+  'social-organic'
+);
+assert.equal(
+  getChannelGroupFromReferrer('https://docs.degov.ai/integration', 'square.degov.ai'),
+  'documentation-referral'
+);
+assert.equal(
+  getChannelGroupFromReferrer('https://lisk.degov.ai/proposals', 'square.degov.ai'),
+  'cross-product-degov-referral'
+);
+assert.equal(
+  getChannelGroupFromReferrer('https://sex.com/post', 'square.degov.ai'),
+  'other-external-referral'
+);
+assert.equal(
+  getChannelGroupFromReferrer('https://evilbing.com/post', 'square.degov.ai'),
+  'other-external-referral'
+);
+
+const analyticsSource = read('src/lib/analytics.ts');
+const homeSource = read('src/app/_components/home-client.tsx');
+const itemSource = read('src/app/_components/daoItem.tsx');
+const combinedSource = `${analyticsSource}\n${homeSource}\n${itemSource}`;
+
+for (const field of [
+  'wallet_address',
+  'user_profile',
+  'notification_destination',
+  'oauth',
+  'private_profile',
+  'window.location.search',
+  'window.location.href'
+]) {
+  assert.ok(!combinedSource.includes(field), `analytics source must not include ${field}`);
+}
+
+assert.ok(
+  homeSource.includes('onClick={() => trackSquareDaoClick(value.code, value.website)}'),
+  'desktop DAO directory links must track public DAO discovery clicks'
+);
+assert.ok(
+  itemSource.includes('onClick={() => trackSquareDaoClick(dao.code, website)}'),
+  'mobile DAO directory links must track public DAO discovery clicks'
+);
+assert.ok(
+  analyticsSource.includes('`${SQUARE_DAO_CLICK_EVENT_NAME}:${params.dao_slug_or_public_id}`'),
+  'dedupe key must use session plus public DAO id only'
+);
+
+console.log('Verified Square DAO discovery analytics contract.');

--- a/web/src/app/_components/daoItem.tsx
+++ b/web/src/app/_components/daoItem.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 
 import { LikeButton } from '@/components/like-button';
 import { Separator } from '@/components/ui/separator';
+import { trackSquareDaoClick } from '@/lib/analytics';
 import type { DaoInfo } from '@/utils/config';
 import { formatNetworkName } from '@/utils/helper';
 
@@ -20,6 +21,7 @@ export const DaoItem = (dao: DaoItemProps) => {
             target="_blank"
             rel="noopener noreferrer"
             className="flex items-center gap-[10px] hover:underline"
+            onClick={() => trackSquareDaoClick(dao.code, website)}
           >
             <Image src={daoIcon} alt={name} width={32} height={32} className="rounded-full" />
             <p className="text-[18px] font-semibold">{name}</p>

--- a/web/src/app/_components/home-client.tsx
+++ b/web/src/app/_components/home-client.tsx
@@ -10,6 +10,7 @@ import { SortableCell } from '@/components/sortable-cell';
 import { Button } from '@/components/ui/button';
 import TagGroup from '@/components/ui/tag-group';
 import { useGraphqlDaoData } from '@/hooks/useGraphqlDaoData';
+import { trackSquareDaoClick } from '@/lib/analytics';
 import { useMiniApp } from '@/provider/miniapp';
 import type { DaoInfo } from '@/utils/config';
 import { formatNetworkName, formatTimeAgo } from '@/utils/helper';
@@ -97,6 +98,7 @@ export function HomeClient({ initialDaoData, initialLoadFailed }: HomeClientProp
               target="_blank"
               rel="noopener noreferrer"
               className="flex items-center gap-[10px] hover:underline"
+              onClick={() => trackSquareDaoClick(value.code, value.website)}
             >
               <Image
                 src={value?.daoIcon}

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -1,0 +1,175 @@
+'use client';
+
+export const SQUARE_DAO_CLICK_EVENT_NAME = 'degov_square_dao_click';
+
+export type ChannelGroup =
+  | 'organic-search'
+  | 'social-organic'
+  | 'documentation-referral'
+  | 'cross-product-degov-referral'
+  | 'ai-search-assistant-referral'
+  | 'other-external-referral'
+  | 'direct-unknown';
+
+export type TargetHostClass = 'degov-dao-host' | 'external-dao-host' | 'unknown';
+
+export type SquareDaoClickEventParams = {
+  source_surface: 'square';
+  dao_slug_or_public_id: string;
+  target_host_class: TargetHostClass;
+  channel_group: ChannelGroup;
+};
+
+declare global {
+  interface Window {
+    gtag?: (command: 'event', eventName: string, params: SquareDaoClickEventParams) => void;
+  }
+}
+
+const SEARCH_HOST_SUBSTRINGS = ['google.', 'yahoo.'];
+const SEARCH_HOST_DOMAINS = ['bing.com', 'duckduckgo.com', 'baidu.com', 'yandex.com'];
+const SOCIAL_HOSTS = [
+  'x.com',
+  'twitter.com',
+  'linkedin.com',
+  'facebook.com',
+  'discord.com',
+  'telegram.org',
+  't.me'
+];
+const AI_REFERRER_HOSTS = [
+  'chatgpt.com',
+  'perplexity.ai',
+  'copilot.microsoft.com',
+  'gemini.google.com'
+];
+
+function normalizePublicId(value: string | null | undefined): string {
+  return String(value ?? '')
+    .trim()
+    .slice(0, 160);
+}
+
+function normalizeHost(hostname: string | null | undefined): string {
+  return String(hostname ?? '')
+    .toLowerCase()
+    .replace(/^www\./, '');
+}
+
+function hostMatchesDomain(hostname: string, candidate: string): boolean {
+  return hostname === candidate || hostname.endsWith(`.${candidate}`);
+}
+
+function hostMatchesDomains(hostname: string, candidates: string[]): boolean {
+  return candidates.some((candidate) => hostMatchesDomain(hostname, candidate));
+}
+
+export function getChannelGroupFromReferrer(
+  referrer: string | null | undefined,
+  currentHost: string | null | undefined
+): ChannelGroup {
+  if (!referrer) return 'direct-unknown';
+
+  let referrerUrl: URL;
+  try {
+    referrerUrl = new URL(referrer);
+  } catch {
+    return 'direct-unknown';
+  }
+
+  const referrerHost = normalizeHost(referrerUrl.hostname);
+  const current = normalizeHost(currentHost);
+
+  if (current && referrerHost === current) {
+    return 'direct-unknown';
+  }
+
+  if (hostMatchesDomains(referrerHost, AI_REFERRER_HOSTS)) {
+    return 'ai-search-assistant-referral';
+  }
+
+  if (
+    SEARCH_HOST_SUBSTRINGS.some((candidate) => referrerHost.includes(candidate)) ||
+    hostMatchesDomains(referrerHost, SEARCH_HOST_DOMAINS)
+  ) {
+    return 'organic-search';
+  }
+
+  if (hostMatchesDomains(referrerHost, SOCIAL_HOSTS)) {
+    return 'social-organic';
+  }
+
+  if (referrerHost === 'docs.degov.ai') {
+    return 'documentation-referral';
+  }
+
+  if (referrerHost.endsWith('.degov.ai') || referrerHost === 'degov.ai') {
+    return 'cross-product-degov-referral';
+  }
+
+  return 'other-external-referral';
+}
+
+export function getTargetHostClass(targetUrl: string | null | undefined): TargetHostClass {
+  if (!targetUrl) return 'unknown';
+
+  let url: URL;
+  try {
+    url = new URL(targetUrl);
+  } catch {
+    return 'unknown';
+  }
+
+  const host = normalizeHost(url.hostname);
+  return host.endsWith('.degov.ai') || host === 'degov.ai' ? 'degov-dao-host' : 'external-dao-host';
+}
+
+export function buildSquareDaoClickEventParams({
+  daoCode,
+  targetUrl,
+  referrer,
+  currentHost
+}: {
+  daoCode: string | null | undefined;
+  targetUrl: string | null | undefined;
+  referrer: string | null | undefined;
+  currentHost: string | null | undefined;
+}): SquareDaoClickEventParams {
+  return {
+    source_surface: 'square',
+    dao_slug_or_public_id: normalizePublicId(daoCode),
+    target_host_class: getTargetHostClass(targetUrl),
+    channel_group: getChannelGroupFromReferrer(referrer, currentHost)
+  };
+}
+
+export function sendSquareAnalyticsEvent(
+  eventName: string,
+  params: SquareDaoClickEventParams
+): boolean {
+  if (typeof window === 'undefined' || typeof window.gtag !== 'function') {
+    return false;
+  }
+
+  window.gtag('event', eventName, params);
+  return true;
+}
+
+export function trackSquareDaoClick(daoCode: string, targetUrl: string): void {
+  const params = buildSquareDaoClickEventParams({
+    daoCode,
+    targetUrl,
+    referrer: document.referrer,
+    currentHost: window.location.hostname
+  });
+  const dedupeKey = `${SQUARE_DAO_CLICK_EVENT_NAME}:${params.dao_slug_or_public_id}`;
+
+  try {
+    if (window.sessionStorage.getItem(dedupeKey)) return;
+    if (sendSquareAnalyticsEvent(SQUARE_DAO_CLICK_EVENT_NAME, params)) {
+      window.sessionStorage.setItem(dedupeKey, '1');
+    }
+  } catch {
+    sendSquareAnalyticsEvent(SQUARE_DAO_CLICK_EVENT_NAME, params);
+  }
+}


### PR DESCRIPTION
## Summary

- add the privacy-safe `degov_square_dao_click` event for public Square DAO directory clicks
- classify only observable referrers into the approved channel groups
- send only the approved public DAO id, target host class, source surface, and channel group payload
- add a DAO discovery analytics contract check to CI

## Verification

- `pnpm run test:dao-discovery-analytics`
- `pnpm run test:private-route-indexing`
- `pnpm run test:structured-data`
- `pnpm run test:content-provenance`
- `pnpm run test:social-preview`
- `pnpm exec prettier --check src/lib/analytics.ts src/app/_components/daoItem.tsx src/app/_components/home-client.tsx scripts/check-dao-discovery-analytics.mjs package.json ../.github/workflows/check.yml`
- `pnpm run build`

Note: `pnpm run lint` / `pnpm exec eslint .` currently fail on the repository ESLint configuration with `Converting circular structure to JSON`; this is pre-existing and also appears during `next build`, which still exits 0.

Refs ringecosystem/degov#1031
Refs ringecosystem/degov#714
Refs #311