### PR TITLE
Consolidate Square directory provenance

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -7,6 +7,7 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "test:content-provenance": "node scripts/check-content-provenance.mjs",
+    "test:rendered-content-provenance": "node scripts/check-rendered-content-provenance.mjs",
     "test:dao-discovery-analytics": "node --experimental-strip-types scripts/check-dao-discovery-analytics.mjs",
     "test:private-route-indexing": "node scripts/check-private-route-indexing.mjs",
     "test:social-preview": "node scripts/check-social-preview.mjs",

--- a/web/scripts/check-content-provenance.mjs
+++ b/web/scripts/check-content-provenance.mjs
@@ -20,31 +20,41 @@ assertContains(
   "const directorySourceUrl = 'https://github.com/ringecosystem/degov-registry';",
   'Directory provenance URL'
 );
-assertContains(pageSource, 'Last server read:', 'Directory freshness text');
-assertContains(pageSource, 'function getHttpUrl(value: string)', 'Representative link URL guard');
-assertContains(
-  pageSource,
-  "url.protocol === 'http:' || url.protocol === 'https:'",
-  'HTTP URL guard'
-);
-assertContains(pageSource, 'return url.toString();', 'Representative URL normalization');
-assertContains(
-  pageSource,
-  '.map((dao) => ({ ...dao, websiteUrl: getHttpUrl(dao.website) }))',
-  'Representative DAO URL normalization'
-);
-assertContains(
-  pageSource,
-  '.filter((dao): dao is typeof dao & { websiteUrl: string } => Boolean(dao.websiteUrl))',
-  'Representative DAO selection'
-);
-assertContains(pageSource, 'href={dao.websiteUrl}', 'Representative DAO safe href');
-assertContains(pageSource, 'aria-label="Representative public DAOs"', 'Representative DAO links');
-assertContains(
-  pageSource,
-  'Representative DAO links are temporarily unavailable in server HTML',
-  'Directory unavailable fallback'
-);
 assertContains(pageSource, 'initialLoadFailed={initialDirectory.failed}', 'Client retry state');
+assertContains(pageSource, 'initialDaoData={initialDirectory.daos}', 'Initial directory data');
+
+assert.ok(
+  !pageSource.includes('Last server read:') && !pageSource.includes('new Date()'),
+  'page must not present request/render time as directory freshness'
+);
+assert.ok(
+  !pageSource.includes('representativeDaos') &&
+    !pageSource.includes('Representative public DAOs') &&
+    !pageSource.includes('.slice(0, 6)'),
+  'page must not emit a duplicate arbitrary representative DAO navigation'
+);
+
+const homeClientSource = readFileSync(join(webRoot, 'src/app/_components/home-client.tsx'), 'utf8');
+const daoListSource = readFileSync(join(webRoot, 'src/app/_components/daoList.tsx'), 'utf8');
+const daoItemSource = readFileSync(join(webRoot, 'src/app/_components/daoItem.tsx'), 'utf8');
+
+assertContains(
+  homeClientSource,
+  'const displayDaoData = daoData.length > 0 ? daoData : initialDaoData;',
+  'HomeClient initial DAO authority'
+);
+assertContains(
+  homeClientSource,
+  'dataSource={filteredAndSortedData}',
+  'Desktop initial directory table'
+);
+assertContains(
+  homeClientSource,
+  'daoInfo={filteredAndSortedData}',
+  'Mobile initial directory list'
+);
+assertContains(homeClientSource, 'href={value?.website}', 'Desktop DAO links');
+assertContains(daoListSource, '<DaoItem {...v} key={v.id}', 'Mobile DAO item render');
+assertContains(daoItemSource, 'href={website}', 'Mobile DAO links');
 
 console.log('Verified Square content provenance contract.');

