### PR TITLE
feat(api): add proposal execution simulation

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -62,9 +62,12 @@ jobs:
 
       - uses: taiki-e/install-action@just
 
+      - name: Check Test
+        working-directory: backend
+        run: |
+          just test
+
       - name: Check Build
         working-directory: backend
         run: |
-          just generate
-          just deps
           just build

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -54,6 +54,18 @@ JWT_SECRET=your_jwt_secret
 # MCP_PROPOSAL_SUMMARY_GENERATE_ENABLED=false
 # MCP_PROPOSAL_SUMMARY_TIMEOUT=30s
 
+# Proposal execution simulation
+# DAOs must also include the `proposal-simulation` feature in the registry.
+# Tenderly credentials remain server-only; rich simulation is restricted to this explicit chain allowlist.
+# SIMULATION_TENDERLY_ACCOUNT=
+# SIMULATION_TENDERLY_PROJECT=
+# SIMULATION_TENDERLY_ACCESS_KEY=
+# SIMULATION_TENDERLY_CHAIN_IDS=1,10,137,42161
+# Allow native eth_call-only simulation when Tenderly is unavailable or the chain is not allowlisted.
+# SIMULATION_NATIVE_RPC_FALLBACK=false
+# SIMULATION_TIMEOUT=15s
+# SIMULATION_RATE_LIMIT_PER_MINUTE=10
+
 # # Background Task Configuration
 # # DAO Sync Task
 # TASK_DAO_SYNC_ENABLED=true

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -160,10 +160,13 @@ func startServer() {
 
 	// Create DAO route handler
 	daoRoute := routes.NewDaoRoute()
+	proposalSimulationRoute := routes.NewProposalSimulationRoute()
 
 	// Support both patterns: /dao/config and /dao/config/{dao}
 	mux.Handle("/dao/config", middlewareChain.Then(http.HandlerFunc(daoRoute.ConfigHandler)))
 	mux.Handle("/dao/config/{dao}", middlewareChain.Then(http.HandlerFunc(daoRoute.ConfigHandler)))
+	mux.Handle("GET /api/v1/daos/{daoCode}/proposal-simulation/capability", middlewareChain.Then(http.HandlerFunc(proposalSimulationRoute.CapabilityHandler)))
+	mux.Handle("POST /api/v1/daos/{daoCode}/proposals/{proposalId}/simulation", middlewareChain.Then(http.HandlerFunc(proposalSimulationRoute.SimulationHandler)))
 
 	registerStytchOAuthRoutes(mux, middlewareChain, cfg, nil)
 

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -126,6 +126,11 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("MCP_PROPOSAL_SUMMARY_GENERATE_ENABLED", false)
 	v.SetDefault("MCP_PROPOSAL_SUMMARY_TIMEOUT", "30s")
 
+	// Proposal execution simulation defaults
+	v.SetDefault("SIMULATION_NATIVE_RPC_FALLBACK", false)
+	v.SetDefault("SIMULATION_TIMEOUT", "15s")
+	v.SetDefault("SIMULATION_RATE_LIMIT_PER_MINUTE", 10)
+
 	// Task defaults
 	v.SetDefault("TASK_DAO_SYNC_ENABLED", true)
 	v.SetDefault("TASK_DAO_SYNC_INTERVAL", "5m")

--- a/backend/routes/proposal_simulation.go
+++ b/backend/routes/proposal_simulation.go
@@ -1,0 +1,178 @@
+package routes
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ringecosystem/degov-square/internal/config"
+	"github.com/ringecosystem/degov-square/services"
+)
+
+const maxProposalSimulationBody = 512 << 10
+
+type ProposalSimulationRoute struct {
+	service *services.ProposalSimulationService
+	timeout time.Duration
+	limiter *proposalSimulationLimiter
+	slots   chan struct{}
+}
+
+type proposalSimulationLimit struct {
+	window time.Time
+	count  int
+}
+
+type proposalSimulationLimiter struct {
+	mu     sync.Mutex
+	limit  int
+	counts map[string]proposalSimulationLimit
+}
+
+func NewProposalSimulationRoute() *ProposalSimulationRoute {
+	cfg := config.GetConfig()
+	timeout := cfg.GetDuration("SIMULATION_TIMEOUT")
+	if timeout <= 0 {
+		timeout = 15 * time.Second
+	}
+	limit := cfg.GetInt("SIMULATION_RATE_LIMIT_PER_MINUTE")
+	if limit <= 0 {
+		limit = 10
+	}
+	return &ProposalSimulationRoute{
+		service: services.NewProposalSimulationService(),
+		timeout: timeout,
+		limiter: &proposalSimulationLimiter{limit: limit, counts: make(map[string]proposalSimulationLimit)},
+		slots:   make(chan struct{}, 4),
+	}
+}
+
+func (route *ProposalSimulationRoute) CapabilityHandler(w http.ResponseWriter, request *http.Request) {
+	capability, err := route.service.Capability(request.Context(), request.PathValue("daoCode"))
+	if err != nil {
+		writeProposalSimulationError(w, http.StatusInternalServerError, "internal_error")
+		return
+	}
+	writeProposalSimulationJSON(w, http.StatusOK, capability)
+}
+
+func (route *ProposalSimulationRoute) SimulationHandler(w http.ResponseWriter, request *http.Request) {
+	daoCode := request.PathValue("daoCode")
+	if !route.limiter.Allow(proposalSimulationClientIP(request), daoCode, time.Now().UTC()) {
+		writeProposalSimulationError(w, http.StatusTooManyRequests, "rate_limited")
+		return
+	}
+	select {
+	case route.slots <- struct{}{}:
+		defer func() { <-route.slots }()
+	default:
+		writeProposalSimulationError(w, http.StatusServiceUnavailable, "simulation_busy")
+		return
+	}
+
+	request.Body = http.MaxBytesReader(w, request.Body, maxProposalSimulationBody)
+	decoder := json.NewDecoder(request.Body)
+	decoder.DisallowUnknownFields()
+	var input services.ProposalSimulationRequest
+	if err := decoder.Decode(&input); err != nil {
+		writeProposalSimulationError(w, http.StatusBadRequest, "invalid_request")
+		return
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		writeProposalSimulationError(w, http.StatusBadRequest, "invalid_request")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(request.Context(), route.timeout)
+	defer cancel()
+	result, err := route.service.Simulate(ctx, daoCode, request.PathValue("proposalId"), input)
+	if err != nil {
+		writeProposalSimulationServiceError(w, err)
+		return
+	}
+	writeProposalSimulationJSON(w, http.StatusOK, result)
+}
+
+func (limiter *proposalSimulationLimiter) Allow(ip, daoCode string, now time.Time) bool {
+	limiter.mu.Lock()
+	defer limiter.mu.Unlock()
+
+	window := now.Truncate(time.Minute)
+	keys := []string{"ip:" + ip, "dao:" + daoCode}
+	for _, key := range keys {
+		entry := limiter.counts[key]
+		if entry.window.Equal(window) && entry.count >= limiter.limit {
+			return false
+		}
+	}
+	for _, key := range keys {
+		entry := limiter.counts[key]
+		if !entry.window.Equal(window) {
+			entry = proposalSimulationLimit{window: window}
+		}
+		entry.count++
+		limiter.counts[key] = entry
+	}
+	if len(limiter.counts) > 1000 {
+		for key, entry := range limiter.counts {
+			if entry.window.Before(window) {
+				delete(limiter.counts, key)
+			}
+		}
+	}
+	return true
+}
+
+func proposalSimulationClientIP(request *http.Request) string {
+	if value := strings.TrimSpace(request.Header.Get("X-Real-IP")); value != "" {
+		return value
+	}
+	if value := strings.TrimSpace(strings.Split(request.Header.Get("X-Forwarded-For"), ",")[0]); value != "" {
+		return value
+	}
+	host, _, err := net.SplitHostPort(request.RemoteAddr)
+	if err == nil {
+		return host
+	}
+	return request.RemoteAddr
+}
+
+func writeProposalSimulationServiceError(w http.ResponseWriter, err error) {
+	var simulationErr *services.ProposalSimulationError
+	if !errors.As(err, &simulationErr) {
+		writeProposalSimulationError(w, http.StatusInternalServerError, "internal_error")
+		return
+	}
+
+	status := http.StatusBadGateway
+	switch simulationErr.Code {
+	case "invalid_request":
+		status = http.StatusBadRequest
+	case "proposal_mismatch":
+		status = http.StatusUnprocessableEntity
+	case "simulation_disabled":
+		status = http.StatusConflict
+	case "provider_rate_limited":
+		status = http.StatusTooManyRequests
+	case "provider_timeout":
+		status = http.StatusGatewayTimeout
+	}
+	writeProposalSimulationError(w, status, simulationErr.Code)
+}
+
+func writeProposalSimulationError(w http.ResponseWriter, status int, code string) {
+	writeProposalSimulationJSON(w, status, map[string]string{"error": code})
+}
+
+func writeProposalSimulationJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(value)
+}

