### PR TITLE
Restore the original Square directory UI

### DIFF
--- a/web/scripts/check-content-provenance.mjs
+++ b/web/scripts/check-content-provenance.mjs
@@ -11,17 +11,13 @@ const assertContains = (source, expected, label) => {
 };
 
 assertContains(pageSource, 'const canonicalUrl = SQUARE_CANONICAL_URL;', 'Square canonical');
-assertContains(pageSource, '<h1', 'Square homepage');
-assertContains(pageSource, 'DeGov Square DAO Directory', 'Square H1 text');
-assertContains(pageSource, 'Square indexes public DAO governance sites', 'Directory description');
-assertContains(pageSource, 'DeGov public DAO registry', 'Directory provenance label');
 assertContains(
   pageSource,
-  "const directorySourceUrl = 'https://github.com/ringecosystem/degov-registry';",
-  'Directory provenance URL'
+  'const initialDirectory = await getPublicDaoDirectory();',
+  'Server DAO directory load'
 );
-assertContains(pageSource, 'initialLoadFailed={initialDirectory.failed}', 'Client retry state');
 assertContains(pageSource, 'initialDaoData={initialDirectory.daos}', 'Initial directory data');
+assertContains(pageSource, 'buildSquareDirectoryStructuredData()', 'Identity-only structured data');
 
 assert.ok(
   !pageSource.includes('Last server read:') && !pageSource.includes('new Date()'),
@@ -32,6 +28,15 @@ assert.ok(
     !pageSource.includes('Representative public DAOs') &&
     !pageSource.includes('.slice(0, 6)'),
   'page must not emit a duplicate arbitrary representative DAO navigation'
+);
+assert.ok(
+  !pageSource.includes('<section') &&
+    !pageSource.includes('Square indexes public DAO governance sites') &&
+    !pageSource.includes('DeGov public DAO registry') &&
+    !pageSource.includes('directorySourceUrl') &&
+    !pageSource.includes('directoryCountText') &&
+    !pageSource.includes('initialLoadFailed'),
+  'page must not render visible SEO/provenance content'
 );
 
 const homeClientSource = readFileSync(join(webRoot, 'src/app/_components/home-client.tsx'), 'utf8');
@@ -56,5 +61,11 @@ assertContains(
 assertContains(homeClientSource, 'href={value?.website}', 'Desktop DAO links');
 assertContains(daoListSource, '<DaoItem {...v} key={v.id}', 'Mobile DAO item render');
 assertContains(daoItemSource, 'href={website}', 'Mobile DAO links');
+assert.ok(
+  !homeClientSource.includes('Discover public DAO governance sites') &&
+    !homeClientSource.includes('DAO directory data is temporarily unavailable') &&
+    !homeClientSource.includes('initialLoadFailed'),
+  'HomeClient header must only show the DAO count before controls'
+);
 
 console.log('Verified Square content provenance contract.');

--- a/web/scripts/check-rendered-content-provenance.mjs
+++ b/web/scripts/check-rendered-content-provenance.mjs
@@ -90,13 +90,20 @@ try {
   const successHtml = await fetchRenderedHome();
   assert.match(successHtml, /Fixture Governance DAO/);
   assert.match(successHtml, /href="https:\/\/fixture\.degov\.ai\/"/);
-  assert.doesNotMatch(successHtml, /Representative public DAOs|Last server read:|ItemList/);
+  assert.match(successHtml, /All DAOs/);
+  assert.doesNotMatch(
+    successHtml,
+    /Representative public DAOs|Last server read:|ItemList|Square indexes public DAO governance sites|DeGov public DAO registry|Directory count:/
+  );
 
   fixtureFails = true;
   const failureHtml = await fetchRenderedHome();
-  assert.match(failureHtml, /temporarily unavailable in server HTML/);
-  assert.match(failureHtml, /DAO directory data is temporarily unavailable/);
+  assert.match(failureHtml, /All DAOs/);
   assert.doesNotMatch(failureHtml, /Fixture Governance DAO|href="https:\/\/fixture\.degov\.ai\/"/);
+  assert.doesNotMatch(
+    failureHtml,
+    /temporarily unavailable in server HTML|DAO directory data is temporarily unavailable|Representative DAO links are temporarily unavailable|Directory count:/
+  );
 
   console.log('Verified rendered Square content provenance contract.');
 } finally {

--- a/web/src/app/_components/home-client.tsx
+++ b/web/src/app/_components/home-client.tsx
@@ -22,10 +22,9 @@ type SortState = 'asc' | 'desc';
 
 interface HomeClientProps {
   initialDaoData: DaoInfo[];
-  initialLoadFailed: boolean;
 }
 
-export function HomeClient({ initialDaoData, initialLoadFailed }: HomeClientProps) {
+export function HomeClient({ initialDaoData }: HomeClientProps) {
   const { daoData, isLoading } = useGraphqlDaoData();
   const { isMiniApp, markReady } = useMiniApp();
   const readySentRef = useRef(false);
@@ -227,7 +226,7 @@ export function HomeClient({ initialDaoData, initialLoadFailed }: HomeClientProp
   return (
     <div className="container flex flex-col gap-[20px]">
       <div className="flex items-center justify-between">
-        <div className="flex flex-col gap-[4px]">
+        <div className="flex items-center gap-[10px]">
           <span className="text-[18px] font-semibold">
             All DAOs({filteredAndSortedData.length}
             {(searchQuery || selectedNetwork) &&
@@ -236,15 +235,6 @@ export function HomeClient({ initialDaoData, initialLoadFailed }: HomeClientProp
               )}
             )
           </span>
-          <span className="text-muted-foreground text-[14px]">
-            Discover public DAO governance sites, networks, and proposal activity.
-          </span>
-          {initialLoadFailed && filteredAndSortedData.length === 0 ? (
-            <span className="text-muted-foreground text-[14px]">
-              DAO directory data is temporarily unavailable. The interactive directory will retry in
-              the browser.
-            </span>
-          ) : null}
         </div>
         <div className="flex items-center gap-[20px]">
           <div className="bg-card flex h-[36px] w-[109px] items-center gap-[13px] rounded-[19px] border px-[17px] py-[9px] md:h-auto md:w-[388px] md:gap-[10px]">

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -6,7 +6,6 @@ import {
   SQUARE_CANONICAL_URL
 } from '@/lib/square-structured-data';
 
-import Link from 'next/link';
 import type { Metadata } from 'next';
 
 const title = 'DeGov Square DAO Directory';
@@ -15,7 +14,6 @@ const description =
 const canonicalUrl = SQUARE_CANONICAL_URL;
 const shareImageUrl = 'https://degov.ai/images/degov-social-card.png';
 const shareImageAlt = 'DeGov Square DAO Directory — discover public DAO governance.';
-const directorySourceUrl = 'https://github.com/ringecosystem/degov-registry';
 
 export const metadata: Metadata = {
   title,
@@ -56,52 +54,17 @@ export const dynamic = 'force-dynamic';
 
 export default async function Home() {
   const initialDirectory = await getPublicDaoDirectory();
-  const directoryCountText = initialDirectory.failed
-    ? 'temporarily unavailable in server HTML'
-    : `${initialDirectory.daos.length} public DAOs`;
   const directoryStructuredData = buildSquareDirectoryStructuredData();
 
   return (
-    <main>
-      <section className="container flex flex-col gap-[12px] pt-[8px] pb-[24px] md:pb-[32px]">
-        <div className="flex flex-col gap-[8px]">
-          <h1 className="text-[28px] leading-[1.15] font-semibold md:text-[40px]">
-            DeGov Square DAO Directory
-          </h1>
-          <p className="text-muted-foreground max-w-[760px] text-[15px] leading-[1.6] md:text-[16px]">
-            Square indexes public DAO governance sites, supported networks, and proposal activity
-            from DeGov registry-backed directory data.
-          </p>
-        </div>
-        <div className="text-muted-foreground flex flex-col gap-[8px] text-[14px] leading-[1.6] md:flex-row md:flex-wrap md:gap-x-[24px]">
-          <p>
-            Directory count:{' '}
-            <strong className="text-foreground font-medium">{directoryCountText}</strong>.
-          </p>
-          <p>
-            Source:{' '}
-            <Link
-              href={directorySourceUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-foreground underline underline-offset-4"
-            >
-              DeGov public DAO registry
-            </Link>
-            .
-          </p>
-        </div>
-      </section>
+    <>
       <script
         id="square-directory-structured-data"
         type="application/ld+json"
         suppressHydrationWarning
         dangerouslySetInnerHTML={{ __html: serializeJsonLd(directoryStructuredData) }}
       />
-      <HomeClient
-        initialDaoData={initialDirectory.daos}
-        initialLoadFailed={initialDirectory.failed}
-      />
-    </main>
+      <HomeClient initialDaoData={initialDirectory.daos} />
+    </>
   );
 }


### PR DESCRIPTION
## Summary

- remove the visible SEO/provenance block that shifted the Square directory UI
- preserve server-rendered DAO data, metadata, canonical/social tags, and identity JSON-LD
- keep the original `All DAOs` header and directory controls unchanged

## Verification

- `pnpm test:content-provenance`
- `pnpm test:structured-data`
- `pnpm test:rendered-content-provenance`
- `pnpm test:private-route-indexing`
- `pnpm test:social-preview`
- `pnpm test:dao-discovery-analytics`
- `pnpm build`
- local production screenshot confirmed the page starts at `All DAOs` without the added SEO block