--- a/web/scripts/check-rendered-content-provenance.mjs
+++ b/web/scripts/check-rendered-content-provenance.mjs
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:http';
+import { once } from 'node:events';
+
+const fixtureDao = {
+  id: 'fixture-dao',
+  name: 'Fixture Governance DAO',
+  code: 'fixture',
+  chainId: 1,
+  chainName: 'Fixture Chain',
+  seq: 1,
+  timeSyncd: '2026-01-01T00:00:00Z',
+  ctime: '2026-01-01T00:00:00Z',
+  utime: '2026-01-01T00:00:00Z',
+  state: 'ACTIVE',
+  tags: [],
+  chips: [],
+  metricsCountMembers: 10,
+  metricsCountProposals: 4,
+  metricsCountVote: 20,
+  metricsSumPower: '100',
+  endpoint: 'https://fixture.degov.ai/',
+  logo: 'https://fixture.degov.ai/logo.png',
+  chainLogo: 'https://fixture.degov.ai/chain.png',
+  liked: false,
+  lastProposal: null
+};
+
+let fixtureFails = false;
+const fixtureServer = createServer((_request, response) => {
+  response.setHeader('content-type', 'application/json');
+  if (fixtureFails) {
+    response.statusCode = 503;
+    response.end(JSON.stringify({ errors: [{ message: 'fixture unavailable' }] }));
+    return;
+  }
+
+  response.end(JSON.stringify({ data: { daos: [fixtureDao] } }));
+});
+
+fixtureServer.listen(0, '127.0.0.1');
+await once(fixtureServer, 'listening');
+const fixtureAddress = fixtureServer.address();
+assert.ok(fixtureAddress && typeof fixtureAddress === 'object');
+
+const portProbe = createServer();
+portProbe.listen(0, '127.0.0.1');
+await once(portProbe, 'listening');
+const appAddress = portProbe.address();
+assert.ok(appAddress && typeof appAddress === 'object');
+const appPort = appAddress.port;
+await new Promise((resolve, reject) =>
+  portProbe.close((error) => (error ? reject(error) : resolve()))
+);
+
+const app = spawn('pnpm', ['exec', 'next', 'dev', '--turbopack', '-p', String(appPort)], {
+  cwd: new URL('..', import.meta.url),
+  env: {
+    ...process.env,
+    NEXT_PUBLIC_GRAPHQL_ENDPOINT: `http://127.0.0.1:${fixtureAddress.port}/graphql`
+  },
+  stdio: ['ignore', 'pipe', 'pipe']
+});
+
+let appLogs = '';
+app.stdout.on('data', (chunk) => {
+  appLogs += chunk;
+});
+app.stderr.on('data', (chunk) => {
+  appLogs += chunk;
+});
+
+async function fetchRenderedHome() {
+  let lastError;
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    try {
+      const response = await fetch(`http://127.0.0.1:${appPort}/`);
+      if (response.ok) return response.text();
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error(`Square test server did not become ready: ${lastError}\n${appLogs}`);
+}
+
+try {
+  const successHtml = await fetchRenderedHome();
+  assert.match(successHtml, /Fixture Governance DAO/);
+  assert.match(successHtml, /href="https:\/\/fixture\.degov\.ai\/"/);
+  assert.doesNotMatch(successHtml, /Representative public DAOs|Last server read:|ItemList/);
+
+  fixtureFails = true;
+  const failureHtml = await fetchRenderedHome();
+  assert.match(failureHtml, /temporarily unavailable in server HTML/);
+  assert.match(failureHtml, /DAO directory data is temporarily unavailable/);
+  assert.doesNotMatch(failureHtml, /Fixture Governance DAO|href="https:\/\/fixture\.degov\.ai\/"/);
+
+  console.log('Verified rendered Square content provenance contract.');
+} finally {
+  app.kill('SIGTERM');
+  await Promise.race([once(app, 'exit'), new Promise((resolve) => setTimeout(resolve, 5_000))]);
+  await new Promise((resolve, reject) =>
+    fixtureServer.close((error) => (error ? reject(error) : resolve()))
+  );
+}

--- a/web/scripts/check-structured-data.mjs
+++ b/web/scripts/check-structured-data.mjs
@@ -9,7 +9,6 @@ import {
   serializeJsonLd,
   SQUARE_CANONICAL_URL,
   SQUARE_COLLECTION_ID,
-  SQUARE_ITEM_LIST_ID,
   SQUARE_WEBSITE_ID
 } from '../src/lib/square-structured-data.ts';
 
@@ -17,14 +16,8 @@ const webRoot = join(fileURLToPath(new URL('..', import.meta.url)));
 
 const read = (path) => readFileSync(join(webRoot, path), 'utf8');
 
-const visibleDaos = [
-  { name: 'Lisk DAO', websiteUrl: 'https://lisk.degov.ai/' },
-  { name: 'Kusama Fellowship', websiteUrl: 'https://collectives.kusama.network/' }
-];
-
-const hiddenDao = { name: 'Hidden DAO', websiteUrl: 'https://hidden.example/' };
-const structuredData = buildSquareDirectoryStructuredData(visibleDaos);
-assert.ok(structuredData, 'visible directory items must produce structured data');
+const structuredData = buildSquareDirectoryStructuredData();
+assert.ok(structuredData, 'Square directory identity must produce structured data');
 
 const serialized = serializeJsonLd(structuredData);
 assert.ok(!serialized.includes('<'), 'serialized JSON-LD must escape literal < characters');
@@ -46,50 +39,19 @@ assert.equal(
   DEGOV_PUBLISHER_ID,
   'CollectionPage publisher identity'
 );
-assert.equal(collectionPage.mainEntity['@id'], SQUARE_ITEM_LIST_ID, 'ItemList @id');
-assert.equal(collectionPage.mainEntity['@type'], 'ItemList', 'mainEntity type');
-assert.equal(collectionPage.mainEntity.numberOfItems, visibleDaos.length, 'visible item count');
-
-const listItems = collectionPage.mainEntity.itemListElement;
-assert.deepEqual(
-  listItems.map((item) => item.name),
-  visibleDaos.map((dao) => dao.name),
-  'JSON-LD item names must match visible DAO labels'
-);
-assert.deepEqual(
-  listItems.map((item) => item.url),
-  visibleDaos.map((dao) => dao.websiteUrl),
-  'JSON-LD item URLs must match visible DAO links'
-);
-assert.deepEqual(
-  listItems.map((item) => item.position),
-  [1, 2],
-  'JSON-LD item positions must follow visible order'
+assert.ok(
+  !('mainEntity' in collectionPage),
+  'CollectionPage must not expose an ItemList without a stable visible ordering contract'
 );
 assert.ok(
-  !JSON.stringify(parsed).includes(hiddenDao.name),
-  'JSON-LD must not include hidden or client-only DAO items'
-);
-assert.equal(
-  buildSquareDirectoryStructuredData([]),
-  null,
-  'directory structured data must be omitted without visible items'
-);
-assert.ok(
-  serializeJsonLd(
-    buildSquareDirectoryStructuredData([
-      { name: 'Bad </script><script>alert(1)</script>', websiteUrl: 'https://example.com/' }
-    ])
-  ).includes('\\u003c/script>'),
-  'JSON-LD serialization must harden script-closing DAO names'
+  serializeJsonLd({ name: 'Bad </script><script>alert(1)</script>' }).includes('\\u003c/script>'),
+  'JSON-LD serialization must harden script-closing content'
 );
 
 const pageSource = read('src/app/page.tsx');
 assert.ok(
-  pageSource.includes(
-    'const directoryStructuredData = buildSquareDirectoryStructuredData(representativeDaos);'
-  ),
-  'page must derive JSON-LD from the same representative DAO items shown in initial HTML'
+  pageSource.includes('const directoryStructuredData = buildSquareDirectoryStructuredData();'),
+  'page must not derive JSON-LD from an arbitrary representative DAO slice'
 );
 assert.ok(
   pageSource.includes(
@@ -102,8 +64,8 @@ assert.ok(
   'page must emit an identifiable Square directory JSON-LD block'
 );
 assert.ok(
-  pageSource.includes('href={dao.websiteUrl}'),
-  'visible representative DAO links must use the same normalized websiteUrl field'
+  !pageSource.includes('representativeDaos') && !pageSource.includes('.slice(0, 6)'),
+  'structured data must not depend on a first-six representative DAO selection'
 );
 
 for (const privateRoute of [

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -17,19 +17,6 @@ const shareImageUrl = 'https://degov.ai/images/degov-social-card.png';
 const shareImageAlt = 'DeGov Square DAO Directory — discover public DAO governance.';
 const directorySourceUrl = 'https://github.com/ringecosystem/degov-registry';
 
-function getHttpUrl(value: string) {
-  try {
-    const url = new URL(value);
-    if (url.protocol === 'http:' || url.protocol === 'https:') {
-      return url.toString();
-    }
-  } catch {
-    return null;
-  }
-
-  return null;
-}
-
 export const metadata: Metadata = {
   title,
   description,
@@ -69,15 +56,10 @@ export const dynamic = 'force-dynamic';
 
 export default async function Home() {
   const initialDirectory = await getPublicDaoDirectory();
-  const representativeDaos = initialDirectory.daos
-    .map((dao) => ({ ...dao, websiteUrl: getHttpUrl(dao.website) }))
-    .filter((dao): dao is typeof dao & { websiteUrl: string } => Boolean(dao.websiteUrl))
-    .slice(0, 6);
-  const directoryReadAt = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
   const directoryCountText = initialDirectory.failed
     ? 'temporarily unavailable in server HTML'
     : `${initialDirectory.daos.length} public DAOs`;
-  const directoryStructuredData = buildSquareDirectoryStructuredData(representativeDaos);
+  const directoryStructuredData = buildSquareDirectoryStructuredData();
 
   return (
     <main>
@@ -108,37 +90,14 @@ export default async function Home() {
             </Link>
             .
           </p>
-          <p>Last server read: {directoryReadAt}.</p>
         </div>
-        {representativeDaos.length > 0 ? (
-          <nav aria-label="Representative public DAOs" className="flex flex-wrap gap-[8px]">
-            {representativeDaos.map((dao) => (
-              <Link
-                key={dao.id}
-                href={dao.websiteUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="border-border hover:bg-accent rounded-[4px] border px-[10px] py-[6px] text-[14px] transition-colors"
-              >
-                {dao.name}
-              </Link>
-            ))}
-          </nav>
-        ) : (
-          <p className="text-muted-foreground text-[14px] leading-[1.6]">
-            Representative DAO links are temporarily unavailable in server HTML; the browser
-            directory retries against the public API.
-          </p>
-        )}
       </section>
-      {directoryStructuredData ? (
-        <script
-          id="square-directory-structured-data"
-          type="application/ld+json"
-          suppressHydrationWarning
-          dangerouslySetInnerHTML={{ __html: serializeJsonLd(directoryStructuredData) }}
-        />
-      ) : null}
+      <script
+        id="square-directory-structured-data"
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(directoryStructuredData) }}
+      />
       <HomeClient
         initialDaoData={initialDirectory.daos}
         initialLoadFailed={initialDirectory.failed}

--- a/web/src/lib/square-structured-data.ts
+++ b/web/src/lib/square-structured-data.ts
@@ -2,16 +2,8 @@ export const SQUARE_CANONICAL_URL = 'https://square.degov.ai/';
 export const DEGOV_PUBLISHER_ID = 'https://degov.ai/#organization';
 export const SQUARE_WEBSITE_ID = `${SQUARE_CANONICAL_URL}#website`;
 export const SQUARE_COLLECTION_ID = `${SQUARE_CANONICAL_URL}#dao-directory`;
-export const SQUARE_ITEM_LIST_ID = `${SQUARE_CANONICAL_URL}#dao-directory-items`;
 
-export type SquareDirectoryStructuredDataItem = {
-  name: string;
-  websiteUrl: string;
-};
-
-export function buildSquareDirectoryStructuredData(items: SquareDirectoryStructuredDataItem[]) {
-  if (items.length === 0) return null;
-
+export function buildSquareDirectoryStructuredData() {
   return [
     {
       '@context': 'https://schema.org',
@@ -36,18 +28,6 @@ export function buildSquareDirectoryStructuredData(items: SquareDirectoryStructu
       },
       publisher: {
         '@id': DEGOV_PUBLISHER_ID
-      },
-      mainEntity: {
-        '@id': SQUARE_ITEM_LIST_ID,
-        '@type': 'ItemList',
-        name: 'Representative public DAOs',
-        numberOfItems: items.length,
-        itemListElement: items.map((item, index) => ({
-          '@type': 'ListItem',
-          position: index + 1,
-          name: item.name,
-          url: item.websiteUrl
-        }))
       }
     }
   ];


### PR DESCRIPTION
## Summary

- use the existing server-rendered Square directory as the crawlable DAO-link authority
- remove the duplicate arbitrary first-six DAO navigation and request-time freshness claim
- retain accurate source/count context and WebSite/CollectionPage identity without an unsupported ItemList
- add deterministic rendered-response coverage for successful and failed upstream directory reads

## UI impact

No redesign. Visible changes are limited to removing the redundant representative-link row and inaccurate `Last server read` line.

## Verification

- content provenance and rendered-response checks
- structured-data, analytics, private-route, and social-preview checks
- `pnpm exec tsc --noEmit`
- Prettier check
- `pnpm build`
- independent review: no remaining actionable findings
- GitHub commit verification: verified SSH signature

Closes #314