--- a/backend/routes/proposal_simulation.go
+++ b/backend/routes/proposal_simulation.go
@@ -130,17 +130,25 @@ func (limiter *proposalSimulationLimiter) Allow(ip, daoCode string, now time.Tim
 }
 
 func proposalSimulationClientIP(request *http.Request) string {
-	if value := strings.TrimSpace(request.Header.Get("X-Real-IP")); value != "" {
-		return value
-	}
-	if value := strings.TrimSpace(strings.Split(request.Header.Get("X-Forwarded-For"), ",")[0]); value != "" {
-		return value
-	}
 	host, _, err := net.SplitHostPort(request.RemoteAddr)
-	if err == nil {
-		return host
+	if err != nil {
+		host = request.RemoteAddr
 	}
-	return request.RemoteAddr
+	directIP := net.ParseIP(strings.TrimSpace(host))
+	if directIP == nil {
+		return request.RemoteAddr
+	}
+	if directIP.IsPrivate() || directIP.IsLoopback() {
+		for _, value := range []string{
+			request.Header.Get("X-Real-IP"),
+			strings.Split(request.Header.Get("X-Forwarded-For"), ",")[0],
+		} {
+			if forwardedIP := net.ParseIP(strings.TrimSpace(value)); forwardedIP != nil {
+				return forwardedIP.String()
+			}
+		}
+	}
+	return directIP.String()
 }
 
 func writeProposalSimulationServiceError(w http.ResponseWriter, err error) {

--- a/backend/routes/proposal_simulation_test.go
+++ b/backend/routes/proposal_simulation_test.go
@@ -42,3 +42,25 @@ func TestProposalSimulationHandlerRejectsWhenConcurrencyIsFull(t *testing.T) {
 		t.Fatalf("busy response = %d %s", recorder.Code, recorder.Body.String())
 	}
 }
+
+func TestProposalSimulationClientIPTrustsOnlyPrivateProxy(t *testing.T) {
+	publicRequest := httptest.NewRequest(http.MethodPost, "/", nil)
+	publicRequest.RemoteAddr = "203.0.113.10:1234"
+	publicRequest.Header.Set("X-Real-IP", "198.51.100.20")
+	if got := proposalSimulationClientIP(publicRequest); got != "203.0.113.10" {
+		t.Fatalf("public direct client IP = %q", got)
+	}
+
+	proxyRequest := httptest.NewRequest(http.MethodPost, "/", nil)
+	proxyRequest.RemoteAddr = "10.0.0.2:1234"
+	proxyRequest.Header.Set("X-Forwarded-For", "198.51.100.20, 10.0.0.2")
+	if got := proposalSimulationClientIP(proxyRequest); got != "198.51.100.20" {
+		t.Fatalf("trusted proxy client IP = %q", got)
+	}
+
+	proxyRequest.Header.Set("X-Real-IP", "not-an-ip")
+	proxyRequest.Header.Set("X-Forwarded-For", "also-invalid")
+	if got := proposalSimulationClientIP(proxyRequest); got != "10.0.0.2" {
+		t.Fatalf("invalid forwarded client IP = %q", got)
+	}
+}

--- a/backend/routes/proposal_simulation_test.go
+++ b/backend/routes/proposal_simulation_test.go
@@ -1,0 +1,44 @@
+package routes
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestProposalSimulationLimiterAppliesPerIPAndDAO(t *testing.T) {
+	limiter := &proposalSimulationLimiter{limit: 2, counts: make(map[string]proposalSimulationLimit)}
+	now := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+	if !limiter.Allow("192.0.2.1", "demo", now) || !limiter.Allow("192.0.2.1", "demo", now) {
+		t.Fatal("first two requests should be allowed")
+	}
+	if limiter.Allow("192.0.2.1", "other", now) {
+		t.Fatal("per-IP limit should reject another DAO")
+	}
+	if limiter.Allow("192.0.2.2", "demo", now) {
+		t.Fatal("per-DAO limit should reject another IP")
+	}
+	if !limiter.Allow("192.0.2.1", "demo", now.Add(time.Minute)) {
+		t.Fatal("next window should be allowed")
+	}
+}
+
+func TestProposalSimulationHandlerRejectsWhenConcurrencyIsFull(t *testing.T) {
+	route := &ProposalSimulationRoute{
+		timeout: time.Second,
+		limiter: &proposalSimulationLimiter{limit: 10, counts: make(map[string]proposalSimulationLimit)},
+		slots:   make(chan struct{}, 1),
+	}
+	route.slots <- struct{}{}
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/daos/demo/proposals/1/simulation", strings.NewReader(`{}`))
+	request.SetPathValue("daoCode", "demo")
+	recorder := httptest.NewRecorder()
+
+	route.SimulationHandler(recorder, request)
+
+	if recorder.Code != http.StatusServiceUnavailable || !strings.Contains(recorder.Body.String(), "simulation_busy") {
+		t.Fatalf("busy response = %d %s", recorder.Code, recorder.Body.String())
+	}
+}

--- a/backend/services/dao.go
+++ b/backend/services/dao.go
@@ -3,6 +3,7 @@ package services
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"regexp"
 	"strings"
@@ -96,7 +97,7 @@ func (s *DaoService) HasFeature(code, feature string) (bool, error) {
 
 	var features []string
 	if err := json.Unmarshal([]byte(dao.Features), &features); err != nil {
-		return false, nil
+		return false, fmt.Errorf("decode DAO features: %w", err)
 	}
 	for _, candidate := range features {
 		if candidate == feature {

--- a/backend/services/dao.go
+++ b/backend/services/dao.go
@@ -87,6 +87,25 @@ func (s *DaoService) GetByCode(code string) (*gqlmodels.Dao, error) {
 	return s.convertToGqlDao(dbDao), nil
 }
 
+// HasFeature reports whether a DAO explicitly enables a feature.
+func (s *DaoService) HasFeature(code, feature string) (bool, error) {
+	var dao dbmodels.Dao
+	if err := s.db.Select("features").Where("code = ?", code).First(&dao).Error; err != nil {
+		return false, err
+	}
+
+	var features []string
+	if err := json.Unmarshal([]byte(dao.Features), &features); err != nil {
+		return false, nil
+	}
+	for _, candidate := range features {
+		if candidate == feature {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // ListDAOCodesWithFeature returns DAO codes that have a specific feature enabled
 // Features are stored as JSON array in the database, e.g., ["fulfill", "notify"]
 func (s *DaoService) ListDAOCodesWithFeature(feature string) ([]string, error) {

--- a/backend/services/proposal_simulation.go
+++ b/backend/services/proposal_simulation.go
@@ -1,0 +1,582 @@
+package services
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/patrickmn/go-cache"
+	"github.com/ringecosystem/degov-square/database"
+	"github.com/ringecosystem/degov-square/internal/config"
+	"github.com/ringecosystem/degov-square/types"
+	"gorm.io/gorm"
+)
+
+const (
+	proposalSimulationFeature = "proposal-simulation"
+	maxSimulationActions      = 50
+	maxSimulationCalldata     = 256 << 10
+	tenderlySimulationURL     = "https://api.tenderly.co/api/v1/account/%s/project/%s/simulate"
+	xAccountWarning           = "Source-chain dispatch simulated; destination-chain execution was not simulated."
+	snapshotWarning           = "Simulation uses a pinned snapshot and cannot guarantee later execution."
+)
+
+const governorSimulationABIJSON = `[
+  {"inputs":[{"type":"address[]","name":"targets"},{"type":"uint256[]","name":"values"},{"type":"bytes[]","name":"calldatas"},{"type":"bytes32","name":"descriptionHash"}],"name":"execute","outputs":[{"type":"uint256"}],"stateMutability":"payable","type":"function"},
+  {"inputs":[{"type":"address[]","name":"targets"},{"type":"uint256[]","name":"values"},{"type":"bytes[]","name":"calldatas"},{"type":"bytes32","name":"descriptionHash"}],"name":"hashProposal","outputs":[{"type":"uint256"}],"stateMutability":"pure","type":"function"}
+]`
+
+var governorSimulationABI = func() abi.ABI {
+	parsed, err := abi.JSON(strings.NewReader(governorSimulationABIJSON))
+	if err != nil {
+		panic(err)
+	}
+	return parsed
+}()
+
+var xAccountSelector = crypto.Keccak256([]byte("send(uint256,address,bytes,bytes)"))[:4]
+
+type ProposalSimulationRequest struct {
+	Caller          string   `json:"caller"`
+	Targets         []string `json:"targets"`
+	Values          []string `json:"values"`
+	Calldatas       []string `json:"calldatas"`
+	DescriptionHash string   `json:"descriptionHash"`
+}
+
+type ProposalSimulationCapability struct {
+	Enabled  bool     `json:"enabled"`
+	Reason   string   `json:"reason,omitempty"`
+	Modes    []string `json:"modes,omitempty"`
+	Fidelity string   `json:"fidelity,omitempty"`
+	Provider string   `json:"provider,omitempty"`
+	ChainID  int      `json:"chainId,omitempty"`
+}
+
+type ProposalSimulationRevert struct {
+	Reason string `json:"reason,omitempty"`
+	Data   string `json:"data,omitempty"`
+}
+
+type ProposalSimulationResult struct {
+	Status            string                    `json:"status"`
+	Fidelity          string                    `json:"fidelity"`
+	Provider          string                    `json:"provider"`
+	ChainID           int                       `json:"chainId"`
+	BlockNumber       string                    `json:"blockNumber"`
+	SimulatedAt       time.Time                 `json:"simulatedAt"`
+	Caller            string                    `json:"caller"`
+	Governor          string                    `json:"governor"`
+	GasUsed           string                    `json:"gasUsed,omitempty"`
+	Revert            *ProposalSimulationRevert `json:"revert,omitempty"`
+	Calls             json.RawMessage           `json:"calls,omitempty"`
+	Logs              json.RawMessage           `json:"logs,omitempty"`
+	AssetChanges      json.RawMessage           `json:"assetChanges,omitempty"`
+	StateChanges      json.RawMessage           `json:"stateChanges,omitempty"`
+	Warnings          []string                  `json:"warnings"`
+	ProviderReference string                    `json:"providerReference,omitempty"`
+}
+
+type ProposalSimulationError struct {
+	Code string
+	Err  error
+}
+
+func (e *ProposalSimulationError) Error() string { return e.Code + ": " + e.Err.Error() }
+func (e *ProposalSimulationError) Unwrap() error { return e.Err }
+
+type proposalSimulationConfig struct {
+	NativeFallback  bool
+	TenderlyAccount string
+	TenderlyProject string
+	TenderlyKey     string
+	TenderlyChains  map[int]struct{}
+	TenderlyURL     string
+}
+
+type ProposalSimulationService struct {
+	daoService       *DaoService
+	daoConfigService *DaoConfigService
+	config           proposalSimulationConfig
+	httpClient       *http.Client
+	cache            *cache.Cache
+	now              func() time.Time
+}
+
+type proposalSimulationDAO struct {
+	ChainID  int
+	RPCURL   string
+	Governor common.Address
+}
+
+type validatedSimulationRequest struct {
+	Caller          common.Address
+	Targets         []common.Address
+	Values          []*big.Int
+	Calldatas       [][]byte
+	DescriptionHash [32]byte
+	ExecuteData     []byte
+	HasXAccount     bool
+}
+
+func NewProposalSimulationService() *ProposalSimulationService {
+	cfg := config.GetConfig()
+	return newProposalSimulationService(database.GetDB(), proposalSimulationConfig{
+		NativeFallback:  cfg.GetBool("SIMULATION_NATIVE_RPC_FALLBACK"),
+		TenderlyAccount: strings.TrimSpace(cfg.GetString("SIMULATION_TENDERLY_ACCOUNT")),
+		TenderlyProject: strings.TrimSpace(cfg.GetString("SIMULATION_TENDERLY_PROJECT")),
+		TenderlyKey:     strings.TrimSpace(cfg.GetString("SIMULATION_TENDERLY_ACCESS_KEY")),
+		TenderlyChains:  parseSimulationChainIDs(cfg.GetString("SIMULATION_TENDERLY_CHAIN_IDS")),
+		TenderlyURL:     tenderlySimulationURL,
+	})
+}
+
+func newProposalSimulationService(db *gorm.DB, cfg proposalSimulationConfig) *ProposalSimulationService {
+	return &ProposalSimulationService{
+		daoService:       &DaoService{db: db},
+		daoConfigService: &DaoConfigService{db: db},
+		config:           cfg,
+		httpClient:       &http.Client{},
+		cache:            cache.New(15*time.Second, 30*time.Second),
+		now:              time.Now,
+	}
+}
+
+func parseSimulationChainIDs(value string) map[int]struct{} {
+	chainIDs := make(map[int]struct{})
+	for _, raw := range strings.Split(value, ",") {
+		chainID, err := strconv.Atoi(strings.TrimSpace(raw))
+		if err == nil && chainID > 0 {
+			chainIDs[chainID] = struct{}{}
+		}
+	}
+	return chainIDs
+}
+
+func (s *ProposalSimulationService) Capability(ctx context.Context, daoCode string) (ProposalSimulationCapability, error) {
+	dao, reason, err := s.resolveDAO(ctx, daoCode)
+	if err != nil {
+		return ProposalSimulationCapability{}, err
+	}
+	if reason != "" {
+		return ProposalSimulationCapability{Enabled: false, Reason: reason}, nil
+	}
+
+	capability := ProposalSimulationCapability{Enabled: true, Modes: []string{"execute"}, ChainID: dao.ChainID}
+	if s.tenderlySupports(dao.ChainID) {
+		capability.Fidelity = "rich"
+		capability.Provider = "tenderly"
+	} else {
+		capability.Fidelity = "basic"
+		capability.Provider = "native"
+	}
+	return capability, nil
+}
+
+func (s *ProposalSimulationService) Simulate(ctx context.Context, daoCode, proposalID string, request ProposalSimulationRequest) (*ProposalSimulationResult, error) {
+	dao, reason, err := s.resolveDAO(ctx, daoCode)
+	if err != nil {
+		return nil, err
+	}
+	if reason != "" {
+		return nil, simulationError("simulation_disabled", errors.New(reason))
+	}
+
+	validated, err := validateSimulationRequest(proposalID, request)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := ethclient.DialContext(ctx, dao.RPCURL)
+	if err != nil {
+		return nil, simulationUpstreamError(ctx, err)
+	}
+	defer client.Close()
+
+	blockNumber, err := client.BlockNumber(ctx)
+	if err != nil {
+		return nil, simulationUpstreamError(ctx, err)
+	}
+	cacheKey := simulationCacheKey(daoCode, proposalID, validated, blockNumber)
+	if cached, found := s.cache.Get(cacheKey); found {
+		if result, ok := cached.(*ProposalSimulationResult); ok {
+			return result, nil
+		}
+	}
+
+	result := &ProposalSimulationResult{
+		Status:      "success",
+		Fidelity:    "basic",
+		Provider:    "native",
+		ChainID:     dao.ChainID,
+		BlockNumber: strconv.FormatUint(blockNumber, 10),
+		SimulatedAt: s.now().UTC(),
+		Caller:      validated.Caller.Hex(),
+		Governor:    dao.Governor.Hex(),
+		Warnings:    []string{snapshotWarning},
+	}
+	if validated.HasXAccount {
+		result.Warnings = append(result.Warnings, xAccountWarning)
+	}
+
+	call := ethereum.CallMsg{From: validated.Caller, To: &dao.Governor, Value: new(big.Int), Data: validated.ExecuteData}
+	if _, err := client.CallContract(ctx, call, new(big.Int).SetUint64(blockNumber)); err != nil {
+		revert, reverted := decodeSimulationRevert(err)
+		if !reverted {
+			return nil, simulationUpstreamError(ctx, err)
+		}
+		result.Status = "reverted"
+		result.Revert = revert
+		result.Warnings = append(result.Warnings, "Native RPC simulation does not include traces or state changes.")
+		s.cache.SetDefault(cacheKey, result)
+		return result, nil
+	}
+
+	if s.tenderlySupports(dao.ChainID) {
+		rich, err := s.simulateTenderly(ctx, dao, validated, blockNumber, result)
+		if err == nil {
+			s.cache.SetDefault(cacheKey, rich)
+			return rich, nil
+		}
+		if !s.config.NativeFallback {
+			return nil, err
+		}
+		result.Warnings = append(result.Warnings,
+			"Rich simulation unavailable; returned native RPC result.",
+			"Native RPC simulation does not include traces or state changes.",
+		)
+	} else {
+		result.Warnings = append(result.Warnings, "Native RPC simulation does not include traces or state changes.")
+	}
+
+	s.cache.SetDefault(cacheKey, result)
+	return result, nil
+}
+
+func (s *ProposalSimulationService) resolveDAO(_ context.Context, daoCode string) (*proposalSimulationDAO, string, error) {
+	daoCode = strings.TrimSpace(daoCode)
+	enabled, err := s.daoService.HasFeature(daoCode, proposalSimulationFeature)
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, "dao_not_found", nil
+	}
+	if err != nil {
+		return nil, "", err
+	}
+	if !enabled {
+		return nil, "dao_feature_disabled", nil
+	}
+
+	daoConfig, err := s.daoConfigService.StandardConfig(daoCode)
+	if err != nil {
+		return nil, "dao_config_unavailable", nil
+	}
+	rpcURL := firstSimulationRPC(daoConfig)
+	if daoConfig.Chain.ID <= 0 || !common.IsHexAddress(daoConfig.Contracts.Governor) || rpcURL == "" {
+		return nil, "dao_config_incomplete", nil
+	}
+	if !s.tenderlySupports(daoConfig.Chain.ID) && !s.config.NativeFallback {
+		return nil, "provider_unavailable", nil
+	}
+
+	return &proposalSimulationDAO{
+		ChainID:  daoConfig.Chain.ID,
+		RPCURL:   rpcURL,
+		Governor: common.HexToAddress(daoConfig.Contracts.Governor),
+	}, "", nil
+}
+
+func firstSimulationRPC(daoConfig *types.DaoConfig) string {
+	for _, candidate := range daoConfig.Chain.RPCs {
+		parsed, err := url.Parse(strings.TrimSpace(candidate))
+		if err == nil && (parsed.Scheme == "http" || parsed.Scheme == "https") && parsed.Host != "" {
+			return parsed.String()
+		}
+	}
+	return ""
+}
+
+func (s *ProposalSimulationService) tenderlySupports(chainID int) bool {
+	if s.config.TenderlyAccount == "" || s.config.TenderlyProject == "" || s.config.TenderlyKey == "" {
+		return false
+	}
+	_, ok := s.config.TenderlyChains[chainID]
+	return ok
+}
+
+func validateSimulationRequest(proposalID string, request ProposalSimulationRequest) (*validatedSimulationRequest, error) {
+	if !common.IsHexAddress(request.Caller) {
+		return nil, simulationError("invalid_request", errors.New("caller must be an EVM address"))
+	}
+	if len(request.Targets) == 0 || len(request.Targets) > maxSimulationActions {
+		return nil, simulationError("invalid_request", fmt.Errorf("targets must contain 1-%d actions", maxSimulationActions))
+	}
+	if len(request.Targets) != len(request.Values) || len(request.Targets) != len(request.Calldatas) {
+		return nil, simulationError("invalid_request", errors.New("targets, values, and calldatas must have equal lengths"))
+	}
+
+	validated := &validatedSimulationRequest{
+		Caller:    common.HexToAddress(request.Caller),
+		Targets:   make([]common.Address, len(request.Targets)),
+		Values:    make([]*big.Int, len(request.Values)),
+		Calldatas: make([][]byte, len(request.Calldatas)),
+	}
+	totalCalldata := 0
+	for index := range request.Targets {
+		if !common.IsHexAddress(request.Targets[index]) {
+			return nil, simulationError("invalid_request", fmt.Errorf("targets[%d] must be an EVM address", index))
+		}
+		validated.Targets[index] = common.HexToAddress(request.Targets[index])
+
+		value, ok := parseUint256(request.Values[index])
+		if !ok {
+			return nil, simulationError("invalid_request", fmt.Errorf("values[%d] must be an unsigned 256-bit integer", index))
+		}
+		validated.Values[index] = value
+
+		calldata, err := hexutil.Decode(request.Calldatas[index])
+		if err != nil {
+			return nil, simulationError("invalid_request", fmt.Errorf("calldatas[%d] must be 0x-prefixed bytes", index))
+		}
+		totalCalldata += len(calldata)
+		if totalCalldata > maxSimulationCalldata {
+			return nil, simulationError("invalid_request", errors.New("calldata exceeds size limit"))
+		}
+		validated.Calldatas[index] = calldata
+		validated.HasXAccount = validated.HasXAccount || bytes.HasPrefix(calldata, xAccountSelector)
+	}
+
+	descriptionHash, err := hexutil.Decode(request.DescriptionHash)
+	if err != nil || len(descriptionHash) != common.HashLength {
+		return nil, simulationError("invalid_request", errors.New("descriptionHash must be 32 bytes"))
+	}
+	copy(validated.DescriptionHash[:], descriptionHash)
+
+	proposalArguments, err := governorSimulationABI.Methods["hashProposal"].Inputs.Pack(
+		validated.Targets, validated.Values, validated.Calldatas, validated.DescriptionHash,
+	)
+	if err != nil {
+		return nil, simulationError("invalid_request", err)
+	}
+	computedID := new(big.Int).SetBytes(crypto.Keccak256(proposalArguments))
+	wantedID, ok := parseProposalID(proposalID)
+	if !ok {
+		return nil, simulationError("invalid_request", errors.New("proposalId must be an unsigned 256-bit integer"))
+	}
+	if computedID.Cmp(wantedID) != 0 {
+		return nil, simulationError("proposal_mismatch", errors.New("payload does not match proposalId"))
+	}
+
+	validated.ExecuteData, err = governorSimulationABI.Pack(
+		"execute", validated.Targets, validated.Values, validated.Calldatas, validated.DescriptionHash,
+	)
+	if err != nil {
+		return nil, simulationError("invalid_request", err)
+	}
+	return validated, nil
+}
+
+func parseUint256(value string) (*big.Int, bool) {
+	value = strings.TrimSpace(value)
+	base := 10
+	if strings.HasPrefix(value, "0x") || strings.HasPrefix(value, "0X") {
+		base = 16
+		value = value[2:]
+		if len(value) == 0 || len(value) > 64 {
+			return nil, false
+		}
+	} else if len(value) == 0 || len(value) > 78 {
+		return nil, false
+	}
+	parsed, ok := new(big.Int).SetString(value, base)
+	return parsed, ok && parsed.Sign() >= 0 && parsed.BitLen() <= 256
+}
+
+func parseProposalID(value string) (*big.Int, bool) {
+	return parseUint256(value)
+}
+
+func simulationCacheKey(daoCode, proposalID string, request *validatedSimulationRequest, blockNumber uint64) string {
+	payloadHash := sha256.Sum256(request.ExecuteData)
+	return strings.Join([]string{
+		daoCode,
+		proposalID,
+		strings.ToLower(request.Caller.Hex()),
+		strconv.FormatUint(blockNumber, 10),
+		hex.EncodeToString(payloadHash[:]),
+	}, ":")
+}
+
+func decodeSimulationRevert(err error) (*ProposalSimulationRevert, bool) {
+	revert := &ProposalSimulationRevert{}
+	var dataError rpc.DataError
+	if errors.As(err, &dataError) {
+		if data := simulationRevertData(dataError.ErrorData()); data != "" {
+			revert.Data = data
+			if decoded, decodeErr := hexutil.Decode(data); decodeErr == nil {
+				if reason, reasonErr := abi.UnpackRevert(decoded); reasonErr == nil {
+					revert.Reason = reason
+				}
+			}
+		}
+	}
+	lowerMessage := strings.ToLower(err.Error())
+	if revert.Data == "" && !strings.Contains(lowerMessage, "revert") {
+		return nil, false
+	}
+	if revert.Reason == "" {
+		revert.Reason = strings.TrimSpace(strings.TrimPrefix(err.Error(), "execution reverted:"))
+		if len(revert.Reason) > 500 {
+			revert.Reason = revert.Reason[:500]
+		}
+	}
+	return revert, true
+}
+
+func simulationRevertData(value any) string {
+	if data, ok := value.(string); ok && strings.HasPrefix(data, "0x") {
+		return data
+	}
+	if object, ok := value.(map[string]any); ok {
+		for _, key := range []string{"data", "result"} {
+			if data := simulationRevertData(object[key]); data != "" {
+				return data
+			}
+		}
+	}
+	return ""
+}
+
+func (s *ProposalSimulationService) simulateTenderly(
+	ctx context.Context,
+	dao *proposalSimulationDAO,
+	request *validatedSimulationRequest,
+	blockNumber uint64,
+	basic *ProposalSimulationResult,
+) (*ProposalSimulationResult, error) {
+	body, err := json.Marshal(map[string]any{
+		"network_id":      strconv.Itoa(dao.ChainID),
+		"from":            request.Caller.Hex(),
+		"to":              dao.Governor.Hex(),
+		"input":           hexutil.Encode(request.ExecuteData),
+		"value":           "0",
+		"gas":             30_000_000,
+		"block_number":    blockNumber,
+		"save":            false,
+		"save_if_fails":   false,
+		"simulation_type": "full",
+	})
+	if err != nil {
+		return nil, simulationError("provider_unavailable", err)
+	}
+
+	endpoint := fmt.Sprintf(s.config.TenderlyURL, url.PathEscape(s.config.TenderlyAccount), url.PathEscape(s.config.TenderlyProject))
+	httpRequest, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, simulationError("provider_unavailable", err)
+	}
+	httpRequest.Header.Set("Content-Type", "application/json")
+	httpRequest.Header.Set("X-Access-Key", s.config.TenderlyKey)
+
+	response, err := s.httpClient.Do(httpRequest)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return nil, simulationError("provider_timeout", err)
+		}
+		return nil, simulationError("provider_unavailable", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode == http.StatusTooManyRequests {
+		return nil, simulationError("provider_rate_limited", errors.New("tenderly rate limited"))
+	}
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return nil, simulationError("provider_unavailable", fmt.Errorf("tenderly status %d", response.StatusCode))
+	}
+
+	var payload struct {
+		Transaction *struct {
+			Status    *bool           `json:"status"`
+			GasUsed   json.RawMessage `json:"gas_used"`
+			ErrorInfo *struct {
+				Message string `json:"error_message"`
+			} `json:"error_info"`
+			CallTrace *struct {
+				Calls json.RawMessage `json:"calls"`
+			} `json:"call_trace"`
+			TransactionInfo *struct {
+				Logs         json.RawMessage `json:"logs"`
+				AssetChanges json.RawMessage `json:"asset_changes"`
+				StateChanges json.RawMessage `json:"state_diff"`
+			} `json:"transaction_info"`
+		} `json:"transaction"`
+		Simulation *struct {
+			ID string `json:"id"`
+		} `json:"simulation"`
+	}
+	if err := json.NewDecoder(io.LimitReader(response.Body, 2<<20)).Decode(&payload); err != nil || payload.Transaction == nil || payload.Transaction.Status == nil {
+		return nil, simulationError("provider_unavailable", errors.New("invalid tenderly response"))
+	}
+
+	result := *basic
+	result.Fidelity = "rich"
+	result.Provider = "tenderly"
+	result.GasUsed = rawJSONNumber(payload.Transaction.GasUsed)
+	if payload.Transaction.CallTrace != nil {
+		result.Calls = payload.Transaction.CallTrace.Calls
+	}
+	if payload.Transaction.TransactionInfo != nil {
+		result.Logs = payload.Transaction.TransactionInfo.Logs
+		result.AssetChanges = payload.Transaction.TransactionInfo.AssetChanges
+		result.StateChanges = payload.Transaction.TransactionInfo.StateChanges
+	}
+	if payload.Simulation != nil {
+		result.ProviderReference = payload.Simulation.ID
+	}
+	if !*payload.Transaction.Status {
+		result.Status = "reverted"
+		result.Revert = &ProposalSimulationRevert{}
+		if payload.Transaction.ErrorInfo != nil {
+			result.Revert.Reason = payload.Transaction.ErrorInfo.Message
+		}
+	}
+	return &result, nil
+}
+
+func rawJSONNumber(value json.RawMessage) string {
+	if len(value) == 0 || bytes.Equal(value, []byte("null")) {
+		return ""
+	}
+	var text string
+	if value[0] == '"' && json.Unmarshal(value, &text) == nil {
+		return text
+	}
+	return string(value)
+}
+
+func simulationError(code string, err error) error {
+	return &ProposalSimulationError{Code: code, Err: err}
+}
+
+func simulationUpstreamError(ctx context.Context, err error) error {
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return simulationError("provider_timeout", err)
+	}
+	return simulationError("rpc_unavailable", err)
+}

--- a/backend/services/proposal_simulation.go
+++ b/backend/services/proposal_simulation.go
@@ -211,6 +211,14 @@ func (s *ProposalSimulationService) Simulate(ctx context.Context, daoCode, propo
 	}
 	defer client.Close()
 
+	chainID, err := client.ChainID(ctx)
+	if err != nil {
+		return nil, simulationUpstreamError(ctx, err)
+	}
+	if !chainID.IsInt64() || chainID.Int64() != int64(dao.ChainID) {
+		return nil, simulationError("provider_unavailable", fmt.Errorf("RPC chain ID %s does not match DAO chain ID %d", chainID, dao.ChainID))
+	}
+
 	blockNumber, err := client.BlockNumber(ctx)
 	if err != nil {
 		return nil, simulationUpstreamError(ctx, err)
@@ -238,7 +246,8 @@ func (s *ProposalSimulationService) Simulate(ctx context.Context, daoCode, propo
 	}
 
 	call := ethereum.CallMsg{From: validated.Caller, To: &dao.Governor, Value: new(big.Int), Data: validated.ExecuteData}
-	if _, err := client.CallContract(ctx, call, new(big.Int).SetUint64(blockNumber)); err != nil {
+	callResult, err := client.CallContract(ctx, call, new(big.Int).SetUint64(blockNumber))
+	if err != nil {
 		revert, reverted := decodeSimulationRevert(err)
 		if !reverted {
 			return nil, simulationUpstreamError(ctx, err)
@@ -248,6 +257,10 @@ func (s *ProposalSimulationService) Simulate(ctx context.Context, daoCode, propo
 		result.Warnings = append(result.Warnings, "Native RPC simulation does not include traces or state changes.")
 		s.cache.SetDefault(cacheKey, result)
 		return result, nil
+	}
+	outputs, err := governorSimulationABI.Methods["execute"].Outputs.Unpack(callResult)
+	if err != nil || len(outputs) != 1 {
+		return nil, simulationError("provider_unavailable", errors.New("native RPC returned an invalid Governor execute result"))
 	}
 
 	if s.tenderlySupports(dao.ChainID) {
@@ -517,9 +530,7 @@ func (s *ProposalSimulationService) simulateTenderly(
 			ErrorInfo *struct {
 				Message string `json:"error_message"`
 			} `json:"error_info"`
-			CallTrace *struct {
-				Calls json.RawMessage `json:"calls"`
-			} `json:"call_trace"`
+			CallTrace       json.RawMessage `json:"call_trace"`
 			TransactionInfo *struct {
 				Logs         json.RawMessage `json:"logs"`
 				AssetChanges json.RawMessage `json:"asset_changes"`
@@ -538,8 +549,8 @@ func (s *ProposalSimulationService) simulateTenderly(
 	result.Fidelity = "rich"
 	result.Provider = "tenderly"
 	result.GasUsed = rawJSONNumber(payload.Transaction.GasUsed)
-	if payload.Transaction.CallTrace != nil {
-		result.Calls = payload.Transaction.CallTrace.Calls
+	if len(payload.Transaction.CallTrace) > 0 && !bytes.Equal(payload.Transaction.CallTrace, []byte("null")) {
+		result.Calls = payload.Transaction.CallTrace
 	}
 	if payload.Transaction.TransactionInfo != nil {
 		result.Logs = payload.Transaction.TransactionInfo.Logs

--- a/backend/services/proposal_simulation_test.go
+++ b/backend/services/proposal_simulation_test.go
@@ -165,10 +165,14 @@ func TestProposalSimulationRunsNativeBeforeTenderlyAtSameBlockAndCaches(t *testi
 		rpcCalls[payload.Method]++
 		mu.Unlock()
 		result := "0x"
+		if payload.Method == "eth_chainId" {
+			result = "0x1"
+		}
 		if payload.Method == "eth_blockNumber" {
 			result = "0x123"
 		}
 		if payload.Method == "eth_call" {
+			result = "0x" + strings.Repeat("0", 63) + "1"
 			var transaction map[string]any
 			if err := json.Unmarshal(payload.Params[0], &transaction); err != nil {
 				t.Errorf("decode eth_call transaction: %v", err)
@@ -201,7 +205,7 @@ func TestProposalSimulationRunsNativeBeforeTenderlyAtSameBlockAndCaches(t *testi
 			t.Errorf("Tenderly payload = %#v", payload)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"transaction":{"status":true,"gas_used":123,"call_trace":{"calls":[]},"transaction_info":{"logs":[],"asset_changes":[],"state_diff":[]}},"simulation":{"id":"sim-1"}}`))
+		_, _ = w.Write([]byte(`{"transaction":{"status":true,"gas_used":123,"call_trace":[],"transaction_info":{"logs":[],"asset_changes":[],"state_diff":[]}},"simulation":{"id":"sim-1"}}`))
 	}))
 	defer tenderlyServer.Close()
 
@@ -234,6 +238,10 @@ func TestProposalSimulationReturnsNativeRevertWithoutTenderly(t *testing.T) {
 		}
 		_ = json.NewDecoder(request.Body).Decode(&payload)
 		w.Header().Set("Content-Type", "application/json")
+		if payload.Method == "eth_chainId" {
+			fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"result":"0x1"}`, payload.ID)
+			return
+		}
 		if payload.Method == "eth_blockNumber" {
 			fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"result":"0x123"}`, payload.ID)
 			return
@@ -255,6 +263,45 @@ func TestProposalSimulationReturnsNativeRevertWithoutTenderly(t *testing.T) {
 	}
 	if result.Status != "reverted" || result.Fidelity != "basic" || result.Revert == nil || tenderlyCalls != 0 {
 		t.Fatalf("revert result = %#v, tenderly calls = %d", result, tenderlyCalls)
+	}
+}
+
+func TestProposalSimulationRejectsWrongChainAndEmptyExecuteResult(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		chainID    string
+		callResult string
+	}{
+		{name: "wrong chain", chainID: "0x2", callResult: "0x" + strings.Repeat("0", 63) + "1"},
+		{name: "empty execute result", chainID: "0x1", callResult: "0x"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			rpcServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+				var payload struct {
+					ID     json.RawMessage `json:"id"`
+					Method string          `json:"method"`
+				}
+				_ = json.NewDecoder(request.Body).Decode(&payload)
+				result := test.callResult
+				switch payload.Method {
+				case "eth_chainId":
+					result = test.chainID
+				case "eth_blockNumber":
+					result = "0x123"
+				}
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"result":%q}`, payload.ID, result)
+			}))
+			defer rpcServer.Close()
+
+			db := newTestProposalSimulationDB(t, rpcServer.URL, `["proposal-simulation"]`)
+			service := newProposalSimulationService(db, proposalSimulationConfig{NativeFallback: true})
+			_, err := service.Simulate(context.Background(), "demo", testSimulationProposalID, testSimulationRequest())
+			var simulationErr *ProposalSimulationError
+			if !errors.As(err, &simulationErr) || simulationErr.Code != "provider_unavailable" {
+				t.Fatalf("simulation error = %v, want provider_unavailable", err)
+			}
+		})
 	}
 }
 

--- a/backend/services/proposal_simulation_test.go
+++ b/backend/services/proposal_simulation_test.go
@@ -1,0 +1,273 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+const (
+	testSimulationDescriptionHash = "0x1c8aff950685c2ed4bc3174f3472287b56d9517b9c948127319a09a7a36deac8"
+	testSimulationProposalID      = "45104572425689951088238789760954264672210632875420191946694406891418830968826"
+	testSimulationExecuteData     = "0x2656227d000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000001001c8aff950685c2ed4bc3174f3472287b56d9517b9c948127319a09a7a36deac800000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000021234000000000000000000000000000000000000000000000000000000000000"
+)
+
+func testSimulationRequest() ProposalSimulationRequest {
+	return ProposalSimulationRequest{
+		Caller:          "0x0000000000000000000000000000000000000002",
+		Targets:         []string{"0x0000000000000000000000000000000000000001"},
+		Values:          []string{"0"},
+		Calldatas:       []string{"0x1234"},
+		DescriptionHash: testSimulationDescriptionHash,
+	}
+}
+
+func newTestProposalSimulationDB(t *testing.T, rpcURL, features string) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite db: %v", err)
+	}
+	for _, statement := range []string{
+		`CREATE TABLE dgv_dao (id TEXT PRIMARY KEY, code TEXT NOT NULL UNIQUE, features TEXT)`,
+		`CREATE TABLE dgv_dao_config (id TEXT PRIMARY KEY, dao_code TEXT NOT NULL UNIQUE, config TEXT NOT NULL)`,
+	} {
+		if err := db.Exec(statement).Error; err != nil {
+			t.Fatalf("create simulation table: %v", err)
+		}
+	}
+	if err := db.Exec(`INSERT INTO dgv_dao (id, code, features) VALUES (?, ?, ?)`, "dao-1", "demo", features).Error; err != nil {
+		t.Fatalf("seed DAO: %v", err)
+	}
+	configYAML := fmt.Sprintf(`
+code: demo
+chain:
+  id: 1
+  rpcs: [%q]
+contracts:
+  governor: "0x0000000000000000000000000000000000000003"
+`, rpcURL)
+	if err := db.Exec(`INSERT INTO dgv_dao_config (id, dao_code, config) VALUES (?, ?, ?)`, "config-1", "demo", configYAML).Error; err != nil {
+		t.Fatalf("seed DAO config: %v", err)
+	}
+	return db
+}
+
+func TestValidateSimulationRequestMatchesOpenZeppelinVector(t *testing.T) {
+	validated, err := validateSimulationRequest(testSimulationProposalID, testSimulationRequest())
+	if err != nil {
+		t.Fatalf("validateSimulationRequest: %v", err)
+	}
+	if got := hexutil.Encode(validated.ExecuteData); got != testSimulationExecuteData {
+		t.Fatalf("execute calldata = %s, want %s", got, testSimulationExecuteData)
+	}
+
+	_, err = validateSimulationRequest("1", testSimulationRequest())
+	var simulationErr *ProposalSimulationError
+	if !errors.As(err, &simulationErr) || simulationErr.Code != "proposal_mismatch" {
+		t.Fatalf("mismatch error = %v, want proposal_mismatch", err)
+	}
+
+	overlong := testSimulationRequest()
+	overlong.Values[0] = strings.Repeat("9", 79)
+	_, err = validateSimulationRequest(testSimulationProposalID, overlong)
+	if !errors.As(err, &simulationErr) || simulationErr.Code != "invalid_request" {
+		t.Fatalf("overlong value error = %v, want invalid_request", err)
+	}
+}
+
+func TestValidateSimulationRequestDetectsXAccountDispatch(t *testing.T) {
+	request := testSimulationRequest()
+	request.Calldatas[0] = hexutil.Encode(xAccountSelector)
+	arguments, err := governorSimulationABI.Methods["hashProposal"].Inputs.Pack(
+		[]common.Address{common.HexToAddress(request.Targets[0])},
+		[]*big.Int{new(big.Int)},
+		[][]byte{xAccountSelector},
+		common.HexToHash(request.DescriptionHash),
+	)
+	if err != nil {
+		t.Fatalf("pack proposal: %v", err)
+	}
+	proposalID := new(big.Int).SetBytes(crypto.Keccak256(arguments)).String()
+	validated, err := validateSimulationRequest(proposalID, request)
+	if err != nil {
+		t.Fatalf("validateSimulationRequest: %v", err)
+	}
+	if !validated.HasXAccount {
+		t.Fatal("XAccount dispatch was not detected")
+	}
+}
+
+func TestProposalSimulationCapabilityRequiresFeatureAndProvider(t *testing.T) {
+	db := newTestProposalSimulationDB(t, "https://rpc.example", `[]`)
+	service := newProposalSimulationService(db, proposalSimulationConfig{NativeFallback: true})
+
+	capability, err := service.Capability(context.Background(), "missing")
+	if err != nil || capability.Enabled || capability.Reason != "dao_not_found" {
+		t.Fatalf("missing capability = %#v, err %v", capability, err)
+	}
+	capability, err = service.Capability(context.Background(), "demo")
+	if err != nil || capability.Enabled || capability.Reason != "dao_feature_disabled" {
+		t.Fatalf("disabled capability = %#v, err %v", capability, err)
+	}
+
+	if err := db.Exec(`UPDATE dgv_dao SET features = ? WHERE code = ?`, `["proposal-simulation"]`, "demo").Error; err != nil {
+		t.Fatalf("enable feature: %v", err)
+	}
+	service = newProposalSimulationService(db, proposalSimulationConfig{})
+	capability, err = service.Capability(context.Background(), "demo")
+	if err != nil || capability.Enabled || capability.Reason != "provider_unavailable" {
+		t.Fatalf("provider-disabled capability = %#v, err %v", capability, err)
+	}
+
+	service = newProposalSimulationService(db, proposalSimulationConfig{NativeFallback: true})
+	capability, err = service.Capability(context.Background(), "demo")
+	if err != nil || !capability.Enabled || capability.Fidelity != "basic" || capability.Provider != "native" {
+		t.Fatalf("native capability = %#v, err %v", capability, err)
+	}
+
+	service = newProposalSimulationService(db, proposalSimulationConfig{
+		TenderlyAccount: "account", TenderlyProject: "project", TenderlyKey: "secret", TenderlyChains: map[int]struct{}{1: {}},
+	})
+	capability, err = service.Capability(context.Background(), "demo")
+	if err != nil || !capability.Enabled || capability.Fidelity != "rich" || capability.Provider != "tenderly" {
+		t.Fatalf("rich capability = %#v, err %v", capability, err)
+	}
+}
+
+func TestProposalSimulationRunsNativeBeforeTenderlyAtSameBlockAndCaches(t *testing.T) {
+	var mu sync.Mutex
+	rpcCalls := map[string]int{}
+	rpcServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		var payload struct {
+			ID     json.RawMessage   `json:"id"`
+			Method string            `json:"method"`
+			Params []json.RawMessage `json:"params"`
+		}
+		if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
+			t.Errorf("decode RPC request: %v", err)
+			return
+		}
+		mu.Lock()
+		rpcCalls[payload.Method]++
+		mu.Unlock()
+		result := "0x"
+		if payload.Method == "eth_blockNumber" {
+			result = "0x123"
+		}
+		if payload.Method == "eth_call" {
+			var transaction map[string]any
+			if err := json.Unmarshal(payload.Params[0], &transaction); err != nil {
+				t.Errorf("decode eth_call transaction: %v", err)
+			}
+			if transaction["to"] != "0x0000000000000000000000000000000000000003" || transaction["value"] != "0x0" || transaction["input"] != testSimulationExecuteData {
+				t.Errorf("eth_call transaction = %#v", transaction)
+			}
+			var block string
+			_ = json.Unmarshal(payload.Params[1], &block)
+			if block != "0x123" {
+				t.Errorf("eth_call block = %q, want 0x123", block)
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"result":%q}`, payload.ID, result)
+	}))
+	defer rpcServer.Close()
+
+	tenderlyCalls := 0
+	tenderlyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		tenderlyCalls++
+		if request.Header.Get("X-Access-Key") != "secret" {
+			t.Errorf("Tenderly access key not sent")
+		}
+		var payload map[string]any
+		if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
+			t.Errorf("decode Tenderly request: %v", err)
+		}
+		if payload["block_number"] != float64(0x123) || payload["value"] != "0" || payload["input"] != testSimulationExecuteData {
+			t.Errorf("Tenderly payload = %#v", payload)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"transaction":{"status":true,"gas_used":123,"call_trace":{"calls":[]},"transaction_info":{"logs":[],"asset_changes":[],"state_diff":[]}},"simulation":{"id":"sim-1"}}`))
+	}))
+	defer tenderlyServer.Close()
+
+	db := newTestProposalSimulationDB(t, rpcServer.URL, `["proposal-simulation"]`)
+	service := newProposalSimulationService(db, proposalSimulationConfig{
+		NativeFallback: true, TenderlyAccount: "account", TenderlyProject: "project", TenderlyKey: "secret",
+		TenderlyChains: map[int]struct{}{1: {}}, TenderlyURL: tenderlyServer.URL + "/account/%s/project/%s/simulate",
+	})
+
+	for range 2 {
+		result, err := service.Simulate(context.Background(), "demo", testSimulationProposalID, testSimulationRequest())
+		if err != nil {
+			t.Fatalf("Simulate: %v", err)
+		}
+		if result.Status != "success" || result.Fidelity != "rich" || result.Provider != "tenderly" || result.BlockNumber != "291" || result.GasUsed != "123" || result.ProviderReference != "sim-1" {
+			t.Fatalf("simulation result = %#v", result)
+		}
+	}
+	if rpcCalls["eth_call"] != 1 || tenderlyCalls != 1 {
+		t.Fatalf("cached calls: eth_call=%d tenderly=%d, want 1 each", rpcCalls["eth_call"], tenderlyCalls)
+	}
+}
+
+func TestProposalSimulationReturnsNativeRevertWithoutTenderly(t *testing.T) {
+	tenderlyCalls := 0
+	rpcServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		var payload struct {
+			ID     json.RawMessage `json:"id"`
+			Method string          `json:"method"`
+		}
+		_ = json.NewDecoder(request.Body).Decode(&payload)
+		w.Header().Set("Content-Type", "application/json")
+		if payload.Method == "eth_blockNumber" {
+			fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"result":"0x123"}`, payload.ID)
+			return
+		}
+		fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"error":{"code":3,"message":"execution reverted: denied","data":{"data":"0x08c379a0"}}}`, payload.ID)
+	}))
+	defer rpcServer.Close()
+	tenderlyServer := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { tenderlyCalls++ }))
+	defer tenderlyServer.Close()
+
+	db := newTestProposalSimulationDB(t, rpcServer.URL, `["proposal-simulation"]`)
+	service := newProposalSimulationService(db, proposalSimulationConfig{
+		NativeFallback: true, TenderlyAccount: "account", TenderlyProject: "project", TenderlyKey: "secret",
+		TenderlyChains: map[int]struct{}{1: {}}, TenderlyURL: tenderlyServer.URL + "/%s/%s",
+	})
+	result, err := service.Simulate(context.Background(), "demo", testSimulationProposalID, testSimulationRequest())
+	if err != nil {
+		t.Fatalf("Simulate: %v", err)
+	}
+	if result.Status != "reverted" || result.Fidelity != "basic" || result.Revert == nil || tenderlyCalls != 0 {
+		t.Fatalf("revert result = %#v, tenderly calls = %d", result, tenderlyCalls)
+	}
+}
+
+func TestProposalMismatchDoesNotCallRPC(t *testing.T) {
+	rpcCalls := 0
+	rpcServer := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { rpcCalls++ }))
+	defer rpcServer.Close()
+	db := newTestProposalSimulationDB(t, rpcServer.URL, `["proposal-simulation"]`)
+	service := newProposalSimulationService(db, proposalSimulationConfig{NativeFallback: true})
+
+	_, err := service.Simulate(context.Background(), "demo", "1", testSimulationRequest())
+	var simulationErr *ProposalSimulationError
+	if !errors.As(err, &simulationErr) || simulationErr.Code != "proposal_mismatch" || rpcCalls != 0 {
+		t.Fatalf("mismatch err = %v, RPC calls = %d", err, rpcCalls)
+	}
+}

--- a/backend/services/proposal_simulation_test.go
+++ b/backend/services/proposal_simulation_test.go
@@ -148,6 +148,15 @@ func TestProposalSimulationCapabilityRequiresFeatureAndProvider(t *testing.T) {
 	}
 }
 
+func TestProposalSimulationCapabilityRejectsMalformedFeatures(t *testing.T) {
+	db := newTestProposalSimulationDB(t, "https://rpc.example", `not-json`)
+	service := newProposalSimulationService(db, proposalSimulationConfig{NativeFallback: true})
+
+	if _, err := service.Capability(context.Background(), "demo"); err == nil {
+		t.Fatal("malformed DAO features should return an error")
+	}
+}
+
 func TestProposalSimulationRunsNativeBeforeTenderlyAtSameBlockAndCaches(t *testing.T) {
 	var mu sync.Mutex
 	rpcCalls := map[string]int{}


### PR DESCRIPTION
## Summary

- add feature-gated proposal execution simulation REST endpoints
- verify the standard Governor proposal hash before any provider call
- verify RPC chain ID and ABI-decode the Governor execute return before reporting native success
- run pinned-block native `eth_call` before optional Tenderly enrichment
- decode Tenderly's real top-level `transaction.call_trace` array
- return completed EVM reverts as HTTP 200 simulation results
- bound requests with validation, timeout, rate limiting, concurrency, and a short cache

## Dependencies

- Registry feature: ringecosystem/degov-registry#136
- DeGov frontend: ringecosystem/degov#1094
- Preview infrastructure: devows/infra#659
- Tracks ringecosystem/degov#1085

## Verification

Local and CI:

- `go test -race ./services ./routes`
- `just test`
- `just build`
- `git diff --check`
- Check Backend, Check Web, and Deploy passed at `5e035a2`

Isolated test environment:

- API: https://api-simulation.next.degov.ai
- image: `ghcr.io/ringecosystem/degov-square/backend:sha-5e035a2`
- digest: `sha256:01f64c1798d49fc8fcaf2287c207672c95550b2d9144258883065aa4c048a79a`
- Base 8453 capability: enabled, native/basic
- Darwinia 46 capability: enabled, native/basic
- unconfigured DAO capability: disabled
- real succeeded Darwinia proposal returned HTTP 200 `status: success` at a pinned block
- real already-executed Darwinia proposal returned HTTP 200 `status: reverted`
- tampered proposal ID returned HTTP 422 `proposal_mismatch`
- empty Governor return and wrong RPC chain are covered by regression tests

## Rollout

Production is untouched. This PR is ready for review but must remain unmerged. Native/basic behavior is live-verified. Tenderly rich behavior is covered by fake-upstream tests using the documented response shape because no staging Tenderly credentials are configured; rich mode remains optional and capability-gated.
